### PR TITLE
Rework of ULV quest tab

### DIFF
--- a/config/ftbquests/quests/chapters/ulv.snbt
+++ b/config/ftbquests/quests/chapters/ulv.snbt
@@ -9,73 +9,87 @@
 	quest_links: [ ]
 	quests: [
 		{
+			description: ["You know what to do."]
 			id: "6F6BC9F29C31FB5E"
 			rewards: [{
 				id: "047B9C2B4668EBE7"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			shape: "gear"
+			size: 2.0d
 			tasks: [{
 				id: "6C9B93A74551D9B8"
 				item: "minecraft:oak_log"
 				type: "item"
 			}]
-			title: "Woody begginings"
-			x: -9.0d
-			y: 1.0d
+			title: "Woody beginnings"
+			x: -32.0d
+			y: 17.0d
 		}
 		{
 			dependencies: ["2B1B7C866E961A68"]
+			description: ["Break the white leaves to collect string."]
 			id: "2E9AA11F694F2BED"
 			rewards: [{
 				id: "60B207F7AA0D51E0"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "6B287D54B185FC50"
 				item: "minecraft:string"
 				type: "item"
 			}]
-			x: -7.0d
-			y: -3.0d
+			x: -26.0d
+			y: 15.5d
 		}
 		{
 			dependencies: ["2E9AA11F694F2BED"]
-			description: ["Now you can generate resources. This will be your main source of resources."]
+			description: ["With this, you can generate your first resources. Afterwards, you can upgrade the mesh to generate more exotic resources. This will be your main source of resources."]
 			id: "3F3E3CD778320054"
 			rewards: [{
 				id: "00E490746BC1868D"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "227BDFB19AEDCC64"
 				item: "exnihilosequentia:string_mesh"
 				type: "item"
 			}]
-			x: -7.0d
-			y: -1.0d
+			x: -24.0d
+			y: 15.5d
 		}
 		{
-			dependencies: ["6F6BC9F29C31FB5E"]
+			dependencies: [
+				"6F6BC9F29C31FB5E"
+				"3F3E3CD778320054"
+			]
+			description: ["Did you know that you can parallelize the process of sieving items? By making a 5x5 grid of sieves, you can sieve up to 25 blocks at a time."]
 			id: "462E016CCFCD4DAA"
 			rewards: [{
+				count: 2
 				id: "2AF48539990D00E7"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			shape: "gear"
+			size: 2.0d
 			tasks: [{
 				id: "2956DB659D25DB23"
 				item: "exnihilosequentia:oak_sieve"
 				type: "item"
 			}]
 			title: "Sieve"
-			x: -11.0d
-			y: 1.0d
+			x: -22.0d
+			y: 17.0d
 		}
 		{
 			dependencies: ["6F6BC9F29C31FB5E"]
+			description: ["The Ex Nihilo crucible can generate water from organic material or collect it from the rain."]
 			id: "649C5DBBC6A5C62F"
 			rewards: [{
 				id: "1FDBCE852F3E6E25"
@@ -87,26 +101,28 @@
 				item: "exnihilosequentia:oak_crucible"
 				type: "item"
 			}]
-			title: "Crucible"
-			x: -11.0d
-			y: -1.0d
+			title: "Water production"
+			x: -30.0d
+			y: 25.0d
 		}
 		{
 			dependencies: ["6F6BC9F29C31FB5E"]
+			description: ["Make yourself an Ex Nihilo barrel; it might come in useful."]
 			id: "64730F02258B0BB8"
 			rewards: [{
 				id: "24970203BFF08338"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "55AD3B5E1779BD00"
 				item: "exnihilosequentia:oak_barrel"
 				type: "item"
 			}]
 			title: "Barrel"
-			x: -11.0d
-			y: 3.0d
+			x: -30.0d
+			y: 27.0d
 		}
 		{
 			dependencies: ["6F6BC9F29C31FB5E"]
@@ -118,30 +134,33 @@
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "56F5CAA43109980D"
 				item: "exnihilosequentia:stone_pebble"
 				type: "item"
 			}]
 			title: "Pebbles from nothing..."
-			x: -7.0d
-			y: 1.0d
+			x: -30.0d
+			y: 19.0d
 		}
 		{
 			dependencies: ["5EDE27AC0D2E089A"]
+			description: ["Congratulations you have opened your inventory and crafted a piece of cobblestone. Keep up the good work."]
 			id: "1BD95B9B7C22E139"
 			rewards: [{
 				id: "36270185DCB99432"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "71F6AD0747D350F5"
 				item: "minecraft:cobblestone"
 				type: "item"
 			}]
-			x: -5.0d
-			y: 1.0d
+			x: -28.0d
+			y: 19.0d
 		}
 		{
 			dependencies: ["1BD95B9B7C22E139"]
@@ -160,6 +179,7 @@
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "688AFC903EA17473"
 				item: {
@@ -173,24 +193,30 @@
 				type: "item"
 			}]
 			title: "Hammer"
-			x: -3.0d
-			y: 1.0d
+			x: -26.0d
+			y: 19.0d
 		}
 		{
-			dependencies: ["4D69EF1B392E5337"]
+			dependencies: [
+				"4D69EF1B392E5337"
+				"462E016CCFCD4DAA"
+			]
+			description: ["Sieve some gravel for resources like tin, iron, copper, magnetite, and sphalerite."]
 			id: "1DF912172D11E3CF"
 			rewards: [{
 				id: "305DCD2591252680"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "5A7063FB954F3F3B"
 				item: "minecraft:gravel"
 				type: "item"
 			}]
-			x: -1.0d
-			y: 1.0d
+			title: "Sieve som gravel"
+			x: -22.0d
+			y: 19.0d
 		}
 		{
 			dependencies: ["64730F02258B0BB8"]
@@ -207,13 +233,14 @@
 				type: "item"
 			}]
 			title: "More dirt"
-			x: -11.0d
-			y: 5.0d
+			x: -28.0d
+			y: 29.0d
 		}
 		{
-			dependencies: ["1DF912172D11E3CF"]
+			dependencies: ["3E70506A8EA08471"]
 			description: ["Coarse dirt can be crafted from 2 dirt and 2 gravel. Sieving coarse dirt will yield regular dirt, with a chance of extra dirt and gravel. This way you can multiply your dirt."]
 			id: "114F9DE75452E66B"
+			optional: true
 			rewards: [{
 				id: "7468905BAC8643A6"
 				item: "kubejs:coin"
@@ -224,63 +251,82 @@
 				item: "minecraft:coarse_dirt"
 				type: "item"
 			}]
-			x: -1.0d
-			y: -1.0d
+			x: -28.0d
+			y: 28.0d
 		}
 		{
-			dependencies: ["1DF912172D11E3CF"]
+			dependencies: [
+				"1DF912172D11E3CF"
+				"462E016CCFCD4DAA"
+			]
+			description: ["Sieve some gravel for resources like amethyst, emerald, diamond, nether quartz, and lapis lazuli."]
 			id: "6CFFBB4FB33FF4D2"
 			rewards: [{
 				id: "177DD27C98054798"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "6AD0070FE7534F7E"
 				item: "minecraft:sand"
 				type: "item"
 			}]
-			x: -1.0d
-			y: 3.0d
+			title: "Sieve som sand"
+			x: -22.0d
+			y: 21.0d
 		}
 		{
-			dependencies: ["6CFFBB4FB33FF4D2"]
+			dependencies: [
+				"6CFFBB4FB33FF4D2"
+				"462E016CCFCD4DAA"
+			]
+			description: ["Sieve some gravel for resources like redstone dust, tiny sulfur dust, ender pearl, and glowstone."]
 			id: "7500749A28B231D4"
 			rewards: [{
 				id: "14DC8F73FEE0DAB3"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "5298C9857E387B0F"
 				item: "exnihilosequentia:dust"
 				type: "item"
 			}]
-			x: -1.0d
-			y: 5.0d
+			title: "Sieve som dust"
+			x: -22.0d
+			y: 23.0d
 		}
 		{
-			dependencies: ["7500749A28B231D4"]
-			description: ["Clay is aquired by putting dust blocks into barrels full of water."]
+			dependencies: [
+				"7500749A28B231D4"
+				"64730F02258B0BB8"
+				"31FADEE78F8D2D8F"
+			]
+			description: ["Clay is acquired by putting dust blocks into barrels full of water."]
 			id: "73E02F929D718620"
 			rewards: [{
 				id: "130E98ADB46FBB07"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "2020CD477702F432"
 				item: "minecraft:clay"
 				type: "item"
 			}]
-			x: -3.0d
-			y: 7.0d
+			title: "Make some clay"
+			x: -22.0d
+			y: 27.0d
 		}
 		{
 			dependencies: [
 				"0CFFABB4101F598A"
 				"73E02F929D718620"
 			]
+			description: ["Maybe you should try and combine some clay and bone meal."]
 			id: "68C0957318547C70"
 			rewards: [{
 				id: "140E46071B25F6AA"
@@ -292,11 +338,12 @@
 				item: "exnihilosequentia:porcelain_clay"
 				type: "item"
 			}]
-			x: -7.0d
-			y: 7.0d
+			x: -26.0d
+			y: 23.0d
 		}
 		{
 			dependencies: ["6F6BC9F29C31FB5E"]
+			description: ["Use the composter to turn organic materials into bone meal. Remember this can only be automated with vanilla hopper."]
 			id: "39DFC93A2EE207AE"
 			rewards: [{
 				id: "29413450AD2466F7"
@@ -308,11 +355,12 @@
 				item: "minecraft:composter"
 				type: "item"
 			}]
-			x: -9.0d
-			y: 3.0d
+			x: -30.0d
+			y: 23.0d
 		}
 		{
 			dependencies: ["39DFC93A2EE207AE"]
+			description: ["Wait, you right-clicked a full composter? Congratulations!"]
 			id: "0CFFABB4101F598A"
 			rewards: [{
 				id: "2ECB1D7F1158014D"
@@ -324,12 +372,12 @@
 				item: "minecraft:bone_meal"
 				type: "item"
 			}]
-			x: -7.0d
-			y: 5.0d
+			x: -28.0d
+			y: 23.0d
 		}
 		{
 			dependencies: ["68C0957318547C70"]
-			description: ["Fired Crucibles will be your first source of lava. Place a heat source under the crucible(like a campfire) and place some cobblestone in the crucible. In time, the cobblestone will melt into lava."]
+			description: ["Fired Crucibles will be your first source of lava. Place a heat source under the crucible (like a campfire) and place some cobblestone in the crucible. In time, the cobblestone will melt into lava."]
 			id: "693473FC6CB62424"
 			rewards: [{
 				id: "6617DAF7783182AF"
@@ -341,12 +389,12 @@
 				item: "exnihilosequentia:fired_crucible"
 				type: "item"
 			}]
-			x: -7.0d
-			y: 9.0d
+			x: -24.0d
+			y: 23.0d
 		}
 		{
 			dependencies: ["649C5DBBC6A5C62F"]
-			description: ["The Ex Nihilo crucible can generate water from organic material. You can take out the water using wooden buckets."]
+			description: ["Take out the water using a wooden bucket."]
 			id: "31FADEE78F8D2D8F"
 			rewards: [{
 				id: "3AA198F6C02683AF"
@@ -369,14 +417,17 @@
 				type: "item"
 			}]
 			title: "Water"
-			x: -11.0d
-			y: -3.0d
+			x: -28.0d
+			y: 25.0d
 		}
 		{
-			dependencies: ["693473FC6CB62424"]
+			dependencies: [
+				"693473FC6CB62424"
+				"4BD6C41404E73F65"
+			]
+			description: ["LAVA IN A WOODEN BUCKET?!?"]
 			id: "07661EEE66EFCD96"
 			rewards: [{
-				count: 2
 				id: "6B1E99FCBCF077DA"
 				item: "kubejs:coin"
 				type: "item"
@@ -396,16 +447,12 @@
 				}
 				type: "item"
 			}]
