### PR TITLE
Ex Deorum and Ex Nihilo: Sequentia durability parity

### DIFF
--- a/kubejs/startup_scripts/ex deorum durability.js
+++ b/kubejs/startup_scripts/ex deorum durability.js
@@ -1,0 +1,18 @@
+ItemEvents.modification(event => {
+    function durability(target, durability) {
+        event.modify(target, item =>{
+            item.maxDamage = durability
+        })
+    }
+    // Hammers
+    durability('exdeorum:stone_hammer', 256)
+    durability('exdeorum:iron_hammer', 512)
+    durability('exdeorum:diamond_hammer', 4096)
+    durability('exdeorum:wooden_hammer', 128)
+    durability('exdeorum:golden_hammer', 64)
+    durability('exdeorum:netherite_hammer', 8192)
+
+    // Crooks
+    durability('exdeorum:crook', 128)
+    durability('exdeorum:bone_crook', 256)
+})


### PR DESCRIPTION
Make Ex Deorum crook and hammer durability the same as Ex Nihilo's was in 1.19.2