### PR TITLE
Update GTCEU Version to 1.5.4

### DIFF
--- a/kubejs/startup_scripts/elements and materials.js
+++ b/kubejs/startup_scripts/elements and materials.js
@@ -214,7 +214,7 @@ function periodicTableElement(material, type) {
 
 function blastProperty(material, temperature, gasTier, voltage, duration) {
     let mat = GTMaterials.get(material);
-    mat.setProperty(PropertyKey.BLAST, new $BlastProperty(temperature, gasTier, voltage, duration));
+    mat.setProperty(PropertyKey.BLAST, new $BlastProperty(temperature, gasTier, voltage, duration, -1, -1));
 }
 
 /*


### PR DESCRIPTION
**Please test to ensure that no unintended side effects occurred due to version bump.**

Bump GTCEU version from 1.4.6 to 1.5.4
Bump LowDragLib version from 1.0.28.c to =>1.0.31, Tested to work on 1.20.1-1.0.33.b-forge
Bump Star-Technology-Core from latest on main, to version built by action at https://github.com/trulyno/Star-Technology-Core/actions/runs/12426062183