-			x: -7.0d
-			y: 11.0d
+			x: -26.0d
+			y: 21.0d
 		}
 		{
 			dependencies: ["07661EEE66EFCD96"]
-			description: [
-				"Now that you have lava, you can make your first automated cobblestone generator."
-				"Using pipes(for example Create pipes), constantly supply stone barrels with water. On top of the barrels, have lava. it doesn't have to be a source block, it can be flowing lava as well."
-				"Using hoppers or Create chutes, harvest thecobblestone from under the barrels."
-			]
+			description: ["Now that you have lava, you can make your first automated cobblestone generator. Using pipes(for example Create pipes), constantly supply stone barrels with water. On top of the barrels, have lava. it doesn't have to be a source block, it can be flowing lava as well. Using hoppers or Create chutes, harvest the cobblestone from under the barrels."]
 			icon: "exnihilosequentia:stone_barrel"
 			id: "104C638A49643965"
 			rewards: [{
@@ -413,16 +460,19 @@
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			shape: "gear"
+			size: 2.0d
 			tasks: [{
 				id: "76B65D1AB70F440B"
 				title: "Cobble Gen"
 				type: "checkmark"
 			}]
-			x: -7.0d
-			y: 13.0d
+			x: -24.0d
+			y: 21.0d
 		}
 		{
-			dependencies: ["4D69EF1B392E5337"]
+			dependencies: ["4DAAABEAA43E1A07"]
+			description: ["By sieving blackstone you get yourself some galena and stibnite."]
 			id: "47D5884CB45EEA2E"
 			rewards: [{
 				id: "46740A01C52342D3"
@@ -434,11 +484,13 @@
 				item: "exnihilosequentia:crushed_blackstone"
 				type: "item"
 			}]
-			x: -3.0d
-			y: -1.0d
+			title: "Sieve some blackstone"
+			x: -14.0d
+			y: 31.0d
 		}
 		{
 			dependencies: ["47D5884CB45EEA2E"]
+			description: ["Smelt the galena into lead."]
 			id: "3515DF7069DCA375"
 			rewards: [{
 				id: "2AF5F49E8E579623"
@@ -450,18 +502,15 @@
 				item: "gtceu:lead_ingot"
 				type: "item"
 			}]
-			x: -3.0d
-			y: -3.0d
+			x: -12.0d
+			y: 31.0d
 		}
 		{
 			dependencies: [
 				"3515DF7069DCA375"
 				"304EDF2AC023A26F"
 			]
-			description: [
-				"This block can harvest water from infinite water sources. Place two water sources noxt to this, and it'll start harvesting. To get the water out of the accumulator, you will need pipes. A good first pipe to use is the Create pipe. Using the pump, you can extract the water. Later you can use pipez pipes to extract without needing to use rotation."
-				"Note that you have no way of extracting water using GregTech pipes until LV."
-			]
+			description: ["This block can harvest water from infinite water sources. Place two water sources next to it, and it will start harvesting. To get the water out of the accumulator, you will need pipes. A good first pipe to use is the Create pipe. Using the pump, you can extract the water. Later, you can use Pipez pipes to extract without needing rotation. Note that you have no way of extracting water using GregTech pipes until LV."]
 			id: "1A68764673949115"
 			rewards: [{
 				count: 2
@@ -469,33 +518,38 @@
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			shape: "gear"
+			size: 2.0d
 			tasks: [{
 				id: "62D7BCC3A9E609C1"
 				item: "thermal:device_water_gen"
 				type: "item"
 			}]
-			x: -5.0d
-			y: -3.0d
+			title: "Faster water production"
+			x: -10.0d
+			y: 31.0d
 		}
 		{
 			dependencies: ["1DF912172D11E3CF"]
+			description: ["Why don’t you make some andesite alloy? Note that it is more iron-efficient to make 16 at a time."]
 			id: "5901D32D9B89F5F8"
 			rewards: [{
 				id: "7876DD8171BB66FB"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "6E5C263F254F2760"
 				item: "create:andesite_alloy"
 				type: "item"
 			}]
-			x: 3.0d
-			y: 1.0d
+			x: -18.0d
+			y: 15.0d
 		}
 		{
 			dependencies: ["5901D32D9B89F5F8"]
-			description: ["Water Wheels are an amaizing source of rotation power. You can chain many together."]
+			description: ["Water wheels are an amazing source of rotational power. You can chain many together."]
 			id: "24F68FA81D90DB13"
 			rewards: [{
 				id: "4D7A933E2E9C3A72"
@@ -515,28 +569,30 @@
 					type: "item"
 				}
 			]
-			x: 3.0d
-			y: -1.0d
+			x: -18.0d
+			y: 13.0d
 		}
 		{
 			dependencies: ["73E02F929D718620"]
+			description: ["Make some firebrick for your first primitive blast furnace. Later on, you can make a kinetic ore factory to multiply your crushed ores even further. "]
 			id: "20E212A187D42415"
 			rewards: [{
 				id: "04733C62F9931518"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "017FFDCA0CE35673"
 				item: "gtceu:firebrick"
 				type: "item"
 			}]
-			x: 5.0d
-			y: 7.0d
+			x: -18.0d
+			y: 27.0d
 		}
 		{
 			dependencies: ["5901D32D9B89F5F8"]
-			description: ["The Mechanical Press can make some plates for cheaper than in crafting table. You will also need it to make firebricks for 3 multiblock machines."]
+			description: ["The Mechanical Press can make some plates for cheaper than in crafting table. You will also need it to make firebricks for 3 different multiblock machines."]
 			id: "6E0AACD6B55F5575"
 			optional: true
 			rewards: [{
@@ -549,12 +605,12 @@
 				item: "create:mechanical_press"
 				type: "item"
 			}]
-			x: 5.0d
-			y: -1.0d
+			x: -16.0d
+			y: 13.0d
 		}
 		{
 			dependencies: ["5901D32D9B89F5F8"]
-			description: ["For the Create Mixer setup, place the charcoal burner bellow a basin(and put some charcoal in it) and place the mixer on top of the basin. The mixer needs a bigger rotation speed that the waterwheels can provide. You can use sets of large cog to small cog to increase the speed. Note that create contrations use stress units proportionally to the speed."]
+			description: ["For the Create Mixer setup, place the charcoal burner below a basin (and put some charcoal in it and light it with a flint and steel) and place the mixer on top of the basin. The mixer needs a greater rotation speed than the waterwheels can provide. You can use sets of large cogs to small cogs to increase the speed. Note that Create contraptions use stress units proportionally to the speed."]
 			icon: "create:mechanical_mixer"
 			id: "2AB0BAA6F02C9C3D"
 			rewards: [{
@@ -562,6 +618,7 @@
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [
 				{
 					id: "0847AECB6DEC3F18"
@@ -591,11 +648,12 @@
 				}
 			]
 			title: "Mixer Setup for alloying"
-			x: 3.0d
-			y: 3.0d
+			x: -16.0d
+			y: 17.0d
 		}
 		{
 			dependencies: ["2AB0BAA6F02C9C3D"]
+			description: ["Bronze is the first alloy you will be making."]
 			id: "6A6B53C8C4D8DC78"
 			rewards: [{
 				id: "7E75D4B3085D62EF"
@@ -607,8 +665,8 @@
 				item: "gtceu:bronze_ingot"
 				type: "item"
 			}]
-			x: 3.0d
-			y: 5.0d
+			x: -12.0d
+			y: 17.0d
 		}
 		{
 			dependencies: ["1DF912172D11E3CF"]
@@ -618,111 +676,126 @@
 			]
 			id: "47AD3DEAA1FEBF6A"
 			rewards: [{
-				count: 2
 				id: "72A5018668323B5B"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "2CF5C5E069487606"
 				item: "thermal:device_tree_extractor"
 				type: "item"
 			}]
-			x: 1.0d
-			y: 3.0d
+			x: -18.0d
+			y: 23.0d
 		}
 		{
 			dependencies: ["47AD3DEAA1FEBF6A"]
+			description: ["Pick up your latex with a bucket."]
 			id: "31ED348BF49F3926"
 			rewards: [{
 				id: "624AD37AC9846658"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "5B5386EEEEC18659"
 				item: "thermal:latex_bucket"
 				type: "item"
 			}]
-			x: 1.0d
-			y: 5.0d
+			x: -16.0d
+			y: 23.0d
 		}
 		{
 			dependencies: ["31ED348BF49F3926"]
-			description: ["Placing the latex bucket in a crafting table will yield raw rubber. You need to cure it before you can use the rubber."]
+			description: ["Placing the latex bucket in a crafting table will yield rubber. You need to cure it before you can use the rubber."]
 			id: "059DBB1D57FBAD54"
 			rewards: [{
 				id: "2DAC4F9A654EDBCB"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "46DC7F3F57E05638"
 				item: "thermal:rubber"
 				type: "item"
 			}]
-			x: 3.0d
-			y: 7.0d
+			x: -14.0d
+			y: 23.0d
 		}
 		{
 			dependencies: [
 				"059DBB1D57FBAD54"
 				"089F09932036F1AA"
+				"2AB0BAA6F02C9C3D"
 			]
-			description: ["To cure rubber you will need a Mixer setup. Look at the Mixer quest for more details."]
+			description: ["To cure rubber, you will need a Mixer setup. Later, there might be easier ways of making rubber."]
 			id: "790FD3E20F554EBA"
 			rewards: [{
+				count: 2
 				id: "46ACFCBC3B6F19CC"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			shape: "gear"
+			size: 2.0d
 			tasks: [{
 				id: "2A525009C4B26E75"
 				item: "thermal:cured_rubber"
 				type: "item"
 			}]
-			x: 1.0d
-			y: 7.0d
+			x: -14.0d
+			y: 21.0d
 		}
 		{
 			dependencies: [
 				"20E212A187D42415"
 				"7E6E7E00E50C3D7E"
 			]
-			description: ["Primitive Blast Furnace is your first steel source. It is best to use wrought iron, as the duration will be shorter."]
+			description: ["The Primitive Blast Furnace is your first source of steel. It is best to use wrought iron, as the duration will be shorter. If you want more than one Primitive Blast Furnace, remember that GregTech multiblocks can wall share."]
 			id: "6F62E5BFF7224E36"
 			rewards: [{
 				id: "5AC0902F6BDB4269"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "7452BCE7F2F99F0D"
 				item: "gtceu:primitive_blast_furnace"
 				type: "item"
 			}]
-			x: 5.0d
-			y: 9.0d
+			x: -16.0d
+			y: 25.0d
 		}
 		{
 			dependencies: ["7500749A28B231D4"]
 			dependency_requirement: "one_completed"
+			description: [
+				"Lore:"
+				""
+				"After hours of sieving dust by hand, you have finally collected 9 pieces of tiny sulfur dust that you combined into a normal piece of sulfur dust."
+			]
 			id: "089F09932036F1AA"
 			rewards: [{
 				id: "73479FD8E7F99EF9"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "61AA4A3746BC3D16"
 				item: "gtceu:sulfur_dust"
 				type: "item"
 			}]
-			x: -1.0d
-			y: 7.0d
+			x: -16.0d
+			y: 21.0d
 		}
 		{
 			dependencies: ["6F62E5BFF7224E36"]
+			description: ["Each tier of machines in GregTech has its own material, and for LV, that material is steel. If you want to start making LV machines, you might want to make some more steel ingots."]
 			id: "1C2D07E0CBA206EC"
 			rewards: [{
 				count: 2
@@ -730,16 +803,19 @@
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			shape: "gear"
+			size: 2.0d
 			tasks: [{
 				id: "228C753188BFFF1D"
 				item: "gtceu:steel_ingot"
 				type: "item"
 			}]
-			x: 7.0d
-			y: 9.0d
+			x: -14.0d
+			y: 25.0d
 		}
 		{
 			dependencies: ["1BD95B9B7C22E139"]
+			description: ["The campfire can be used as a heat source under a crucibel. Later on you will use it for turning iron ingots into wrought iron and glass dust into glass."]
 			id: "4BD6C41404E73F65"
 			rewards: [{
 				id: "2A4CD9F50C4F0AEB"
@@ -751,11 +827,11 @@
 				item: "minecraft:campfire"
 				type: "item"
 			}]
-			x: -3.0d
-			y: 3.0d
+			x: -28.0d
+			y: 21.0d
 		}
 		{
-			dependencies: ["4BD6C41404E73F65"]
+			dependencies: ["1DF912172D11E3CF"]
 			description: ["Wrought iron can be aquired, by smelting iron ingots over a campfire. The cultured members of the Star Technology official discord server call it \"sizzle\", You can come there and post screenshots of your sizzle."]
 			id: "7E6E7E00E50C3D7E"
 			rewards: [{
@@ -763,13 +839,14 @@
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "5B0054F8A5AC3FDE"
 				item: "gtceu:wrought_iron_ingot"
 				type: "item"
 			}]
-			x: -3.0d
-			y: 9.0d
+			x: -18.0d
+			y: 25.0d
 		}
 		{
 			dependencies: ["6CFFBB4FB33FF4D2"]
@@ -793,14 +870,12 @@
 				item: "gtceu:glass_dust"
 				type: "item"
 			}]
-			x: -3.0d
-			y: 5.0d
+			x: -16.0d
+			y: 19.0d
 		}
 		{
-			dependencies: [
-				"4BD6C41404E73F65"
-				"4A07418169FBB38B"
-			]
+			dependencies: ["4A07418169FBB38B"]
+			description: ["Smelt the glass dust by cooking it on a campfire."]
 			id: "304EDF2AC023A26F"
 			rewards: [{
 				id: "1BD8EFB15B5CFA15"
@@ -812,12 +887,12 @@
 				item: "minecraft:glass"
 				type: "item"
 			}]
-			x: -5.0d
-			y: 3.0d
+			x: -14.0d
+			y: 19.0d
 		}
 		{
 			dependencies: ["73E02F929D718620"]
-			description: ["The coke oven can turn logs into charcoal and creosote. You can autoextract the creosote using a coke oven hatch."]
+			description: ["The coke oven can turn logs into charcoal and creosote. You can auto-extract the creosote using a coke oven hatch."]
 			id: "74654E9B54B46682"
 			rewards: [{
 				id: "03820BFA40789B46"
@@ -829,11 +904,12 @@
 				item: "gtceu:coke_oven"
 				type: "item"
 			}]
-			x: -1.0d
-			y: 9.0d
+			x: -18.0d
+			y: 29.0d
 		}
 		{
 			dependencies: ["74654E9B54B46682"]
+			description: ["Use your excess creosote oil as a fuel source if you have too many treated wooden planks."]
 			id: "7D4CFD957FDE81BF"
 			rewards: [{
 				id: "625C96F601B2FE9C"
@@ -845,8 +921,8 @@
 				item: "gtceu:creosote_bucket"
 				type: "item"
 			}]
-			x: -1.0d
-			y: 11.0d
+			x: -16.0d
+			y: 29.0d
 		}
 		{
 			dependencies: ["7D4CFD957FDE81BF"]
@@ -862,8 +938,8 @@
 				item: "gtceu:treated_wood_planks"
 				type: "item"
 			}]
-			x: -1.0d
-			y: 13.0d
+			x: -14.0d
+			y: 29.0d
 		}
 		{
 			dependencies: ["40491E2463C0EDFD"]
@@ -879,8 +955,8 @@
 				item: "gtceu:large_barrel"
 				type: "item"
 			}]
-			x: 1.0d
-			y: 13.0d
+			x: -12.0d
+			y: 27.0d
 		}
 		{
 			dependencies: [
@@ -899,16 +975,17 @@
 				item: "gtceu:large_stone_barrel"
 				type: "item"
 			}]
-			x: -3.0d
-			y: 13.0d
+			x: -14.0d
+			y: 27.0d
 		}
 		{
 			dependencies: [
 				"6A6B53C8C4D8DC78"
 				"304EDF2AC023A26F"
 			]
-			description: ["Fluid Cells is an upgradable fluid storage solution. Once you have some bronze, you should invest in these."]
+			description: ["Fluid Cells is an upgradable fluid storage solution (Use the LV, MV, HV, or EV upgrades). Once you have some bronze, you should invest in these."]
 			id: "5ACE5FD72B08BCBE"
+			optional: true
 			rewards: [{
 				count: 2
 				id: "57B27F4618B0FDA2"
@@ -933,8 +1010,8 @@
 				}
 				type: "item"
 			}]
-			x: -5.0d
-			y: 5.0d
+			x: -12.0d
+			y: 19.0d
 		}
 		{
 			dependencies: ["6E0AACD6B55F5575"]
@@ -951,8 +1028,8 @@
 				item: "createdieselgenerators:plant_oil_bucket"
 				type: "item"
 			}]
