### PR TITLE
Fix Superconductor.js Recipe Replacements

### DIFF
--- a/kubejs/server_scripts/superconductors.js
+++ b/kubejs/server_scripts/superconductors.js
@@ -93,10 +93,10 @@ ServerEvents.recipes(event => {
     // Replaces
     ['soul_infused','signalum','lumium','enderium','shellite','twinite','dragonsteel','prismalium','melodium','stellarium'].forEach(material => {
         ['dust','nugget','ingot','gear','plate','rod'].forEach(type =>{
-            event.replaceInput({input: `#forge:${type}s/${material}`}, `#forge:${type}s/${material}`, `gtceu:${material}_${type}`);
+            event.replaceInput({not: {input: `#forge:${type}s`}, input: `#forge:${type}s/${material}`}, `#forge:${type}s/${material}`, `gtceu:${material}_${type}`);
             event.replaceOutput({output: `#forge:${type}s/${material}`}, `#forge:${type}s/${material}`, `gtceu:${material}_${type}`);
         });
-        event.replaceInput({input: `#forge:storage_blocks/${material}`}, `#forge:storage_blocks/${material}`, `gtceu:${material}_block`);
+        event.replaceInput({not: {input: `#forge:storage_blocks`}, input: `#forge:storage_blocks/${material}`}, `#forge:storage_blocks/${material}`, `gtceu:${material}_block`);
         event.replaceOutput({output: `#forge:storage_blocks/${material}`}, `#forge:storage_blocks/${material}`, `gtceu:${material}_block`);
     });
    


### PR DESCRIPTION
Fixes #157 

This bug was introduced in [this commit](https://github.com/trulyno/star-technology/commit/e20b345fa1195409ab217131df4738c7132e44bc) on the 1.20.1 branch. Manually reverting this change locally fixes the issue and allow the hammer to be crafted with any rods, but I'm not sure if this breaks anything else later on in the game. 

My understanding of the mechanics of the bug is this:

Line 96 is this:
``event.replaceInput({input: `#forge:${type}s/${material}`}, `#forge:${type}s/${material}`, `gtceu:${material}_${type}`);``

`type` and  `material` are set in nested for each loops. In the first iteration of both loops, `type = rod`, `material = soul_infused`, and the line reads:

``event.replaceInput({input: `#forge:rods/soul_infused`}, `#forge:rods/soul_infused`, `gtceu:soul_infused_rod`);``

This line is then taking _ANY_ recipe that takes `#forge:rods/soul_infused` as an input and replaces that input with `gtceu:soul_infused_rod`. This includes the recipe for the hammer, which takes `#forge:rods`, since `#forge:soul_infused_rods` is included in `#forge:rods`. Then in subsequent iterations of the loop, the recipe for hammer is already set to take `#gtceu:soul_infused_rods`, so the filters ignore this recipe.

This PR fixes this issue by adding an additional filter condition that excludes this type of generic recipe from the replacements. This should also fix any other recipes broken by generic dust, nugget, ingot, gear, plate, and rod item recipes. I've also added the same filter condition to the `#forge:storage_blocks` type. I've omitted the filter from the output replacement, since I don't think there are any recipes that output a generic item like this.