### PR TITLE
Added platform name

### DIFF
--- a/kubejs/startup_scripts/config.js
+++ b/kubejs/startup_scripts/config.js
@@ -1,0 +1,2 @@
+
+Platform.mods.kubejs.name = 'Star Technology';


### PR DESCRIPTION
Kubejs mod name tooltips will show up as 'Star Technology' instead of 'KubeJS'