-			x: 7.0d
-			y: -1.0d
+			x: -14.0d
+			y: 13.0d
 		}
 		{
 			dependencies: ["2AB0BAA6F02C9C3D"]
@@ -969,8 +1046,8 @@
 				item: "createdieselgenerators:ethanol_bucket"
 				type: "item"
 			}]
-			x: 7.0d
-			y: 3.0d
+			x: -14.0d
+			y: 15.0d
 		}
 		{
 			dependencies: [
@@ -990,11 +1067,12 @@
 				item: "createdieselgenerators:biodiesel_bucket"
 				type: "item"
 			}]
-			x: 9.0d
-			y: 1.0d
+			x: -12.0d
+			y: 14.0d
 		}
 		{
 			dependencies: ["435527E6C4D218A5"]
+			description: ["At this stage of the game, gold is not obtainable through sieving, but have you tried washing some red sand?"]
 			id: "1BEB4C8A49FACC76"
 			optional: true
 			rewards: [{
@@ -1007,8 +1085,8 @@
 				item: "createdieselgenerators:huge_diesel_engine"
 				type: "item"
 			}]
-			x: 9.0d
-			y: 3.0d
+			x: -10.0d
+			y: 15.0d
 		}
 		{
 			dependencies: ["435527E6C4D218A5"]
@@ -1024,8 +1102,8 @@
 				item: "createdieselgenerators:diesel_engine"
 				type: "item"
 			}]
