### PR TITLE
Lowered minimum invar cases, so essence replicator multiblock can fit required hatches

### DIFF
--- a/kubejs/startup_scripts/multiblocks/Mystical Agriculture/essence_replication.js
+++ b/kubejs/startup_scripts/multiblocks/Mystical Agriculture/essence_replication.js
@@ -19,7 +19,7 @@ GTCEuStartupEvents.registry('gtceu:machine', event => {
             .aisle('ISSSI', '#FGF#', '#FGF#', '#FGF#', 'ISSSI')
             .aisle('IICII', '#####', '#####', '#####', 'IIIII')
             .where('C', Predicates.controller(Predicates.blocks(definition.get())))
-            .where('I', Predicates.blocks(GTBlocks.CASING_INVAR_HEATPROOF.get()).setMinGlobalLimited(26)
+            .where('I', Predicates.blocks(GTBlocks.CASING_INVAR_HEATPROOF.get()).setMinGlobalLimited(23)
                 .or(Predicates.autoAbilities(definition.getRecipeTypes()))
                 .or(Predicates.abilities(PartAbility.PARALLEL_HATCH).setMaxGlobalLimited(1))
                 .or(Predicates.abilities(PartAbility.MAINTENANCE).setExactLimit(1)))


### PR DESCRIPTION
Essence replicator can't house required hatches with 26 of possible 31 slots taken by Heat Proof Invar casings

For recipes that require both item and fluid input and output, there is not enought space for energy hatch or parallel hatch. 23 will allow for 1 of each input + output hatch and bus, 2 energy hatches, maintenance hatch and parallel hatch.