### PR TITLE
feat(tags): Introduce new tag groups for EKOF mats + refactor EKOF code

### DIFF
--- a/kubejs/server_scripts/multiblock recipes/ore_factory.js
+++ b/kubejs/server_scripts/multiblock recipes/ore_factory.js
@@ -48,14 +48,6 @@ var ekofProcessableTiers = {
     ],
   };
   
-  ServerEvents.tags("item", (event) => {
-    Object.keys(ekofProcessableTiers).forEach((tier) => {
-      ekofProcessableTiers[tier].forEach((item) => {
-        event.add(`kubejs:ekof_processable_${tier}`, `gtceu:crushed_${item.material}_ore`);
-      });
-    });
-  });
-  
   ServerEvents.recipes((event) => {
     event.shaped(Item.of("gtceu:electrico_kinetic_ore_factory"), ["GCG", "PLP", "WPW"], {
       G: "gtceu:bronze_gear",
@@ -110,3 +102,10 @@ var ekofProcessableTiers = {
     });
   });
   
+  ServerEvents.tags("item", (event) => {
+    Object.keys(ekofProcessableTiers).forEach((tier) => {
+      ekofProcessableTiers[tier].forEach((item) => {
+        event.add(`kubejs:ekof_processable_${tier}`, `gtceu:crushed_${item.material}_ore`);
+      });
+    });
+  });

--- a/kubejs/server_scripts/multiblock recipes/ore_factory.js
+++ b/kubejs/server_scripts/multiblock recipes/ore_factory.js
@@ -19,7 +19,7 @@ var ekofProcessableTiers = {
       { material: "bornite", secondary: "gold", tertiary: "pyrite", quaternary: "cobalt" },
       { material: "pentlandite", secondary: "cobalt", tertiary: "iron", quaternary: "sulfur" },
       { material: "rock_salt", secondary: "salt", tertiary: "salt", quaternary: "borax" },
-      { material: "salt", secondary: "rock_salt", tertiary: "rock_salt", quaternary: "borax" },
+      { material: "salt", secondary: "rock_salt", tertiary: "rock_salt", quaternary: "borax" }
     ],
   
     128: [
@@ -28,23 +28,18 @@ var ekofProcessableTiers = {
       { material: "pyrochlore", secondary: "apatite", tertiary: "apatite", quaternary: "calcium" },
       { material: "pyrolusite", secondary: "manganese", tertiary: "manganese", quaternary: "tantalite" },
       { material: "cobaltite", secondary: "cobalt", tertiary: "sulfur", quaternary: "cobalt" },
-      {
-        material: "apatite",
-        secondary: "tricalcium_phosphate",
-        tertiary: "tricalcium_phosphate",
-        quaternary: "phosphate",
-      },
+      { material: "apatite", secondary: "tricalcium_phosphate", tertiary: "tricalcium_phosphate", quaternary: "phosphate" }
     ],
   
     512: [
       { material: "bauxite", secondary: "gallium", tertiary: "grossular", quaternary: "rutile" },
       { material: "pitchblende", secondary: "thorium", tertiary: "thorium", quaternary: "uraninite" },
-      { material: "ilmenite", secondary: "iron", tertiary: "iron", quaternary: "rutile" },
+      { material: "ilmenite", secondary: "iron", tertiary: "iron", quaternary: "rutile" }
     ],
   
     2048: [
       { material: "cooperite", secondary: "palladium", tertiary: "nickel", quaternary: "nickel" },
-      { material: "bastnasite", secondary: "neodymium", tertiary: "neodymium", quaternary: "rare_earth" },
+      { material: "bastnasite", secondary: "neodymium", tertiary: "neodymium", quaternary: "rare_earth" }
     ],
   };
   

--- a/kubejs/server_scripts/multiblock recipes/ore_factory.js
+++ b/kubejs/server_scripts/multiblock recipes/ore_factory.js
@@ -51,13 +51,9 @@ var ekofProcessableTiers = {
   ServerEvents.tags("item", (event) => {
     Object.keys(ekofProcessableTiers).forEach((tier) => {
       ekofProcessableTiers[tier].forEach((item) => {
-        console.log(`EVENT: ${event}: Added tag gtceu:crushed_${item.material}_ore to startech:ekof_processable_${tier}`);
         event.add(`startech:ekof_processable_${tier}`, `gtceu:crushed_${item.material}_ore`);
       });
     });
-  
-    var someTags = event.get("startech:ekof_processable_32").getObjectIds();
-    console.log(`EVENT: ${event}: ${someTags}`);
   });
   
   ServerEvents.recipes((event) => {

--- a/kubejs/server_scripts/multiblock recipes/ore_factory.js
+++ b/kubejs/server_scripts/multiblock recipes/ore_factory.js
@@ -56,9 +56,11 @@ var ekofProcessableTiers = {
       L: "gtceu:lv_machine_hull",
       W: "gtceu:tin_single_cable",
     });
+  });
   
-    function ekof_basic(rpm, material, secondary, tertiary) {
-      const itemName = `gtceu:crushed_${material}_ore`;
+  function ekof_basic(rpm, material, secondary, tertiary) {
+    const itemName = `gtceu:crushed_${material}_ore`;
+    ServerEvents.recipes((event) => {
       event.recipes.gtceu
         .electrico_kinetic_ore_factory(`${material}_e_ore_factory`)
         .itemInputs(itemName)
@@ -71,10 +73,16 @@ var ekofProcessableTiers = {
         .inputStress(256)
         .rpm(rpm == 2048 ? 256 : rpm == 512 ? 192 : rpm)
         .EUt(28);
-    }
+    });
   
-    function ekof(rpm, material, secondary, tertiary, quaternary) {
-      const itemName = `gtceu:crushed_${material}_ore`;
+    ServerEvents.tags("item", (event) => {
+      event.add(`kubejs:ekof_processable_${rpm}`, itemName);
+    });
+  }
+  
+  function ekof(rpm, material, secondary, tertiary, quaternary) {
+    const itemName = `gtceu:crushed_${material}_ore`;
+    ServerEvents.recipes((event) => {
       event.recipes.gtceu
         .electrico_kinetic_ore_factory(`${material}_e_ore_factory`)
         .itemInputs(itemName)
@@ -88,24 +96,21 @@ var ekofProcessableTiers = {
         .inputStress(rpm * 4)
         .rpm(rpm == 2048 ? 256 : rpm == 512 ? 192 : rpm)
         .EUt(rpm * 0.75);
-    }
+    });
   
-    // Iterate over each tier and processable item and register the recipes
-    Object.keys(ekofProcessableTiers).forEach((tier) => {
-      ekofProcessableTiers[tier].forEach((item) => {
-        if (item.quaternary) {
-          ekof(tier, item.material, item.secondary, item.tertiary, item.quaternary);
-        } else {
-          ekof_basic(tier, item.material, item.secondary, item.tertiary);
-        }
-      });
+    ServerEvents.tags("item", (event) => {
+      event.add(`kubejs:ekof_processable_${rpm}`, itemName);
+    });
+  }
+  
+  // Iterate over each tier and processable item and register the recipes
+  Object.keys(ekofProcessableTiers).forEach((tier) => {
+    ekofProcessableTiers[tier].forEach((item) => {
+      if (item.quaternary) {
+        ekof(tier, item.material, item.secondary, item.tertiary, item.quaternary);
+      } else {
+        ekof_basic(tier, item.material, item.secondary, item.tertiary);
+      }
     });
   });
   
-  ServerEvents.tags("item", (event) => {
-    Object.keys(ekofProcessableTiers).forEach((tier) => {
-      ekofProcessableTiers[tier].forEach((item) => {
-        event.add(`kubejs:ekof_processable_${tier}`, `gtceu:crushed_${item.material}_ore`);
-      });
-    });
-  });

--- a/kubejs/server_scripts/multiblock recipes/ore_factory.js
+++ b/kubejs/server_scripts/multiblock recipes/ore_factory.js
@@ -51,7 +51,7 @@ var ekofProcessableTiers = {
   ServerEvents.tags("item", (event) => {
     Object.keys(ekofProcessableTiers).forEach((tier) => {
       ekofProcessableTiers[tier].forEach((item) => {
-        event.add(`startech:ekof_processable_${tier}`, `gtceu:crushed_${item.material}_ore`);
+        event.add(`start:ekof_processable_${tier}`, `gtceu:crushed_${item.material}_ore`);
       });
     });
   });

--- a/kubejs/server_scripts/multiblock recipes/ore_factory.js
+++ b/kubejs/server_scripts/multiblock recipes/ore_factory.js
@@ -51,7 +51,7 @@ var ekofProcessableTiers = {
   ServerEvents.tags("item", (event) => {
     Object.keys(ekofProcessableTiers).forEach((tier) => {
       ekofProcessableTiers[tier].forEach((item) => {
-        event.add(`start:ekof_processable_${tier}`, `gtceu:crushed_${item.material}_ore`);
+        event.add(`kubejs:ekof_processable_${tier}`, `gtceu:crushed_${item.material}_ore`);
       });
     });
   });

--- a/kubejs/server_scripts/multiblock recipes/ore_factory.js
+++ b/kubejs/server_scripts/multiblock recipes/ore_factory.js
@@ -1,139 +1,116 @@
+/**
+ * @typedef {{material: string, secondary: string, tertiary: string, quaternary?: string }} EKOFProcessableItemDetails
+ */
 
-ServerEvents.recipes(event => {
-
-    event.shaped(Item.of('gtceu:electrico_kinetic_ore_factory'), [
-        'GCG',
-        'PLP',
-        'WPW'
-    ], {
-        G: 'gtceu:bronze_gear',
-        C: '#gtceu:circuits/lv',
-        P: 'gtceu:steel_plate',
-        L: 'gtceu:lv_machine_hull',
-        W: 'gtceu:tin_single_cable'
+/** @type {Record<number, EKOFProcessableItem[]>} */
+var ekofProcessableTiers = {
+    32: [
+      { material: "iron", secondary: "nickel", tertiary: "tin" },
+      { material: "magnetite", secondary: "gold", tertiary: "gold" },
+      { material: "copper", secondary: "gold", tertiary: "nickel" },
+      { material: "tin", secondary: "iron", tertiary: "zinc" },
+      { material: "sphalerite", secondary: "gallium", tertiary: "sulfur" },
+      { material: "galena", secondary: "silver", tertiary: "sulfur" },
+      { material: "stibnite", secondary: "antimony", tertiary: "sulfur" },
+      { material: "chalcopyrite", secondary: "gold", tertiary: "pyrite", quaternary: "cobalt" },
+      { material: "cassiterite", secondary: "tin", tertiary: "tin", quaternary: "bismuth" },
+      { material: "silver", secondary: "gold", tertiary: "lead", quaternary: "sulfur" },
+      { material: "gold", secondary: "silver", tertiary: "copper", quaternary: "nickel" },
+      { material: "bornite", secondary: "gold", tertiary: "pyrite", quaternary: "cobalt" },
+      { material: "pentlandite", secondary: "cobalt", tertiary: "iron", quaternary: "sulfur" },
+      { material: "rock_salt", secondary: "salt", tertiary: "salt", quaternary: "borax" },
+      { material: "salt", secondary: "rock_salt", tertiary: "rock_salt", quaternary: "borax" },
+    ],
+  
+    128: [
+      { material: "monazite", secondary: "thorium", tertiary: "thorium", quaternary: "neodymium" },
+      { material: "lepidolite", secondary: "lithium", tertiary: "lithium", quaternary: "caesium" },
+      { material: "pyrochlore", secondary: "apatite", tertiary: "apatite", quaternary: "calcium" },
+      { material: "pyrolusite", secondary: "manganese", tertiary: "manganese", quaternary: "tantalite" },
+      { material: "cobaltite", secondary: "cobalt", tertiary: "sulfur", quaternary: "cobalt" },
+      {
+        material: "apatite",
+        secondary: "tricalcium_phosphate",
+        tertiary: "tricalcium_phosphate",
+        quaternary: "phosphate",
+      },
+    ],
+  
+    512: [
+      { material: "bauxite", secondary: "gallium", tertiary: "grossular", quaternary: "rutile" },
+      { material: "pitchblende", secondary: "thorium", tertiary: "thorium", quaternary: "uraninite" },
+      { material: "ilmenite", secondary: "iron", tertiary: "iron", quaternary: "rutile" },
+    ],
+  
+    2048: [
+      { material: "cooperite", secondary: "palladium", tertiary: "nickel", quaternary: "nickel" },
+      { material: "bastnasite", secondary: "neodymium", tertiary: "neodymium", quaternary: "rare_earth" },
+    ],
+  };
+  
+  ServerEvents.tags("item", (event) => {
+    Object.keys(ekofProcessableTiers).forEach((tier) => {
+      ekofProcessableTiers[tier].forEach((item) => {
+        console.log(`EVENT: ${event}: Added tag gtceu:crushed_${item.material}_ore to startech:ekof_processable_${tier}`);
+        event.add(`startech:ekof_processable_${tier}`, `gtceu:crushed_${item.material}_ore`);
+      });
     });
-
-    event.recipes.gtceu.electrico_kinetic_ore_factory('iron_e_ore_factory')
-        .itemInputs('gtceu:crushed_iron_ore')
-        .inputFluids('minecraft:water 100')
-        .itemOutputs('gtceu:iron_dust')
-        .chancedOutput('gtceu:iron_dust', 7500, 50)
-        .chancedOutput('gtceu:nickel_dust', 4500, 100)
-        .chancedOutput('gtceu:tin_dust', 3250, 50)
+  
+    var someTags = event.get("startech:ekof_processable_32").getObjectIds();
+    console.log(`EVENT: ${event}: ${someTags}`);
+  });
+  
+  ServerEvents.recipes((event) => {
+    event.shaped(Item.of("gtceu:electrico_kinetic_ore_factory"), ["GCG", "PLP", "WPW"], {
+      G: "gtceu:bronze_gear",
+      C: "#gtceu:circuits/lv",
+      P: "gtceu:steel_plate",
+      L: "gtceu:lv_machine_hull",
+      W: "gtceu:tin_single_cable",
+    });
+  
+    function ekof_basic(rpm, material, secondary, tertiary) {
+      const itemName = `gtceu:crushed_${material}_ore`;
+      event.recipes.gtceu
+        .electrico_kinetic_ore_factory(`${material}_e_ore_factory`)
+        .itemInputs(itemName)
+        .inputFluids("minecraft:water 100")
+        .itemOutputs(`gtceu:${material}_dust`)
+        .chancedOutput(`gtceu:${material}_dust`, 7500, 150)
+        .chancedOutput(`gtceu:${secondary}_dust`, 4500, 100)
+        .chancedOutput(`gtceu:${tertiary}_dust`, 3250, 50)
         .duration(160)
         .inputStress(256)
-        .rpm(32)
+        .rpm(rpm == 2048 ? 256 : rpm == 512 ? 192 : rpm)
         .EUt(28);
-
-    event.recipes.gtceu.electrico_kinetic_ore_factory('magnetite_e_ore_factory')
-        .itemInputs('gtceu:crushed_magnetite_ore')
-        .inputFluids('minecraft:water 100')
-        .itemOutputs('gtceu:magnetite_dust')
-        .chancedOutput('gtceu:magnetite_dust', 7500, 50)
-        .chancedOutput('gtceu:gold_dust', 4500, 100)
-        .chancedOutput('gtceu:gold_dust', 3250, 50)
-        .duration(160)
-        .inputStress(256)
-        .rpm(32)
-        .EUt(28);
-
-    event.recipes.gtceu.electrico_kinetic_ore_factory('copper_e_ore_factory')
-        .itemInputs('gtceu:crushed_copper_ore')
-        .inputFluids('minecraft:water 100')
-        .itemOutputs('gtceu:copper_dust')
-        .chancedOutput('gtceu:copper_dust', 7500, 50)
-        .chancedOutput('gtceu:gold_dust', 4500, 100)
-        .chancedOutput('gtceu:nickel_dust', 3250, 50)
-        .duration(160)
-        .inputStress(256)
-        .rpm(32)
-        .EUt(28);
-
-    event.recipes.gtceu.electrico_kinetic_ore_factory('tin_e_ore_factory')
-        .itemInputs('gtceu:crushed_tin_ore')
-        .inputFluids('minecraft:water 100')
-        .itemOutputs('gtceu:tin_dust')
-        .chancedOutput('gtceu:tin_dust', 7500, 50)
-        .chancedOutput('gtceu:iron_dust', 4500, 100)
-        .chancedOutput('gtceu:zinc_dust', 3250, 50)
-        .duration(160)
-        .inputStress(256)
-        .rpm(32)
-        .EUt(28);
-
-    event.recipes.gtceu.electrico_kinetic_ore_factory('sphalerite_e_ore_factory')
-        .itemInputs('gtceu:crushed_sphalerite_ore')
-        .inputFluids('minecraft:water 100')
-        .itemOutputs('gtceu:sphalerite_dust')
-        .chancedOutput('gtceu:sphalerite_dust', 7500, 50)
-        .chancedOutput('gtceu:gallium_dust', 4500, 100)
-        .chancedOutput('gtceu:sulfur_dust', 3250, 50)
-        .duration(160)
-        .inputStress(256)
-        .rpm(32)
-        .EUt(28);
-
-    event.recipes.gtceu.electrico_kinetic_ore_factory('galena_e_ore_factory')
-        .itemInputs('gtceu:crushed_galena_ore')
-        .inputFluids('minecraft:water 100')
-        .itemOutputs('gtceu:galena_dust')
-        .chancedOutput('gtceu:galena_dust', 7500, 50)
-        .chancedOutput('gtceu:silver_dust', 4500, 100)
-        .chancedOutput('gtceu:sulfur_dust', 3250, 50)
-        .duration(160)
-        .inputStress(256)
-        .rpm(32)
-        .EUt(28);
-
-    event.recipes.gtceu.electrico_kinetic_ore_factory('stibnite_e_ore_factory')
-        .itemInputs('gtceu:crushed_stibnite_ore')
-        .inputFluids('minecraft:water 100')
-        .itemOutputs('gtceu:stibnite_dust')
-        .chancedOutput('gtceu:stibnite_dust', 7500, 50)
-        .chancedOutput('gtceu:antimony_dust', 4500, 100)
-        .chancedOutput('gtceu:sulfur_dust', 3250, 50)
-        .duration(160)
-        .inputStress(256)
-        .rpm(32)
-        .EUt(28);
-
-
-    function ekof(rpm, material, secondary, tertiary, quaternary) {
-        event.recipes.gtceu.electrico_kinetic_ore_factory(`${material}_e_ore_factory`)
-            .itemInputs(`gtceu:crushed_${material}_ore`)
-            .inputFluids(`${(rpm >= 512) ? 'gtceu:sodium_persulfate' : 'gtceu:distilled_water'} 100`)
-            .itemOutputs(`gtceu:${material}_dust`)
-            .chancedOutput(`gtceu:${material}_dust`, 5000, 150)
-            .chancedOutput(`gtceu:${secondary}_dust`, 2500, 100)
-            .chancedOutput(`gtceu:${tertiary}_dust`, 1250, 50)
-            .chancedOutput(`gtceu:${quaternary}_dust`, 750, 100)
-            .duration(320)
-            .inputStress(rpm * 4)
-            .rpm((rpm == 2048) ? 256 : (rpm == 512) ? 192 : rpm)
-            .EUt(rpm * 0.75);
     }
-
-    ekof(32, 'chalcopyrite', 'gold', 'pyrite', 'cobalt');
-    ekof(32, 'cassiterite', 'tin', 'tin', 'bismuth');
-    ekof(32, 'silver', 'gold', 'lead', 'sulfur');
-    ekof(32, 'gold', 'silver', 'copper', 'nickel');
-    ekof(32, 'bornite', 'gold', 'pyrite', 'cobalt');
-    ekof(32, 'pentlandite', 'cobalt', 'iron', 'sulfur');
-    ekof(32, 'rock_salt', 'salt', 'salt', 'borax');
-    ekof(32, 'salt', 'rock_salt', 'rock_salt', 'borax');
-    
-    ekof(128, 'monazite', 'thorium', 'thorium', 'neodymium');
-    ekof(128, 'lepidolite', 'lithium', 'lithium', 'caesium');
-    ekof(128, 'pyrochlore', 'apatite', 'apatite', 'calcium');
-    ekof(128, 'pyrolusite', 'manganese', 'manganese', 'tantalite');
-    ekof(128, 'cobaltite', 'cobalt', 'sulfur', 'cobalt');
-    ekof(128, 'apatite', 'tricalcium_phosphate', 'tricalcium_phosphate', 'phosphate');
-
-    ekof(512, 'bauxite', 'gallium', 'grossular', 'rutile');
-    ekof(512, 'pitchblende', 'thorium', 'thorium', 'uraninite');
-    ekof(512, 'ilmenite', 'iron', 'iron', 'rutile');
-
-    ekof(2048, 'cooperite', 'palladium', 'nickel', 'nickel');
-    ekof(2048, 'bastnasite', 'neodymium', 'neodymium', 'rare_earth');
-
-});
+  
+    function ekof(rpm, material, secondary, tertiary, quaternary) {
+      const itemName = `gtceu:crushed_${material}_ore`;
+      event.recipes.gtceu
+        .electrico_kinetic_ore_factory(`${material}_e_ore_factory`)
+        .itemInputs(itemName)
+        .inputFluids(`${rpm >= 512 ? "gtceu:sodium_persulfate" : "gtceu:distilled_water"} 100`)
+        .itemOutputs(`gtceu:${material}_dust`)
+        .chancedOutput(`gtceu:${material}_dust`, 5000, 150)
+        .chancedOutput(`gtceu:${secondary}_dust`, 2500, 100)
+        .chancedOutput(`gtceu:${tertiary}_dust`, 1250, 50)
+        .chancedOutput(`gtceu:${quaternary}_dust`, 750, 100)
+        .duration(320)
+        .inputStress(rpm * 4)
+        .rpm(rpm == 2048 ? 256 : rpm == 512 ? 192 : rpm)
+        .EUt(rpm * 0.75);
+    }
+  
+    // Iterate over each tier and processable item and register the recipes
+    Object.keys(ekofProcessableTiers).forEach((tier) => {
+      ekofProcessableTiers[tier].forEach((item) => {
+        if (item.quaternary) {
+          ekof(tier, item.material, item.secondary, item.tertiary, item.quaternary);
+        } else {
+          ekof_basic(tier, item.material, item.secondary, item.tertiary);
+        }
+      });
+    });
+  });
+  


### PR DESCRIPTION
This PR introduces new tag groups for EKOF materials as follows: 

startech:ekof_processable_32
startech:ekof_processable_128
startech:ekof_processable_512
startech:ekof_processable_2048

This enables users to more easily find and track down all ores that work in Electric Kinetic Ore Factories (EKOFs) to process materials for their respective EU Tiers (which is denoted in RPM's in the code)

Ideally this should work with Tag Export bus but for some reason kubejs tags are not being read by ae2extended tag export bus. 