-			x: 9.0d
-			y: -1.0d
+			x: -10.0d
+			y: 13.0d
 		}
 		{
 			dependencies: ["576B279682D613EF"]
@@ -1041,12 +1119,12 @@
 				item: "createdieselgenerators:large_diesel_engine"
 				type: "item"
 			}]
-			x: 11.0d
-			y: -1.0d
+			x: -8.5d
+			y: 13.0d
 		}
 		{
 			dependencies: ["40491E2463C0EDFD"]
-			description: ["Large Farms are automated farms. You can make enough potatoes to carry your ethanol production."]
+			description: ["Large Farms are automated farms. You can make enough potatoes to carry your ethanol production or power your base later using kelp."]
 			id: "56265DC432D1A4E6"
 			rewards: [{
 				id: "1485D3C77DA93880"
@@ -1058,18 +1136,19 @@
 				item: "gtceu:large_farm"
 				type: "item"
 			}]
-			x: -1.0d
-			y: 15.0d
+			x: -12.0d
+			y: 29.0d
 		}
 		{
 			dependencies: ["6F6BC9F29C31FB5E"]
-			description: ["When breaking leaves with crooks, they have a higher chance of dropping saplings."]
+			description: ["When breaking leaves with crooks, they have a higher chance of dropping saplings. Remember that you can also make stone crooks."]
 			id: "2C30C61EE8FD5564"
 			rewards: [{
 				id: "1D05F80FA9F4E11E"
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "3641F869BFBA5472"
 				item: {
@@ -1081,8 +1160,8 @@
 				}
 				type: "item"
 			}]
-			x: -9.0d
-			y: -1.0d
+			x: -30.0d
+			y: 15.5d
 		}
 		{
 			dependencies: ["2C30C61EE8FD5564"]
@@ -1093,13 +1172,143 @@
 				item: "kubejs:coin"
 				type: "item"
 			}]
