### PR TITLE
Rice fix

### DIFF
--- a/kubejs/server_scripts/early_game/dust.js
+++ b/kubejs/server_scripts/early_game/dust.js
@@ -1,0 +1,16 @@
+ServerEvents.recipes(event => {
+    event.custom({
+    "type": "create:crushing",
+    "ingredients": [
+      {
+        "item": "minecraft:sand"
+      }
+    ],
+    "results": [
+      {
+        "item": "ex_nihilo:dust"
+      }
+    ],
+    "processingTime": 350
+    })
+  })

--- a/kubejs/server_scripts/early_game/rice.js
+++ b/kubejs/server_scripts/early_game/rice.js
@@ -1,0 +1,3 @@
+ServerEvents.recipes(event => {
+    event.shapeless('farmersdelight:rice_panicle',['thermal:rice_seeds','minecraft:bone_meal'])
+})

--- a/kubejs/server_scripts/early_game/rice.js
+++ b/kubejs/server_scripts/early_game/rice.js
@@ -1,3 +1,0 @@
-ServerEvents.recipes(event => {
-    event.shapeless('farmersdelight:rice_panicle',['thermal:rice_seeds','minecraft:bone_meal'])
-})


### PR DESCRIPTION
This push contributes a single file with 3 lines of code, that makes farmers delight rice accesible early game, instead of being locked behind nature essence from mystical agriculture