+			size: 1.25d
 			tasks: [{
 				id: "247E7214802A580F"
 				item: "exnihilosequentia:silkworm"
 				type: "item"
 			}]
-			x: -9.0d
-			y: -3.0d
+			x: -28.0d
+			y: 15.5d
+		}
+		{
+			dependencies: ["4D69EF1B392E5337"]
+			description: ["Effortless Building is a mod which allows you to effortlessly build different shapes. This can be used to your advantage. Quickly build a cube and afterwards dismantle it with your hammer using FTB Ultimine and produce gravel, sand, and dust in huge quantities. "]
+			id: "0039242F8446D7D2"
+			optional: true
+			tasks: [{
+				id: "47600FF1AD457B04"
+				title: "Effortless building"
+				type: "checkmark"
+			}]
+			x: -26.0d
+			y: 18.0d
+		}
+		{
+			dependencies: ["24542D28F5C40FF4"]
+			description: ["Right-click on a piece of dirt with mycelium spores to transform it into mycelium."]
+			id: "574511FD8581391A"
+			rewards: [{
+				id: "60BF4EFB5F7A57D0"
+				item: "kubejs:coin"
+				type: "item"
+			}]
+			tasks: [{
+				id: "2072276A12B4C1E9"
+				item: "minecraft:mycelium"
+				type: "item"
+			}]
+			x: -20.0d
+			y: 31.0d
+		}
+		{
+			dependencies: [
+				"3E70506A8EA08471"
+				"462E016CCFCD4DAA"
+			]
+			description: ["By sieving dirt, you gain access to a huge variety of different organic materials and stones. Maybe these will be useful later?"]
+			icon: "minecraft:dirt"
+			id: "24542D28F5C40FF4"
+			rewards: [{
+				id: "26A185D41296C10E"
+				item: "kubejs:coin"
+				type: "item"
+			}]
+			tasks: [
+				{
+					id: "4A279CE7871686CE"
+					item: "minecraft:sugar_cane"
+					type: "item"
+				}
+				{
+					id: "5826560D3272CB36"
+					item: "minecraft:wheat_seeds"
+					type: "item"
+				}
+				{
+					id: "2052678D8A236683"
+					item: "minecraft:carrot"
+					type: "item"
+				}
+				{
+					id: "25DDFC69F456A3C7"
+					item: "minecraft:potato"
+					type: "item"
+				}
+				{
+					id: "011C0BC6362719DA"
+					item: "exnihilosequentia:blackstone_pebble"
+					type: "item"
+				}
+				{
+					id: "2024DC5C4D42C8FA"
+					item: "exnihilosequentia:mycelium_spores"
+					type: "item"
+				}
+				{
+					id: "2C180F1579039F26"
+					item: "thermal:slime_mushroom_spores"
+					type: "item"
+				}
+			]
+			title: "Sieve some dirt"
+			x: -22.0d
+			y: 31.0d
+		}
+		{
+			dependencies: ["574511FD8581391A"]
+			description: ["Place a barrel on top of the mycelium and fill it with water."]
+			id: "571C22918E6B4604"
+			rewards: [{
+				id: "4AB80A34CBE14445"
+				item: "kubejs:coin"
+				type: "item"
+			}]
+			tasks: [{
+				id: "6AC86FBE15B4BF18"
+				item: {
+					Count: 1b
+					id: "woodenbucket:wooden_bucket"
+					tag: {
+						Damage: 0
+						Fluid: {
+							Amount: 1000
+							FluidName: "exnihilosequentia:witch_water"
+						}
+					}
+				}
+				type: "item"
+			}]
+			title: "Witch water"
+			x: -18.0d
+			y: 31.0d
+		}
+		{
+			dependencies: ["571C22918E6B4604"]
+			description: ["If you right-click sand into the barrel you will get soul sand."]
+			id: "4DAAABEAA43E1A07"
+			rewards: [{
+				id: "3ED0DE31E9FA184F"
+				item: "kubejs:coin"
+				type: "item"
+			}]
+			tasks: [{
+				id: "1FC10536D27FA96B"
+				item: "minecraft:soul_sand"
+				type: "item"
+			}]
+			x: -16.0d
+			y: 31.0d
 		}
 	]
 	title: "ULV"


### PR DESCRIPTION
This is a rework of the ULV quest tab. The goal was to make progression more clear by dividing it into a "before sieving" side (left) and an "after sieving" side (right). Other than that, I have spellchecked and added text for more or less all the quests, as well as added a small quest line explaining how to make Witching Water. Quests that are "completely necessary" have been scaled by 1.25, so they appear larger. Quests that are "goals" have been given a gear shape. The quests have been moved around, so there should not be any issue for existing players. However, I have not tested this. If you guys like this, I will start work on LV and beyond since I see a lot of potential (and have nothing to do over my summer break xD).

Before rework:
![image](https://github.com/trulyno/star-technology/assets/42304902/4863d093-18b9-4d67-8402-47a14cc108a0)

After rework:
![image](https://github.com/trulyno/star-technology/assets/42304902/61cff996-5a27-4c92-987c-33637a42a28b)

As a side note, who am I to redo the quest book?
I have been playing GT for around 5-6 years on and off in GT:NH. In my current GT:NH run, we are at the IV/LuV stage, so this is where my knowledge stops. As for StarT, we are at the HV/EV stage.