### PR TITLE
Cleanup and refactors

### DIFF
--- a/kubejs/config/common.properties
+++ b/kubejs/config/common.properties
@@ -9,5 +9,5 @@ hideServerScriptErrors=false
 saveDevPropertiesInConfig=false
 packmode=
 ignoreCustomUniqueRecipeIds=false
-creativeModeTabIcon=minecraft\:purple_dye
+creativeModeTabIcon=kubejs\:coin
 startupErrorReportUrl=

--- a/kubejs/server_scripts/augments.js
+++ b/kubejs/server_scripts/augments.js
@@ -1,3 +1,7 @@
+// priority: 1000000
+
+global.id = (id) => `start:${id}`;
+
 ServerEvents.recipes(event => {
     const id = global.id;
 
@@ -7,7 +11,7 @@ ServerEvents.recipes(event => {
         {tier: 'mv', plate: 'electrum', glass: ':signalum', gear: 'steel', fluid: 'gtceu:redstone 720', Mod: 16},
         {tier: 'hv', plate: 'lumium', glass: ':lumium', gear: 'aluminium', fluid: 'gtceu:glowstone 720', Mod: 64},
         {tier: 'ev', plate: 'soul_infused', glass: ':enderium', gear: 'stainless_steel', fluid: 'thermal:ender 750', Mod: 256}
-    ].forEach(tier=>{
+    ].forEach(tier => {
         event.recipes.gtceu.assembler(id(`${tier.tier}_kit`))
             .itemInputs(`4x gtceu:${tier.plate}_plate`, `thermal${tier.glass}_glass`, `gtceu:${tier.gear}_gear`, `#gtceu:circuits/${tier.tier}`)
             .itemOutputs(Item.of(`kubejs:${tier.tier}_upgrade_kit`, `{AugmentData:{BaseMod:${tier.Mod}f,Type: Upgrade}}`))
@@ -17,14 +21,14 @@ ServerEvents.recipes(event => {
     });
 
     // ARC augments
-    event.recipes.gtceu.assembler(id('arc_augment_lv'))
+    event.recipes.gtceu.assembler(id('lv_arc_augment'))
         .itemInputs('2x gtceu:bronze_plate', '2x gtceu:silver_gear', 'thermal_extra:soul_infused_glass')
         .itemOutputs(Item.of('kubejs:lv_arc_kit', '{AugmentData:{Type: Dynamo, DynamoEnergy:0.95f, DynamoPower:0.5f}}'))
         .duration(600)
         .EUt(28);
 
     // MCI augments
-    event.recipes.gtceu.assembler(id('mci_augment_1'))
+    event.recipes.gtceu.assembler(id('mv_mci_augment'))
         .itemInputs('2x gtceu:electrum_plate', '2x gtceu:lead_gear', 'thermal_extra:soul_infused_glass')
         .itemOutputs(Item.of('kubejs:lv_mci_kit', '{AugmentData:{Type: Dynamo, DynamoEnergy:1.1f}}'))
         .duration(600)
@@ -39,7 +43,7 @@ ServerEvents.recipes(event => {
         G: 'gtceu:gold_plate',
         S: 'gtceu:silver_plate',
         C: 'thermal:rf_coil'
-    });
+    }).id('start:shaped/ulv_rfc_kit');
 
     //RFS
     event.shaped(Item.of('kubejs:ulv_rfs_kit', '{AugmentData:{Type: RF, RFMax:6f, RFXfer:2f}}'), [
@@ -50,7 +54,7 @@ ServerEvents.recipes(event => {
         G: 'gtceu:gold_plate',
         S: 'gtceu:silver_plate',
         C: 'thermal:rf_coil'
-    });
+    }).id('start:shaped/ulv_rfs_kit');
 
     //RFT
     event.shaped(Item.of('kubejs:ulv_rft_kit', '{AugmentData:{Type: RF, RFMax:2f, RFXfer:6f}}'), [
@@ -61,7 +65,7 @@ ServerEvents.recipes(event => {
         G: 'gtceu:gold_plate',
         S: 'gtceu:silver_plate',
         C: 'thermal:rf_coil'
-    });
+    }).id('start:shaped/ulv_rft_kit');
 
     //FLS
     event.shaped(Item.of('kubejs:ulv_fls_kit', '{AugmentData:{Type: Fluid, FluidMax:4f}}'), [
@@ -72,7 +76,7 @@ ServerEvents.recipes(event => {
         R: 'gtceu:wrought_iron_plate',
         I: 'gtceu:rubber_plate',
         G: 'thermal:obsidian_glass'
-    });
+    }).id('start:shaped/ulv_fls_kit');
     
     // ARC's and MCI's
     [
@@ -101,7 +105,7 @@ ServerEvents.recipes(event => {
         {tier: 'ev', last_tier: 'hv', metal: 'enderium', Max: 22, Avg: 20, Min: 10, energy: 'ev'},
         {tier: 'iv', last_tier: 'ev', metal: 'shellite', Max: 26, Avg: 24, Min: 12, energy: 'iv'}
     ].forEach(foo => {
-        event.recipes.gtceu.alloy_smelter(id(`kubejs:${foo.tier}_rfc_kit`))
+        event.recipes.gtceu.alloy_smelter(id(`${foo.tier}_rfc_kit`))
             .itemInputs(`kubejs:${foo.last_tier}_rfc_kit`, `2x gtceu:${foo.metal}_gear`)
             .itemOutputs(Item.of(`kubejs:${foo.tier}_rfc_kit`, `{AugmentData:{Type: RF, RFMax:${foo.Avg}f, RFXfer:${foo.Avg}f}}`))
             .duration(600)

--- a/kubejs/server_scripts/augments.js
+++ b/kubejs/server_scripts/augments.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     // Upgrade augments
     [
@@ -7,7 +8,7 @@ ServerEvents.recipes(event => {
         {tier: 'hv', plate: 'lumium', glass: ':lumium', gear: 'aluminium', fluid: 'gtceu:glowstone 720', Mod: 64},
         {tier: 'ev', plate: 'soul_infused', glass: ':enderium', gear: 'stainless_steel', fluid: 'thermal:ender 750', Mod: 256}
     ].forEach(tier=>{
-        event.recipes.gtceu.assembler(`${tier.tier}_kit`)
+        event.recipes.gtceu.assembler(id(`${tier.tier}_kit`))
             .itemInputs(`4x gtceu:${tier.plate}_plate`, `thermal${tier.glass}_glass`, `gtceu:${tier.gear}_gear`, `#gtceu:circuits/${tier.tier}`)
             .itemOutputs(Item.of(`kubejs:${tier.tier}_upgrade_kit`, `{AugmentData:{BaseMod:${tier.Mod}f,Type: Upgrade}}`))
             .inputFluids(tier.fluid)
@@ -16,14 +17,14 @@ ServerEvents.recipes(event => {
     });
 
     // ARC augments
-    event.recipes.gtceu.assembler('arc_augment_lv')
+    event.recipes.gtceu.assembler(id('arc_augment_lv'))
         .itemInputs('2x gtceu:bronze_plate', '2x gtceu:silver_gear', 'thermal_extra:soul_infused_glass')
         .itemOutputs(Item.of('kubejs:lv_arc_kit', '{AugmentData:{Type: Dynamo, DynamoEnergy:0.95f, DynamoPower:0.5f}}'))
         .duration(600)
         .EUt(28);
 
     // MCI augments
-    event.recipes.gtceu.assembler('mci_augment_1')
+    event.recipes.gtceu.assembler(id('mci_augment_1'))
         .itemInputs('2x gtceu:electrum_plate', '2x gtceu:lead_gear', 'thermal_extra:soul_infused_glass')
         .itemOutputs(Item.of('kubejs:lv_mci_kit', '{AugmentData:{Type: Dynamo, DynamoEnergy:1.1f}}'))
         .duration(600)
@@ -79,13 +80,13 @@ ServerEvents.recipes(event => {
         {tier: 'hv', last_tier: 'mv', gear: 'enderium', glass: 'lumium', DynEA: 0.8, DynP: 1, DynEM: 1.5, energy: 'hv'},
         {tier: 'ev', last_tier: 'hv', gear: 'shellite', glass: 'enderium', DynEA: 0.75, DynP: 2, DynEM: 2, energy: 'ev'}
     ].forEach(tier=> {
-        event.recipes.gtceu.assembler(`arc_augment_${tier.tier}`)
+        event.recipes.gtceu.assembler(id(`arc_augment_${tier.tier}`))
             .itemInputs(`kubejs:${tier.last_tier}_arc_kit`, `2x gtceu:${tier.gear}_gear`, `thermal:${tier.glass}_glass`)
             .itemOutputs(Item.of(`kubejs:${tier.tier}_arc_kit`, `{AugmentData:{Type: Dynamo, DynamoEnergy:${tier.DynEA}f, DynamoPower:${tier.DynP}f}}`))
             .duration(600)
             .EUt(global.va[tier.energy]);
             
-        event.recipes.gtceu.assembler(`mci_augment_${tier.tier}`)
+        event.recipes.gtceu.assembler(id(`mci_augment_${tier.tier}`))
             .itemInputs(`kubejs:${tier.last_tier}_mci_kit`, `2x gtceu:${tier.gear}_gear`, `thermal:${tier.glass}_glass`)
             .itemOutputs(Item.of(`kubejs:${tier.tier}_mci_kit`, `{AugmentData:{Type: Dynamo, DynamoEnergy:${tier.DynEM}f}}`))
             .duration(600)
@@ -100,25 +101,25 @@ ServerEvents.recipes(event => {
         {tier: 'ev', last_tier: 'hv', metal: 'enderium', Max: 22, Avg: 20, Min: 10, energy: 'ev'},
         {tier: 'iv', last_tier: 'ev', metal: 'shellite', Max: 26, Avg: 24, Min: 12, energy: 'iv'}
     ].forEach(foo => {
-        event.recipes.gtceu.alloy_smelter(`kubejs:${foo.tier}_rfc_kit`)
+        event.recipes.gtceu.alloy_smelter(id(`kubejs:${foo.tier}_rfc_kit`))
             .itemInputs(`kubejs:${foo.last_tier}_rfc_kit`, `2x gtceu:${foo.metal}_gear`)
             .itemOutputs(Item.of(`kubejs:${foo.tier}_rfc_kit`, `{AugmentData:{Type: RF, RFMax:${foo.Avg}f, RFXfer:${foo.Avg}f}}`))
             .duration(600)
             .EUt(global.va[foo.energy]);
 
-        event.recipes.gtceu.alloy_smelter(`${foo.tier}_rfs_kit`)
+        event.recipes.gtceu.alloy_smelter(id(`${foo.tier}_rfs_kit`))
             .itemInputs(`kubejs:${foo.last_tier}_rfs_kit`, `2x gtceu:${foo.metal}_gear`)
             .itemOutputs(Item.of(`kubejs:${foo.tier}_rfs_kit`, `{AugmentData:{Type: RF, RFMax:${foo.Max}f, RFXfer:${foo.Min}f}}`))
             .duration(600)
             .EUt(global.va[foo.energy]);
 
-        event.recipes.gtceu.alloy_smelter(`${foo.tier}_rft_kit`)
+        event.recipes.gtceu.alloy_smelter(id(`${foo.tier}_rft_kit`))
             .itemInputs(`kubejs:${foo.last_tier}_rft_kit`, `2x gtceu:${foo.metal}_gear`)
             .itemOutputs(Item.of(`kubejs:${foo.tier}_rft_kit`, `{AugmentData:{Type: RF, RFMax:${foo.Min}f, RFXfer:${foo.Max}f}}`))
             .duration(600)
             .EUt(global.va[foo.energy]);
 
-        event.recipes.gtceu.alloy_smelter(`${foo.tier}_fls_kit`)
+        event.recipes.gtceu.alloy_smelter(id(`${foo.tier}_fls_kit`))
             .itemInputs(`kubejs:${foo.last_tier}_fls_kit`, `2x gtceu:${foo.metal}_gear`)
             .itemOutputs(Item.of(`kubejs:${foo.tier}_fls_kit`, `{AugmentData:{Type: Fluid, FluidMax:${foo.Avg}f}}`))
             .duration(600)

--- a/kubejs/server_scripts/circuit_etching.js
+++ b/kubejs/server_scripts/circuit_etching.js
@@ -1,46 +1,42 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
+
     // etching fluid
-    event.recipes.gtceu.chemical_reactor('copper_chloride')
+    event.recipes.gtceu.chemical_reactor(id('copper_chloride'))
         .itemInputs('1x gtceu:copper_dust')
         .inputFluids('gtceu:chlorine 1000')
         .itemOutputs('2x gtceu:copper_chloride_dust')
         .duration(600)
         .EUt(GTValues.VHA[GTValues.HV]);
- 
- 
-    event.recipes.gtceu.large_chemical_reactor('copper_chloride')
+
+    event.recipes.gtceu.large_chemical_reactor(id('copper_chloride'))
         .itemInputs('1x gtceu:copper_dust')
         .inputFluids('gtceu:chlorine 1000')
         .itemOutputs('2x gtceu:copper_chloride_dust')
         .duration(600)
         .EUt(GTValues.VHA[GTValues.HV]);
- 
- 
- 
- 
-    event.recipes.gtceu.mixer('cupric_chloride_solution')
+
+    event.recipes.gtceu.mixer(id('cupric_chloride_solution'))
         .itemInputs('1x gtceu:copper_chloride_dust')
         .inputFluids('gtceu:hydrochloric_acid 1000')
         .outputFluids('gtceu:cupric_chloride_solution 1000')
         .duration(400)
         .EUt(GTValues.VHA[GTValues.EV]);
- 
- 
+
     // non-cleanroom etching with CuCl
     [
         {board: 'phenolic', foil: 'silver', foil_count: 4, amount: 50, duration: 300, energy: 30},
         {board: 'plastic', foil: 'copper', foil_count: 6, amount: 125, duration: 600, energy: 30},
         {board: 'epoxy', foil: 'electrum', foil_count: 8, amount: 250, duration: 900, energy: 30}
     ].forEach(type=>{
-        event.recipes.gtceu.chemical_reactor(`${type.board}_circuit_board_copper`)
+        event.recipes.gtceu.chemical_reactor(id(`${type.board}_circuit_board_copper`))
             .itemInputs(`gtceu:${type.board}_circuit_board`, `${type.foil_count}x gtceu:${type.foil}_foil`)
             .inputFluids(`gtceu:cupric_chloride_solution ${type.amount}`)
             .itemOutputs(`gtceu:${type.board}_printed_circuit_board`)
             .duration(type.duration)
             .EUt(type.energy);
- 
- 
-        event.recipes.gtceu.large_chemical_reactor(`${type.board}_circuit_board_copper`)
+
+        event.recipes.gtceu.large_chemical_reactor(id(`${type.board}_circuit_board_copper`))
             .itemInputs(`gtceu:${type.board}_circuit_board`, `4x gtceu:${type.foil}_foil`)
             .inputFluids(`gtceu:cupric_chloride_solution ${type.amount}`)
             .itemOutputs(`gtceu:${type.board}_printed_circuit_board`)
@@ -55,7 +51,7 @@ ServerEvents.recipes(event => {
         {board: 'multilayer_fiber_reinforced', foil: 'platinum', foil_count: 8, amount: 1000, duration: 1500, energy: 120},
         {board: 'wetware', foil: 'niobium_titanium', foil_count: 32, amount: 2500, duration: 1800, energy: 480}
     ].forEach(type=>{
-        event.recipes.gtceu.chemical_reactor(`${type.board}_circuit_board_copper`)
+        event.recipes.gtceu.chemical_reactor(id(`${type.board}_circuit_board_copper`))
             .itemInputs(`gtceu:${type.board}_circuit_board`, `${type.foil_count}x gtceu:${type.foil}_foil`)
             .inputFluids(`gtceu:cupric_chloride_solution ${type.amount}`)
             .itemOutputs(`gtceu:${type.board}_printed_circuit_board`)
@@ -64,7 +60,7 @@ ServerEvents.recipes(event => {
             .EUt(type.energy);
  
  
-        event.recipes.gtceu.large_chemical_reactor(`${type.board}_circuit_board_copper`)
+        event.recipes.gtceu.large_chemical_reactor(id(`${type.board}_circuit_board_copper`))
             .itemInputs(`gtceu:${type.board}_circuit_board`, `${type.foil_count}x gtceu:${type.foil}_foil`)
             .inputFluids(`gtceu:cupric_chloride_solution ${type.amount}`)
             .itemOutputs(`gtceu:${type.board}_printed_circuit_board`)
@@ -83,7 +79,7 @@ ServerEvents.recipes(event => {
           {id: 'iron', name: 'iron_iii_chloride', multiplier: 2},
           {id: 'sodium', name: 'sodium_persulfate', multiplier: 4}
         ].forEach(fluid => {
-            event.recipes.gtceu.chemical_reactor(`${type.board}_circuit_board_${fluid.id}`)
+            event.recipes.gtceu.chemical_reactor(id(`${type.board}_circuit_board_${fluid.id}`))
                 .itemInputs(`kubejs:${type.board}_circuit_board`, `${type.foil_count}x gtceu:${type.foil}_foil`)
                 .inputFluids(`gtceu:${fluid.name} ${type.amount*fluid.multiplier}`)
                 .itemOutputs(`kubejs:${type.board}_printed_circuit_board`)
@@ -92,7 +88,7 @@ ServerEvents.recipes(event => {
                 .EUt(type.energy);
  
  
-            event.recipes.gtceu.large_chemical_reactor(`${type.board}_circuit_board_${fluid.id}`)
+            event.recipes.gtceu.large_chemical_reactor(id(`${type.board}_circuit_board_${fluid.id}`))
                 .itemInputs(`kubejs:${type.board}_circuit_board`, `${type.foil_count}x gtceu:${type.foil}_foil`)
                 .inputFluids(`gtceu:${fluid.name} ${type.amount*fluid.multiplier}`)
                 .itemOutputs(`kubejs:${type.board}_printed_circuit_board`)

--- a/kubejs/server_scripts/circuit_etching.js
+++ b/kubejs/server_scripts/circuit_etching.js
@@ -1,6 +1,6 @@
 ServerEvents.recipes(event => {
     const id = global.id;
-
+    
     // etching fluid
     event.recipes.gtceu.chemical_reactor(id('copper_chloride'))
         .itemInputs('1x gtceu:copper_dust')

--- a/kubejs/server_scripts/converters.js
+++ b/kubejs/server_scripts/converters.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     event.remove({ output: /gtceu:.*_energy_converter/ });
     
@@ -28,7 +29,7 @@ ServerEvents.recipes(event => {
                 W: `gtceu:${superconductor}_${thickness}_wire`,
                 C: `#gtceu:circuits/${tier}`,
                 S: `gtceu:${tier}_machine_hull`
-            });
+            }).id(`start:shaped/${tier}_${amps}_energy_converter`);
         };
         for (const [tier, superconductor] of Object.entries(PRMconverterMaterials)) {
             event.shaped(Item.of(`gtceu:${tier}_${amps}_energy_converter`), [
@@ -39,7 +40,7 @@ ServerEvents.recipes(event => {
                 W: `gtceu:${superconductor}_${thickness}_wire`,
                 C: `#gtceu:circuits/${tier}`,
                 S: `gtceu:${tier}_machine_hull`
-            });
+            }).id(`start:shaped/${tier}_${amps}_energy_converter`);
         };
     };
     

--- a/kubejs/server_scripts/converters.js
+++ b/kubejs/server_scripts/converters.js
@@ -1,4 +1,3 @@
-
 ServerEvents.recipes(event => {
 
     event.remove({ output: /gtceu:.*_energy_converter/ });
@@ -18,11 +17,6 @@ ServerEvents.recipes(event => {
         uhv: 'stellarium',
         uev: 'ancient_runicalium'
     }
-    
-    converterCraftingRecipe('1a','single');
-    converterCraftingRecipe('4a','quadruple');
-    converterCraftingRecipe('8a','octal');
-    converterCraftingRecipe('16a','hex');
     
     function converterCraftingRecipe(amps,thickness){
         for (const [tier, superconductor] of Object.entries(ADVconverterMaterials)) {
@@ -48,6 +42,11 @@ ServerEvents.recipes(event => {
             });
         };
     };
+    
+    converterCraftingRecipe('1a','single');
+    converterCraftingRecipe('4a','quadruple');
+    converterCraftingRecipe('8a','octal');
+    converterCraftingRecipe('16a','hex');
 
     // 64A Converter Recipe
     for (const [tier, superconductor] of Object.entries(ADVconverterMaterials)) {

--- a/kubejs/server_scripts/early_game/alloying.js
+++ b/kubejs/server_scripts/early_game/alloying.js
@@ -1,18 +1,18 @@
 ServerEvents.recipes(event => {
     
-    event.recipes.create.mixing('3x gtceu:bronze_ingot', ['3x minecraft:copper_ingot', '#forge:ingots/tin']).heatRequirement('lowheated');
-    event.shapeless('3x gtceu:bronze_dust', ['gtceu:copper_dust', 'gtceu:copper_dust', 'gtceu:copper_dust', 'gtceu:tin_dust']);
+    event.recipes.create.mixing('3x gtceu:bronze_ingot', ['3x minecraft:copper_ingot', '#forge:ingots/tin']).heatRequirement('lowheated').id('start:create_mixer/bronze');
+    event.shapeless('3x gtceu:bronze_dust', ['gtceu:copper_dust', 'gtceu:copper_dust', 'gtceu:copper_dust', 'gtceu:tin_dust']).id('start:shapeless/bronze_dust');
 
-    event.recipes.create.mixing('1x gtceu:red_alloy_ingot', ['minecraft:copper_ingot', '4x minecraft:redstone']).heatRequirement('lowheated');
-    event.shapeless('1x gtceu:red_alloy_dust', ['gtceu:copper_dust', 'minecraft:redstone', 'minecraft:redstone', 'minecraft:redstone', 'minecraft:redstone']);
+    event.recipes.create.mixing('1x gtceu:red_alloy_ingot', ['minecraft:copper_ingot', '4x minecraft:redstone']).heatRequirement('lowheated').id('start:create_mixer/red_alloy');;
+    event.shapeless('1x gtceu:red_alloy_dust', ['gtceu:copper_dust', 'minecraft:redstone', 'minecraft:redstone', 'minecraft:redstone', 'minecraft:redstone']).id('start:shapeless/red_alloy_dust');
 
-    event.recipes.create.mixing('3x gtceu:brass_ingot', ['3x minecraft:copper_ingot', '#forge:ingots/zinc']).heatRequirement('lowheated');
-    event.shapeless('3x gtceu:brass_dust', ['gtceu:copper_dust', 'gtceu:copper_dust', 'gtceu:copper_dust', 'gtceu:zinc_dust']);
+    event.recipes.create.mixing('3x gtceu:brass_ingot', ['3x minecraft:copper_ingot', '#forge:ingots/zinc']).heatRequirement('lowheated').id('start:create_mixer/brass');;
+    event.shapeless('3x gtceu:brass_dust', ['gtceu:copper_dust', 'gtceu:copper_dust', 'gtceu:copper_dust', 'gtceu:zinc_dust']).id('start:shapeless/brass_dust');
 
-    event.recipes.create.mixing('2x gtceu:invar_ingot', ['2x minecraft:iron_ingot', '#forge:ingots/nickel']).heatRequirement('lowheated');
-    event.shapeless('2x gtceu:invar_dust', ['gtceu:iron_dust', 'gtceu:iron_dust', 'gtceu:nickel_dust']);
+    event.recipes.create.mixing('2x gtceu:invar_ingot', ['2x minecraft:iron_ingot', '#forge:ingots/nickel']).heatRequirement('lowheated').id('start:create_mixer/invar');;
+    event.shapeless('2x gtceu:invar_dust', ['gtceu:iron_dust', 'gtceu:iron_dust', 'gtceu:nickel_dust']).id('start:shapeless/invar_dust');
 
-    event.recipes.create.mixing('1x gtceu:soul_infused_ingot', ['2x thermal_extra:soul_sand_dust', '#forge:ingots/invar']).heatRequirement('lowheated');
-    event.shapeless('1x gtceu:soul_infused_dust', ['thermal_extra:soul_sand_dust', 'thermal_extra:soul_sand_dust', 'gtceu:invar_dust']);
+    event.recipes.create.mixing('1x gtceu:soul_infused_ingot', ['2x thermal_extra:soul_sand_dust', '#forge:ingots/invar']).heatRequirement('lowheated').id('start:create_mixer/soul_infused');;
+    event.shapeless('1x gtceu:soul_infused_dust', ['thermal_extra:soul_sand_dust', 'thermal_extra:soul_sand_dust', 'gtceu:invar_dust']).id('start:shapeless/soul_infused_dust');
 
 })

--- a/kubejs/server_scripts/early_game/alloying.js
+++ b/kubejs/server_scripts/early_game/alloying.js
@@ -1,18 +1,19 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
     
-    event.recipes.create.mixing('3x gtceu:bronze_ingot', ['3x minecraft:copper_ingot', '#forge:ingots/tin']).heatRequirement('lowheated').id('start:create_mixer/bronze');
+    event.recipes.create.mixing('3x gtceu:bronze_ingot', ['3x minecraft:copper_ingot', '#forge:ingots/tin']).heatRequirement('lowheated').id('start:create_mixing/bronze');
     event.shapeless('3x gtceu:bronze_dust', ['gtceu:copper_dust', 'gtceu:copper_dust', 'gtceu:copper_dust', 'gtceu:tin_dust']).id('start:shapeless/bronze_dust');
 
-    event.recipes.create.mixing('1x gtceu:red_alloy_ingot', ['minecraft:copper_ingot', '4x minecraft:redstone']).heatRequirement('lowheated').id('start:create_mixer/red_alloy');;
+    event.recipes.create.mixing('1x gtceu:red_alloy_ingot', ['minecraft:copper_ingot', '4x minecraft:redstone']).heatRequirement('lowheated').id('start:create_mixing/red_alloy');;
     event.shapeless('1x gtceu:red_alloy_dust', ['gtceu:copper_dust', 'minecraft:redstone', 'minecraft:redstone', 'minecraft:redstone', 'minecraft:redstone']).id('start:shapeless/red_alloy_dust');
 
-    event.recipes.create.mixing('3x gtceu:brass_ingot', ['3x minecraft:copper_ingot', '#forge:ingots/zinc']).heatRequirement('lowheated').id('start:create_mixer/brass');;
+    event.recipes.create.mixing('3x gtceu:brass_ingot', ['3x minecraft:copper_ingot', '#forge:ingots/zinc']).heatRequirement('lowheated').id('start:create_mixing/brass');;
     event.shapeless('3x gtceu:brass_dust', ['gtceu:copper_dust', 'gtceu:copper_dust', 'gtceu:copper_dust', 'gtceu:zinc_dust']).id('start:shapeless/brass_dust');
 
-    event.recipes.create.mixing('2x gtceu:invar_ingot', ['2x minecraft:iron_ingot', '#forge:ingots/nickel']).heatRequirement('lowheated').id('start:create_mixer/invar');;
+    event.recipes.create.mixing('2x gtceu:invar_ingot', ['2x minecraft:iron_ingot', '#forge:ingots/nickel']).heatRequirement('lowheated').id('start:create_mixing/invar');;
     event.shapeless('2x gtceu:invar_dust', ['gtceu:iron_dust', 'gtceu:iron_dust', 'gtceu:nickel_dust']).id('start:shapeless/invar_dust');
 
-    event.recipes.create.mixing('1x gtceu:soul_infused_ingot', ['2x thermal_extra:soul_sand_dust', '#forge:ingots/invar']).heatRequirement('lowheated').id('start:create_mixer/soul_infused');;
+    event.recipes.create.mixing('1x gtceu:soul_infused_ingot', ['2x thermal_extra:soul_sand_dust', '#forge:ingots/invar']).heatRequirement('lowheated').id('start:create_mixing/soul_infused');;
     event.shapeless('1x gtceu:soul_infused_dust', ['thermal_extra:soul_sand_dust', 'thermal_extra:soul_sand_dust', 'gtceu:invar_dust']).id('start:shapeless/soul_infused_dust');
 
 })

--- a/kubejs/server_scripts/early_game/barrels.js
+++ b/kubejs/server_scripts/early_game/barrels.js
@@ -1,5 +1,4 @@
 ServerEvents.recipes(event => {
-
     const id = global.id;
 
     event.shaped('gtceu:ulv_barrel',[

--- a/kubejs/server_scripts/early_game/barrels.js
+++ b/kubejs/server_scripts/early_game/barrels.js
@@ -1,5 +1,7 @@
 ServerEvents.recipes(event => {
 
+    const id = (id) => `start:${id}`;
+
     event.shaped('gtceu:ulv_barrel',[
         'ABA',
         'ACA',
@@ -8,7 +10,7 @@ ServerEvents.recipes(event => {
         B: 'minecraft:chest',
         C: 'woodenbucket:wooden_bucket',
         D: '#minecraft:wooden_slabs'
-    });
+    }).id('start:shaped/ulv_barrel');
 
     event.shaped('gtceu:ulv_stone_barrel',[
         'ABA',
@@ -18,33 +20,35 @@ ServerEvents.recipes(event => {
             B: 'minecraft:chest',
             C: 'minecraft:bucket',
             D: 'minecraft:stone_slab'
-    });
+    }).id('start:shaped/ulv_stone_barrel');
 
-     function sbarrel(output,fluidcons,nconsfluid,circ){
-        event.recipes.gtceu.stone_barrel(`${output}`)
+    const sbarrel = (output, fluidcons, nconsfluid, circ) => {
+        event.recipes.gtceu.stone_barrel(id(`${output}`))
             .notConsumableFluid(`${nconsfluid}`)
             .inputFluids(`${fluidcons} 1000`)
-            .itemOutputs(`${output}`)
+            .itemOutputs(`minecraft:${output}`)
             .circuit(circ)
             .duration(15);
     }
-    sbarrel('minecraft:cobblestone','minecraft:water','minecraft:lava','')
-    sbarrel('minecraft:obsidian','minecraft:lava','minecraft:water',1)
-    sbarrel('minecraft:blackstone','exnihilosequentia:witch_water','minecraft:lava','')
 
-        event.recipes.gtceu.stone_barrel(`gtceu:tempered_glass`)
-            .itemInputs(`minecraft:glass`)
-            .inputFluids(`minecraft:lava 1000`)
-            .itemOutputs(`gtceu:tempered_glass`)
-            .duration(600);
+    sbarrel('cobblestone','minecraft:water','minecraft:lava','')
+    sbarrel('obsidian','minecraft:lava','minecraft:water',1)
+    sbarrel('blackstone','exnihilosequentia:witch_water','minecraft:lava','')
 
-    function barrel(output,item,fluid){
-        event.recipes.gtceu.barrel(`${output}`)
+    event.recipes.gtceu.stone_barrel(id(`tempered_glass`))
+        .itemInputs(`minecraft:glass`)
+        .inputFluids(`minecraft:lava 1000`)
+        .itemOutputs(`gtceu:tempered_glass`)
+        .duration(600);
+
+    const barrel = (output, item, fluid) => {
+        event.recipes.gtceu.barrel(id(`${output.split(':')[1]}`))
             .itemInputs(`${item}`)
             .inputFluids(`${fluid} 1000`)
             .itemOutputs(`${output}`)
             .duration(15);
     }
+
     barrel('minecraft:clay','exnihilosequentia:dust','minecraft:water')
     barrel('minecraft:mud','minecraft:dirt','minecraft:water')
     barrel('minecraft:pointed_dripstone','exnihilosequentia:crushed_dripstone','minecraft:water')
@@ -67,15 +71,14 @@ ServerEvents.recipes(event => {
         'minecraft:glow_berries','minecraft:cactus','exnihilosequentia:silkworm', '#minecraft:flowers', '#forge:seeds', '#forge:crops', '#minecraft:saplings', '#minecraft:leaves'
     ]
     compost.forEach(type => {
-        const id = type.slice(type.indexOf(':')+1)
-        event.recipes.gtceu.barrel_composting(`${id}_composting`)
+        event.recipes.gtceu.barrel_composting(id(`${type.split(':')[1]}_composting`))
             .itemInputs(`4x ${type}`)
             .itemOutputs('minecraft:dirt')
             .duration(15);
     });
 
-    function transformation(output,ncItem){
-        event.recipes.gtceu.barrel_transformation(`${output}`)
+    const transformation = (output, ncItem) => {
+        event.recipes.gtceu.barrel_transformation(id(`${output.split(':')[1]}`))
             .notConsumable(`${ncItem}`)
             .inputFluids('minecraft:water 1000')
             .outputFluids(`${output} 1000`)

--- a/kubejs/server_scripts/early_game/barrels.js
+++ b/kubejs/server_scripts/early_game/barrels.js
@@ -1,6 +1,6 @@
 ServerEvents.recipes(event => {
 
-    const id = (id) => `start:${id}`;
+    const id = global.id;
 
     event.shaped('gtceu:ulv_barrel',[
         'ABA',

--- a/kubejs/server_scripts/early_game/composter.js
+++ b/kubejs/server_scripts/early_game/composter.js
@@ -1,5 +1,4 @@
 ServerEvents.recipes(event => {
-
     const id = global.id;
 
     event.shaped('gtceu:ulv_advanced_composter',[

--- a/kubejs/server_scripts/early_game/composter.js
+++ b/kubejs/server_scripts/early_game/composter.js
@@ -1,5 +1,7 @@
 ServerEvents.recipes(event => {
 
+    const id = (id) => `start:${id}`;
+
     event.shaped('gtceu:ulv_advanced_composter',[
         'PRP',
         'PGP',
@@ -9,10 +11,10 @@ ServerEvents.recipes(event => {
         R: 'gtceu:iron_gear',
         I: 'gtceu:iron_plate',
         S: 'thermal:redstone_servo'
-    });
+    }).id('start:shaped/ulv_advanced_composter');
 
     function composting (odds, fuel) {
-        event.recipes.gtceu.composting(fuel.split(':')[1])
+        event.recipes.gtceu.composting(id(fuel.split(':')[1]))
             .itemInputs(`${fuel}`)
             .chancedOutput('minecraft:bone_meal', odds, 0)
             .duration(42)

--- a/kubejs/server_scripts/early_game/composter.js
+++ b/kubejs/server_scripts/early_game/composter.js
@@ -1,6 +1,6 @@
 ServerEvents.recipes(event => {
 
-    const id = (id) => `start:${id}`;
+    const id = global.id;
 
     event.shaped('gtceu:ulv_advanced_composter',[
         'PRP',

--- a/kubejs/server_scripts/early_game/sieving.js
+++ b/kubejs/server_scripts/early_game/sieving.js
@@ -1,4 +1,3 @@
-
 ServerEvents.recipes(event => {
     const dirt = 'minecraft:dirt';
     const gravel = 'minecraft:gravel';
@@ -12,7 +11,7 @@ ServerEvents.recipes(event => {
     const rdirt = 'minecraft:rooted_dirt'
     const myc = 'minecraft:mycelium'
 
-    function sieve(mesh, chance, input, result, wlog) {
+    const sieve = (mesh, chance, input, result, wlog) => {
         event.custom({
             "type": `exnihilosequentia:sifting`,
             "input": input,
@@ -22,7 +21,7 @@ ServerEvents.recipes(event => {
                 mesh: mesh
             }],
             "waterlogged": wlog
-        })
+        }).id(`start:sifting/${input.split(':')[1]}_${result.split(':')[1]}`); // doesn't work, idk why
     }
 
     function hammer(input, result) {

--- a/kubejs/server_scripts/early_game/sieving.js
+++ b/kubejs/server_scripts/early_game/sieving.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
     const dirt = 'minecraft:dirt';
     const gravel = 'minecraft:gravel';
     const cdirt = 'minecraft:coarse_dirt';

--- a/kubejs/server_scripts/early_game/solid_blast_furnace.js
+++ b/kubejs/server_scripts/early_game/solid_blast_furnace.js
@@ -1,5 +1,8 @@
 ServerEvents.recipes(event => {
-    event.recipes.gtceu.coke_oven('sugar_coke')
+
+    const id = (id) => `start:${id}`;
+
+    event.recipes.gtceu.coke_oven(id('sugar_coke'))
         .itemOutputs('minecraft:charcoal')
         .outputFluids(Fluid.of('gtceu:creosote', 50))
         .itemInputs('8x minecraft:sugar_cane')
@@ -16,7 +19,7 @@ ServerEvents.recipes(event => {
         P: 'gtceu:steel_plate',
         B: 'gtceu:solid_machine_casing',
         F: '#forge:tools/screwdrivers'
-    });
+    }).id('start:shaped/solid_blast_furnace');
 
     const fuel = [
         'gtceu:charcoal_dust',
@@ -31,36 +34,36 @@ ServerEvents.recipes(event => {
     ];
 
     fuel.forEach(fuel => {
-        var cutFuel = fuel.slice(fuel.indexOf(':')+1)
-        event.recipes.gtceu.solid_blast_furnace(`silicon_from_silicon_dioxide/${cutFuel}`)
+        const cutFuel = fuel.split(':')[1]
+        event.recipes.gtceu.solid_blast_furnace(id(`silicon_from_silicon_dioxide/${cutFuel}`))
             .itemInputs('6x gtceu:silicon_dioxide_dust', `2x ${fuel}`)
             .itemOutputs('2x gtceu:silicon_dust', '2x gtceu:tiny_dark_ash_dust')
             .duration(1000);
-        event.recipes.gtceu.solid_blast_furnace(`steel_from_magnetite_dust/${cutFuel}`)
+
+        event.recipes.gtceu.solid_blast_furnace(id(`steel_from_magnetite_dust/${cutFuel}`))
             .itemInputs('7x gtceu:magnetite_dust', '2x gtceu:silicon_dust', `2x ${fuel}`)
             .itemOutputs('3x gtceu:steel_ingot', '6x gtceu:silicon_dioxide_dust', '2x gtceu:tiny_dark_ash_dust')
             .duration(1500);
 
-        event.recipes.gtceu.solid_blast_furnace(`sulfur_from_sphalerite/${cutFuel}`)
+        event.recipes.gtceu.solid_blast_furnace(id(`sulfur_from_sphalerite/${cutFuel}`))
             .itemInputs('2x gtceu:sphalerite_dust', '4x minecraft:andesite', `2x ${fuel}`)
             .itemOutputs('12x create:andesite_alloy', '1x gtceu:sulfur_dust', '2x gtceu:tiny_dark_ash_dust')
             .duration(200);
     });
 
     goodFuel.forEach(fuel => {
-        var cutFuel = fuel.slice(fuel.indexOf(':')+1)
-
-        event.recipes.gtceu.solid_blast_furnace(`silicon_from_silicon_dioxide/${cutFuel}`)
+        const cutFuel = fuel.split(':')[1]
+        event.recipes.gtceu.solid_blast_furnace(id(`silicon_from_silicon_dioxide/${cutFuel}`))
             .itemInputs('6x gtceu:silicon_dioxide_dust', `2x ${fuel}`)
             .itemOutputs('2x gtceu:silicon_dust', '2x gtceu:tiny_ash_dust')
             .duration(750);
 
-        event.recipes.gtceu.solid_blast_furnace(`steel_from_magnetite_dust/${cutFuel}`)
+        event.recipes.gtceu.solid_blast_furnace(id(`steel_from_magnetite_dust/${cutFuel}`))
             .itemInputs('7x gtceu:magnetite_dust', '2x gtceu:silicon_dust', `2x ${fuel}`)
             .itemOutputs('3x gtceu:steel_ingot', '6x gtceu:silicon_dioxide_dust', '2x gtceu:tiny_ash_dust')
             .duration(1125);
 
-        event.recipes.gtceu.solid_blast_furnace(`sulfur_from_sphalerite/${cutFuel}`)
+        event.recipes.gtceu.solid_blast_furnace(id(`sulfur_from_sphalerite/${cutFuel}`))
             .itemInputs('2x gtceu:sphalerite_dust', '4x minecraft:andesite', `2x ${fuel}`)
             .itemOutputs('12x create:andesite_alloy', '1x gtceu:sulfur_dust', '2x gtceu:tiny_ash_dust')
             .duration(150);
@@ -68,38 +71,47 @@ ServerEvents.recipes(event => {
 
     //Bessemer Steel
     const coalType = ['coal','charcoal']
-    ironType('minecraft:iron',720,'iron',5/6)
-    ironType('gtceu:wrought_iron',320,'wrought_iron',3/4)
-    function ironType(FeType,baseTime,naming,cokeScaler){
-    coalType.forEach(coal => {
-        event.recipes.gtceu.bessemer_blast_furnace(`${naming}_${coal}_to_steel_dust`)
-        .itemInputs(`${FeType}_ingot`,`2x gtceu:${coal}_dust`)
-        .itemOutputs('gtceu:steel_ingot',`gtceu:tiny_dark_ash_dust`)
-        .duration(baseTime); 
-    event.recipes.gtceu.bessemer_blast_furnace(`${naming}_${coal}_to_steel`)
-        .itemInputs(`${FeType}_ingot`,`2x minecraft:${coal}`)
-        .itemOutputs('gtceu:steel_ingot',`gtceu:tiny_dark_ash_dust`)
-        .duration(baseTime);  
-    })
-    event.recipes.gtceu.bessemer_blast_furnace(`${naming}_coal_to_steel_block`)
-        .itemInputs(`${FeType}_block`,`2x minecraft:coal_block`)
-        .itemOutputs('gtceu:steel_block',`gtceu:dark_ash_dust`)
-        .duration(baseTime*9);
-    event.recipes.gtceu.bessemer_blast_furnace(`${naming}_charcoal_to_steel_block`)
-        .itemInputs(`${FeType}_block`,`2x gtceu:charcoal_block`)
-        .itemOutputs('gtceu:steel_block',`gtceu:dark_ash_dust`)
-        .duration(baseTime*9);
-    event.recipes.gtceu.bessemer_blast_furnace(`${naming}_coke_to_steel_block`)
-        .itemInputs(`${FeType}_block`,`gtceu:coke_block`)
-        .itemOutputs('gtceu:steel_block',`gtceu:ash_dust`)
-        .duration(baseTime*9*cokeScaler);
-    event.recipes.gtceu.bessemer_blast_furnace(`${naming}_coke_to_steel_dust`)
-        .itemInputs(`${FeType}_ingot`,`gtceu:coke_dust`)
-        .itemOutputs('gtceu:steel_ingot',`gtceu:ash_dust`)
-        .duration(baseTime*cokeScaler);
-    event.recipes.gtceu.bessemer_blast_furnace(`${naming}_coke_to_steel`)
-        .itemInputs(`${FeType}_ingot`,`gtceu:coke_gem`)
-        .itemOutputs('gtceu:steel_ingot',`gtceu:ash_dust`)
-        .duration(baseTime*cokeScaler);
+
+    const ironType = (FeType, baseTime, cokeScaler) => {
+        const naming = FeType.split(':')[1]
+        coalType.forEach(coal => {
+            event.recipes.gtceu.bessemer_blast_furnace(id(`${naming}_${coal}_to_steel_dust`))
+                .itemInputs(`${FeType}_ingot`,`2x gtceu:${coal}_dust`)
+                .itemOutputs('gtceu:steel_ingot',`gtceu:tiny_dark_ash_dust`)
+                .duration(baseTime); 
+
+            event.recipes.gtceu.bessemer_blast_furnace(id(`${naming}_${coal}_to_steel`))
+                .itemInputs(`${FeType}_ingot`,`2x minecraft:${coal}`)
+                .itemOutputs('gtceu:steel_ingot',`gtceu:tiny_dark_ash_dust`)
+                .duration(baseTime);  
+        })
+
+        event.recipes.gtceu.bessemer_blast_furnace(id(`${naming}_coal_to_steel_block`))
+            .itemInputs(`${FeType}_block`,`2x minecraft:coal_block`)
+            .itemOutputs('gtceu:steel_block',`gtceu:dark_ash_dust`)
+            .duration(baseTime*9);
+
+        event.recipes.gtceu.bessemer_blast_furnace(id(`${naming}_charcoal_to_steel_block`))
+            .itemInputs(`${FeType}_block`,`2x gtceu:charcoal_block`)
+            .itemOutputs('gtceu:steel_block',`gtceu:dark_ash_dust`)
+            .duration(baseTime*9);
+
+        event.recipes.gtceu.bessemer_blast_furnace(id(`${naming}_coke_to_steel_block`))
+            .itemInputs(`${FeType}_block`,`gtceu:coke_block`)
+            .itemOutputs('gtceu:steel_block',`gtceu:ash_dust`)
+            .duration(baseTime*9*cokeScaler);
+            
+        event.recipes.gtceu.bessemer_blast_furnace(id(`${naming}_coke_to_steel_dust`))
+            .itemInputs(`${FeType}_ingot`,`gtceu:coke_dust`)
+            .itemOutputs('gtceu:steel_ingot',`gtceu:ash_dust`)
+            .duration(baseTime*cokeScaler);
+
+        event.recipes.gtceu.bessemer_blast_furnace(id(`${naming}_coke_to_steel`))
+            .itemInputs(`${FeType}_ingot`,`gtceu:coke_gem`)
+            .itemOutputs('gtceu:steel_ingot',`gtceu:ash_dust`)
+            .duration(baseTime*cokeScaler);
+
     }
+    ironType('minecraft:iron', 720, 5/6)
+    ironType('gtceu:wrought_iron', 320, 3/4)
 });

--- a/kubejs/server_scripts/early_game/solid_blast_furnace.js
+++ b/kubejs/server_scripts/early_game/solid_blast_furnace.js
@@ -1,5 +1,4 @@
 ServerEvents.recipes(event => {
-
     const id = global.id;
 
     event.recipes.gtceu.coke_oven(id('sugar_coke'))

--- a/kubejs/server_scripts/early_game/solid_blast_furnace.js
+++ b/kubejs/server_scripts/early_game/solid_blast_furnace.js
@@ -1,6 +1,6 @@
 ServerEvents.recipes(event => {
 
-    const id = (id) => `start:${id}`;
+    const id = global.id;
 
     event.recipes.gtceu.coke_oven(id('sugar_coke'))
         .itemOutputs('minecraft:charcoal')

--- a/kubejs/server_scripts/endgame content/abydos_lines/akreyrium_line.js
+++ b/kubejs/server_scripts/endgame content/abydos_lines/akreyrium_line.js
@@ -1,7 +1,8 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     // Line Specific Controller Recipe
-    event.recipes.gtceu.assembly_line('folding_akreyrium_stabiliser')
+    event.recipes.gtceu.assembly_line(id('folding_akreyrium_stabiliser'))
         .itemInputs('gtceu:uhv_machine_hull', '12x #gtceu:circuits/uhv','48x kubejs:uepic_chip','16x gtceu:small_pure_netherite_gear','32x gtceu:neutronium_normal_fluid_pipe',
             '16x gtceu:light_blue_glass_lens','16x gtceu:lime_glass_lens','16x gtceu:magenta_glass_lens','8x gtceu:uhv_field_generator',
             '8x gtceu:uhv_fluid_regulator','4x gtceu:uhv_sensor','8x gtceu:pure_netherite_rotor')
@@ -17,7 +18,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.UV]); 
 
     // Akreyrium Processing
-    event.recipes.gtceu.cyclonic_sifter('akreyrium_sieving')
+    event.recipes.gtceu.cyclonic_sifter(id('akreyrium_sieving'))
         .chancedInput('1x kubejs:netherite_reinforced_mesh', 500, -50)
         .inputFluids('gtceu:gritty_akreyrium 100000')
         .outputFluids('gtceu:lepton_sparse_akreyrium 1000')
@@ -26,7 +27,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.UHV]*.8);
 
     // Coalescing Superalloy mixing
-    event.recipes.gtceu.mixer('lepton_coalescing_superalloy_dust')
+    event.recipes.gtceu.mixer(id('lepton_coalescing_superalloy_dust'))
         .itemInputs(
             '4x gtceu:thallium_tungstate_dust', '2x gtceu:nickel_dust', '4x gtceu:graphene_dust', '3x gtceu:niobium_dust', "4x gtceu:bismuth_dust"
         ).itemOutputs('17x gtceu:lepton_coalescing_superalloy_dust')
@@ -34,7 +35,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.LuV]);
     
     // Leptonic Flux Recipe
-    event.recipes.gtceu.mixer('leptonic_flux_akreyrium')
+    event.recipes.gtceu.mixer(id('leptonic_flux_akreyrium'))
         .itemInputs('1x kubejs:amorphous_akreyrium')
         .inputFluids('gtceu:lepton_coalescing_superalloy 864', 'gtceu:lepton_sparse_akreyrium 1000')
         .outputFluids('gtceu:lepton_flux_akreyrium 1000')
@@ -42,7 +43,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.UV]);
 
     // Empty injection catalyst recipe
-    event.recipes.gtceu.assembler('blank_injection_catalyst')
+    event.recipes.gtceu.assembler(id('blank_injection_catalyst'))
         .itemInputs(
             '1x gtceu:petri_dish', '2x kubejs:uhv_microfluidic_flow_valve', '32x gtceu:neutronium_foil',
             '12x kubejs:uhv_high_strength_panel', '8x gtceu:neutronium_screw'
@@ -52,7 +53,7 @@ ServerEvents.recipes(event => {
         .duration(800)
         .EUt(GTValues.VA[GTValues.UHV]);
     
-    event.recipes.gtceu.injection_mixer('lepton_flavour_foundational_flux')
+    event.recipes.gtceu.injection_mixer(id('lepton_flavour_foundational_flux'))
         .itemInputs('1x kubejs:amorphous_akreyrium')
         .inputFluids('gtceu:lepton_coalescing_superalloy 864')
         .outputFluids('gtceu:lepton_flavour_foundational_flux 1000')
@@ -66,27 +67,27 @@ ServerEvents.recipes(event => {
     //-----------------------------------------------------------------------------
 
     // Intermediate to catalyst
-    event.recipes.gtceu.mixer('light_tau_infusion_flux')
+    event.recipes.gtceu.mixer(id('light_tau_infusion_flux'))
         .inputFluids('gtceu:mercury 3850', 'gtceu:lepton_flavour_foundational_flux 1000')
         .outputFluids('gtceu:light_tau_infusion_flux 1000')
         .duration(360)
         .EUt(GTValues.VA[GTValues.ZPM]);
 
-    event.recipes.gtceu.distillation_tower('light_tau_infusion_flux_decomp')
+    event.recipes.gtceu.distillation_tower(id('light_tau_infusion_flux_decomp'))
         .inputFluids('gtceu:light_tau_infusion_flux 1000')
         .outputFluids('gtceu:superlight_tau_infusion_flux 800', 'gtceu:heavy_tau_infusion_flux 200')
         .itemOutputs('1x kubejs:aspect_of_weight')
         .duration(320)
         .EUt(GTValues.VA[GTValues.UV]);
 
-    event.recipes.gtceu.brewery('heavy_tau_conversion')
+    event.recipes.gtceu.brewery(id('heavy_tau_conversion'))
         .inputFluids('gtceu:superlight_tau_infusion_flux 1000')
         .itemInputs('1x kubejs:aspect_of_weight')
         .outputFluids('gtceu:heavy_tau_infusion_flux 500')
         .duration(400)
         .EUt(GTValues.VA[GTValues.UV]);
 
-    event.recipes.gtceu.injection_mixer('heavy_tau_densification')
+    event.recipes.gtceu.injection_mixer(id('heavy_tau_densification'))
         // TODO: Better idea for "densifying/heavying" items which can be freely
         // consumed.
         .itemInputs('1x kubejs:aspect_of_weight', '1x gtceu:osmiridium_dust')
@@ -95,7 +96,7 @@ ServerEvents.recipes(event => {
         .duration(120)
         .EUt(GTValues.VA[GTValues.UV]);
 
-    event.recipes.gtceu.mixer('tau_infusion_flux_unification')
+    event.recipes.gtceu.mixer(id('tau_infusion_flux_unification'))
         .itemInputs('1x kubejs:aspect_of_weight')
         .inputFluids('gtceu:superheavy_tau_infusion_flux 2000', 'gtceu:superlight_tau_infusion_flux 2000')
         .outputFluids('gtceu:ethereal_tau_infusion_flux 5000')
@@ -103,7 +104,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.UV]);
 
     // Tau canning
-    event.recipes.gtceu.canner('tau_canner')
+    event.recipes.gtceu.canner(id('tau_canner'))
         .itemInputs('1x kubejs:blank_injection_catalyst')
         .inputFluids('gtceu:ethereal_tau_infusion_flux 125')
         .itemOutputs('1x kubejs:tau_injection_catalyst')
@@ -115,7 +116,7 @@ ServerEvents.recipes(event => {
     //-----------------------------------------------------------------------------
     
     // Intermediate to catalyst
-    event.recipes.gtceu.mixer('twinkling_muon_infusion_flux')
+    event.recipes.gtceu.mixer(id('twinkling_muon_infusion_flux'))
         .inputFluids('gtceu:glowstone 512', 'gtceu:lepton_flavour_foundational_flux 1000')
         .outputFluids('gtceu:twinkling_muon_infusion_flux 1000')
         .duration(360)
@@ -123,51 +124,51 @@ ServerEvents.recipes(event => {
     
 
     // Normal chemical reactor
-    event.recipes.gtceu.chemical_reactor('twink_muon_lighting')
+    event.recipes.gtceu.chemical_reactor(id('twink_muon_lighting'))
         .inputFluids('gtceu:twinkling_muon_infusion_flux 1000', 'minecraft:lava 1000')
         .outputFluids('gtceu:glowing_muon_infusion_flux 1000')
         .duration(360)
         .EUt(GTValues.VA[GTValues.LuV]);
         
-    event.recipes.gtceu.chemical_reactor('glowing_muon_lighting')
+    event.recipes.gtceu.chemical_reactor(id('glowing_muon_lighting'))
         .inputFluids('gtceu:glowing_muon_infusion_flux 1000', 'gtceu:blaze 288')
         .outputFluids('gtceu:shining_muon_infusion_flux 1000')
         .duration(460)
         .EUt(GTValues.VA[GTValues.ZPM]);
 
-    event.recipes.gtceu.chemical_reactor('shining_muon_lighting')
+    event.recipes.gtceu.chemical_reactor(id('shining_muon_lighting'))
         .inputFluids('gtceu:shining_muon_infusion_flux 1000', 'gtceu:lumium 288')
         .outputFluids('gtceu:radiant_muon_infusion_flux 1000')
         .duration(160)
         .EUt(GTValues.VA[GTValues.UV]);
         
     // Large chemical reactor
-    event.recipes.gtceu.large_chemical_reactor('twinkling_muon_lighting')
+    event.recipes.gtceu.large_chemical_reactor(id('twinkling_muon_lighting'))
         .inputFluids('gtceu:twinkling_muon_infusion_flux 1000', 'minecraft:lava 1000')
         .outputFluids('gtceu:glowing_muon_infusion_flux 1000')
         .duration(360)
         .EUt(GTValues.VA[GTValues.LuV]);
         
-    event.recipes.gtceu.large_chemical_reactor('glowing_muon_lighting')
+    event.recipes.gtceu.large_chemical_reactor(id('glowing_muon_lighting'))
         .inputFluids('gtceu:glowing_muon_infusion_flux 1000', 'gtceu:blaze 288')
         .outputFluids('gtceu:shining_muon_infusion_flux 1000')
         .duration(460)
         .EUt(GTValues.VA[GTValues.ZPM]);
 
-    event.recipes.gtceu.large_chemical_reactor('shining_muon_lighting')
+    event.recipes.gtceu.large_chemical_reactor(id('shining_muon_lighting'))
         .inputFluids('gtceu:shining_muon_infusion_flux 1000', 'gtceu:lumium 288')
         .outputFluids('gtceu:radiant_muon_infusion_flux 1000')
         .duration(160)
         .EUt(GTValues.VA[GTValues.UV]);
 
-    event.recipes.gtceu.injection_mixer('muon_unification')
+    event.recipes.gtceu.injection_mixer(id('muon_unification'))
         .inputFluids('gtceu:twinkling_muon_infusion_flux 1000', 'gtceu:glowing_muon_infusion_flux 1000', 'gtceu:shining_muon_infusion_flux 1000', 'gtceu:radiant_muon_infusion_flux 1000')
         .outputFluids('gtceu:brilliant_muon_infusion_flux 4000')
         .duration(360)
         .EUt(GTValues.VA[GTValues.UV]);
 
     // Muon canning
-    event.recipes.gtceu.canner('muon_canner')
+    event.recipes.gtceu.canner(id('muon_canner'))
         .itemInputs('1x kubejs:blank_injection_catalyst')
         .inputFluids('gtceu:brilliant_muon_infusion_flux 125')
         .itemOutputs('1x kubejs:muon_injection_catalyst')
@@ -179,57 +180,57 @@ ServerEvents.recipes(event => {
     //-----------------------------------------------------------------------------
     
     // Intermediate to catalyst
-    event.recipes.gtceu.mixer('mono_phase_electron_infusion_flux')
+    event.recipes.gtceu.mixer(id('mono_phase_electron_infusion_flux'))
         .inputFluids('gtceu:electrum 512', 'gtceu:lepton_flavour_foundational_flux 1000')
         .outputFluids('gtceu:mono_phase_electron_infusion_flux 1000')
         .duration(360)
         .EUt(GTValues.VA[GTValues.ZPM]);
     
     // Agent
-    event.recipes.gtceu.distillation_tower('di_phase_electron_infusion_agent')
+    event.recipes.gtceu.distillation_tower(id('di_phase_electron_infusion_agent'))
         .inputFluids('gtceu:mono_phase_electron_infusion_flux 1000')
         .itemOutputs('1x gtceu:di_phase_electron_infusion_agent_dust')
         .outputFluids('gtceu:lepton_coalescing_superalloy 864')
         .duration(140)
         .EUt(GTValues.VA[GTValues.UV]);
 
-    event.recipes.gtceu.polarizer('tri_phase_electron_infusion_agent')
+    event.recipes.gtceu.polarizer(id('tri_phase_electron_infusion_agent'))
         .itemInputs('1x gtceu:di_phase_electron_infusion_agent_dust')
         .itemOutputs('1x gtceu:tri_phase_electron_infusion_agent_dust')
         .duration(160)
         .EUt(GTValues.VA[GTValues.UHV]);
 
-    event.recipes.gtceu.electromagnetic_separator('tri_phase_separation')
+    event.recipes.gtceu.electromagnetic_separator(id('tri_phase_separation'))
         .itemInputs('1x gtceu:tri_phase_electron_infusion_agent_dust')
         .itemOutputs('10x gtceu:weak_gamma_phase_electron_infusion_agent_dust', '5x gtceu:weak_beta_phase_electron_infusion_agent_dust', '1x gtceu:alpha_phase_electron_infusion_agent_dust')
         .duration(360)
         .EUt(GTValues.VA[GTValues.UHV]);
 
-    event.recipes.gtceu.mixer('weak_gamma_phase')
+    event.recipes.gtceu.mixer(id('weak_gamma_phase'))
         .itemInputs('1x gtceu:weak_gamma_phase_electron_infusion_agent_dust', '1x gtceu:annealed_copper_dust')
         .itemOutputs('1x gtceu:gamma_phase_electron_infusion_agent_dust')
         .duration(80)
         .EUt(GTValues.VA[GTValues.UV]);
 
-    event.recipes.gtceu.mixer('weak_beta_phase')
+    event.recipes.gtceu.mixer(id('weak_beta_phase'))
         .itemInputs('1x gtceu:weak_beta_phase_electron_infusion_agent_dust', '1x gtceu:sterling_silver_dust')
         .itemOutputs('1x gtceu:beta_phase_electron_infusion_agent_dust')
         .duration(160)
         .EUt(GTValues.VA[GTValues.UV]);
 
-    event.recipes.gtceu.polarizer('gamma_phase_electron_infusion_agent')
+    event.recipes.gtceu.polarizer(id('gamma_phase_electron_infusion_agent'))
         .itemInputs('1x gtceu:gamma_phase_electron_infusion_agent_dust')
         .itemOutputs('1x gtceu:beta_phase_electron_infusion_agent_dust')
         .duration(75)
         .EUt(GTValues.VA[GTValues.UHV]);
 
-    event.recipes.gtceu.polarizer('beta_phase_electron_infusion_agent_dust')
+    event.recipes.gtceu.polarizer(id('beta_phase_electron_infusion_agent_dust'))
         .itemInputs('1x gtceu:beta_phase_electron_infusion_agent_dust')
         .itemOutputs('1x gtceu:alpha_phase_electron_infusion_agent_dust')
         .duration(100)
         .EUt(GTValues.VA[GTValues.UHV]);
 
-    event.recipes.gtceu.injection_mixer('electron_unification')
+    event.recipes.gtceu.injection_mixer(id('electron_unification'))
         .inputFluids('gtceu:lepton_coalescing_superalloy 864')
         .itemInputs('16x gtceu:alpha_phase_electron_infusion_agent_dust')
         .outputFluids('gtceu:alternating_phase_electron_infusion_flux 1000')
@@ -237,7 +238,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.UV]);
 
     // Electron canning
-    event.recipes.gtceu.canner('electron_canner')
+    event.recipes.gtceu.canner(id('electron_canner'))
         .itemInputs('1x kubejs:blank_injection_catalyst')
         .inputFluids('gtceu:alternating_phase_electron_infusion_flux 125')
         .itemOutputs('1x kubejs:electron_injection_catalyst')
@@ -268,7 +269,7 @@ ServerEvents.recipes(event => {
     add_injection_recipe('electron', 1000, 'electron');
 
     // Damaged fixing
-    event.recipes.gtceu.assembler('damaged_injection_catalyst_washing')
+    event.recipes.gtceu.assembler(id('damaged_injection_catalyst_washing'))
         .itemInputs('1x kubejs:damaged_injection_catalyst')
         .inputFluids('gtceu:neutronium 80')
         .itemOutputs('1x kubejs:blank_injection_catalyst')
@@ -277,7 +278,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.UV]);
 
     // Stabilisation recipes
-    event.recipes.gtceu.folding_akreyrium_stabiliser('lepton_flux_stabilisation')
+    event.recipes.gtceu.folding_akreyrium_stabiliser(id('lepton_flux_stabilisation'))
         .inputFluids('gtceu:lepton_flux_akreyrium 1000')
         .itemInputs('1x kubejs:crystalline_akreyrium', '1x gtceu:gray_glass_lens')
         .itemOutputs('1x gtceu:gray_glass_lens')
@@ -285,7 +286,7 @@ ServerEvents.recipes(event => {
         .duration(1200)
         .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.folding_akreyrium_stabiliser('electron_stabilisation')
+    event.recipes.gtceu.folding_akreyrium_stabiliser(id('electron_stabilisation'))
         .inputFluids('gtceu:dense_electron_akreyrium 1000')
         .itemInputs('1x kubejs:crystalline_akreyrium', '1x gtceu:magenta_glass_lens')
         .itemOutputs('1x gtceu:magenta_glass_lens')
@@ -293,7 +294,7 @@ ServerEvents.recipes(event => {
         .duration(200)
         .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.folding_akreyrium_stabiliser('muon_stabilisation')
+    event.recipes.gtceu.folding_akreyrium_stabiliser(id('muon_stabilisation'))
         .inputFluids('gtceu:dense_muon_akreyrium 1000')
         .itemInputs('1x kubejs:crystalline_akreyrium', '1x gtceu:lime_glass_lens')
         .itemOutputs('1x gtceu:lime_glass_lens')
@@ -301,7 +302,7 @@ ServerEvents.recipes(event => {
         .duration(200)
         .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.folding_akreyrium_stabiliser('tau_stabilisation')
+    event.recipes.gtceu.folding_akreyrium_stabiliser(id('tau_stabilisation'))
         .inputFluids('gtceu:dense_tau_akreyrium 1000')
         .itemInputs('1x kubejs:crystalline_akreyrium', '1x gtceu:light_blue_glass_lens')
         .itemOutputs('1x gtceu:light_blue_glass_lens')

--- a/kubejs/server_scripts/endgame content/abydos_lines/magma_and_ore_decomp.js
+++ b/kubejs/server_scripts/endgame content/abydos_lines/magma_and_ore_decomp.js
@@ -1,8 +1,9 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
     
     //Magma Breakdown
     
-    event.recipes.gtceu.molten_destabilizing('decomp_abydos_titanite_rich_magma')
+    event.recipes.gtceu.molten_destabilizing(id('decomp_abydos_titanite_rich_magma'))
         .inputFluids('gtceu:abydos_titanite_rich_magma 80000')
         .outputFluids('gtceu:titanite 30000')
         .outputFluids('gtceu:molten_ore_mixture 15000')
@@ -14,7 +15,7 @@ ServerEvents.recipes(event => {
         .duration(2400)
         .EUt(GTValues.VHA[GTValues.ZPM]);
 
-    event.recipes.gtceu.molten_destabilizing('decomp_abydos_zapolite_rich_magma')
+    event.recipes.gtceu.molten_destabilizing(id('decomp_abydos_zapolite_rich_magma'))
         .inputFluids('gtceu:abydos_zapolite_rich_magma 80000')
         .outputFluids('gtceu:zapolite 30000')
         .outputFluids('gtceu:molten_ore_mixture 15000')
@@ -40,14 +41,14 @@ ServerEvents.recipes(event => {
     //Titanite and Zapolite done in their own lines
     
     //Iodides
-    event.recipes.gtceu.large_chemical_reactor('lautarite_decomp')
+    event.recipes.gtceu.large_chemical_reactor(id('lautarite_decomp'))
         .itemInputs('9x gtceu:lautarite_dust')
         .inputFluids('gtceu:nitric_acid 2000')
         .itemOutputs('gtceu:calcium_dust')
         .outputFluids('gtceu:hydrogen_iodide 2000','gtceu:nitrogen_dioxide 2000','gtceu:oxygen 5000')
         .duration(200)
         .EUt(GTValues.VHA[GTValues.EV]);
-    event.recipes.gtceu.large_chemical_reactor('iodargyrite_decomp')
+    event.recipes.gtceu.large_chemical_reactor(id('iodargyrite_decomp'))
         .itemInputs('2x gtceu:iodargyrite_dust')
         .inputFluids('gtceu:hydrogen 1000')
         .itemOutputs('gtceu:silver_dust')
@@ -102,24 +103,24 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VHA[GTValues.EV]);
 
     //Tellurides
-    event.recipes.gtceu.electromagnetic_separator('sylvanite_decomp')
+    event.recipes.gtceu.electromagnetic_separator(id('sylvanite_decomp'))
         .itemInputs('3x gtceu:sylvanite_dust')
         .itemOutputs('2x gtceu:tellurium_dust','gtceu:silver_dust')
         .duration(200)
         .EUt(GTValues.VHA[GTValues.EV]);
-    event.recipes.gtceu.electromagnetic_separator('calaverite_decomp')
+    event.recipes.gtceu.electromagnetic_separator(id('calaverite_decomp'))
         .itemInputs('3x gtceu:calaverite_dust')
         .itemOutputs('2x gtceu:tellurium_dust','gtceu:gold_dust')
         .duration(200)
         .EUt(GTValues.VHA[GTValues.EV]);
 
     //carbon acid fixes
-    event.recipes.gtceu.electrolyzer('carbon_acid')
+    event.recipes.gtceu.electrolyzer(id('carbon_acid'))
         .inputFluids('gtceu:carbon_acid 1000')
         .outputFluids('minecraft:water 1000','gtceu:carbon_dioxide')
         .duration(60)
         .EUt(60);
-    event.recipes.gtceu.large_chemical_reactor('carbon_acid')
+    event.recipes.gtceu.large_chemical_reactor(id('carbon_acid'))
         .itemInputs('6x gtceu:potassium_carbonate_dust')
         .inputFluids('gtceu:hydrogen 1000')
         .itemOutputs('gtceu:potassium_dust')

--- a/kubejs/server_scripts/endgame content/abydos_lines/zapolgium_line.js
+++ b/kubejs/server_scripts/endgame content/abydos_lines/zapolgium_line.js
@@ -1,31 +1,31 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
     const toRemoveId = ['gtceu:electrolyzer/decomposition_electrolyzing_zapolite', 'gtceu:electrolyzer/decomposition_electrolyzing_zapolgium_aluminium_oxide', 'gtceu:electrolyzer/decomposition_electrolyzing_zapolgium_diiodide_oxide', 'gtceu:electrolyzer/decomposition_electrolyzing_zapolgium_oxide', 'gtceu:electrolyzer/decomposition_electrolyzing_zapolgium_chloride', 'gtceu:electrolyzer/decomposition_electrolyzing_zapolgium_hydroxide', 'gtceu:electrolyzer/decomposition_electrolyzing_zapolgium_diiodide_dioxide'];
 
     toRemoveId.forEach(element => {
         event.remove({id: element});
     });
 
-    event.recipes.gtceu.electromagnetic_separator('zapolite_proc_1')
+    event.recipes.gtceu.electromagnetic_separator(id('zapolite_proc_1'))
         .itemInputs('gtceu:zapolite_dust')
         .itemOutputs('gtceu:zapolgium_aluminium_oxide_dust')
         .chancedOutput('gtceu:small_zapolgium_diiodide_dioxide_dust', 4000, 1000)
         .duration(400)
         .EUt(6400);
 
-    event.recipes.gtceu.centrifuge('zapolite_proc_2_a_1')
+    event.recipes.gtceu.centrifuge(id('zapolite_proc_2_a_1'))
         .itemInputs('gtceu:zapolgium_aluminium_oxide_dust')
         .itemOutputs('gtceu:zapolgium_diiodide_oxide_dust', 'gtceu:bauxite_dust')
         .duration(800)
         .EUt(12000);
 
-    event.recipes.gtceu.electrolyzer('zapolite_proc_2_a_2')
+    event.recipes.gtceu.electrolyzer(id('zapolite_proc_2_a_2'))
         .itemInputs('gtceu:zapolgium_diiodide_oxide_dust')
         .itemOutputs('gtceu:zapolgium_oxide_dust', '2x gtceu:iodine_dust')
         .duration(600)
         .EUt(16000);
 
-    event.recipes.gtceu.large_chemical_reactor('zapolite_proc_2_b_1')
+    event.recipes.gtceu.large_chemical_reactor(id('zapolite_proc_2_b_1'))
         .itemInputs('gtceu:zapolgium_diiodide_dioxide_dust')
         .inputFluids('gtceu:hydrogen 2000')
         .itemOutputs('gtceu:zapolgium_oxide_dust', '2x gtceu:iodine_dust')
@@ -33,7 +33,7 @@ ServerEvents.recipes(event => {
         .duration(300)
         .EUt(20000);
 
-    event.recipes.gtceu.large_chemical_reactor('zapolite_proc_3')
+    event.recipes.gtceu.large_chemical_reactor(id('zapolite_proc_3'))
         .itemInputs('gtceu:zapolgium_oxide_dust')
         .inputFluids('gtceu:hydrochloric_acid 1000')
         .itemOutputs('gtceu:zapolgium_chloride_dust')
@@ -41,13 +41,13 @@ ServerEvents.recipes(event => {
         .duration(600)
         .EUt(28000);
 
-    event.recipes.gtceu.large_chemical_reactor('zapolgium_ore_proc_4')
+    event.recipes.gtceu.large_chemical_reactor(id('zapolgium_ore_proc_4'))
         .itemInputs('gtceu:zapolgium_chloride_dust', 'gtceu:potassium_hydroxide_dust')
         .itemOutputs('gtceu:zapolgium_hydroxide_dust', '2x gtceu:rock_salt_dust')
         .duration(1200)
         .EUt(56000);
 
-    event.recipes.gtceu.electric_blast_furnace('zapolgium_proc_5')
+    event.recipes.gtceu.electric_blast_furnace(id('zapolgium_proc_5'))
         .itemInputs('gtceu:zapolgium_hydroxide_dust', 'gtceu:carbon_dust')
         .itemOutputs('gtceu:hot_zapolgium_ingot')
         .outputFluids('gtceu:carbon_monoxide 1000', 'gtceu:steam 1000')

--- a/kubejs/server_scripts/endgame content/abydos_lines/zirconium_line.js
+++ b/kubejs/server_scripts/endgame content/abydos_lines/zirconium_line.js
@@ -1,5 +1,5 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     const toRemoveId = ['gtceu:electrolyzer/decomposition_electrolyzing_titanite_slurry_residue', 'gtceu:electrolyzer/decomposition_electrolyzing_hydroxo_dioxo_titanite_mixture', 'gtceu:electrolyzer/decomposition_electrolyzing_titanite_residue', 'gtceu:electrolyzer/decomposition_electrolyzing_titanium_tetrachloride_mixture', 'gtceu:electrolyzer/decomposition_electrolyzing_zirconium_tetrachloride', 'minecraft:nuclearcraft_zirconium_dust'];
 
@@ -7,7 +7,7 @@ ServerEvents.recipes(event => {
         event.remove({id: element});
     });
 
-    event.recipes.gtceu.chemical_reactor('perchloric_acid')
+    event.recipes.gtceu.chemical_reactor(id('perchloric_acid'))
         .itemInputs('gtceu:sodium_perchlorate_dust')
         .inputFluids('gtceu:hydrochloric_acid 1000')
         .outputFluids('gtceu:perchloric_acid 1000')
@@ -15,7 +15,7 @@ ServerEvents.recipes(event => {
         .duration(200)
         .EUt(120);
 
-    event.recipes.gtceu.large_chemical_reactor('perchloric_acid')
+    event.recipes.gtceu.large_chemical_reactor(id('perchloric_acid'))
         .itemInputs('gtceu:sodium_perchlorate_dust')
         .inputFluids('gtceu:hydrochloric_acid 1000')
         .outputFluids('gtceu:perchloric_acid 1000')
@@ -23,21 +23,21 @@ ServerEvents.recipes(event => {
         .duration(200)
         .EUt(120);
 
-    event.recipes.gtceu.mixer('titanite_proc_1')
+    event.recipes.gtceu.mixer(id('titanite_proc_1'))
         .itemInputs('gtceu:titanite_dust')
         .inputFluids('gtceu:perchloric_acid 3000')
         .outputFluids('gtceu:titanite_slurry 1000')
         .duration(400)
         .EUt(28000);
 
-    event.recipes.gtceu.centrifuge('titanite_proc_2')
+    event.recipes.gtceu.centrifuge(id('titanite_proc_2'))
         .inputFluids('gtceu:titanite_slurry 1000')
         .itemOutputs('gtceu:calcium_perchlorate_dust')
         .outputFluids('gtceu:titanite_slurry_residue 1000', 'gtceu:silica_gel 1000', 'minecraft:water 1000')
         .duration(360)
         .EUt(28000);
 
-    event.recipes.gtceu.chemical_reactor('calcium_perchlorate_to_perchloric_acid')
+    event.recipes.gtceu.chemical_reactor(id('calcium_perchlorate_to_perchloric_acid'))
         .itemInputs('gtceu:calcium_perchlorate_dust')
         .inputFluids('gtceu:sulfuric_acid 1000')
         .itemOutputs('6x gtceu:calcium_sulfate_dust')
@@ -45,7 +45,7 @@ ServerEvents.recipes(event => {
         .duration(120)
         .EUt(496);
 
-    event.recipes.gtceu.large_chemical_reactor('calcium_perchlorate_to_perchloric_acid')
+    event.recipes.gtceu.large_chemical_reactor(id('calcium_perchlorate_to_perchloric_acid'))
         .itemInputs('gtceu:calcium_perchlorate_dust')
         .inputFluids('gtceu:sulfuric_acid 1000')
         .itemOutputs('6x gtceu:calcium_sulfate_dust')
@@ -53,41 +53,41 @@ ServerEvents.recipes(event => {
         .duration(120)
         .EUt(496);
 
-    event.recipes.gtceu.centrifuge('silica_gel_to_perchloric_acid')
+    event.recipes.gtceu.centrifuge(id('silica_gel_to_perchloric_acid'))
         .inputFluids('gtceu:silica_gel 1000')
         .itemOutputs('gtceu:silicon_dioxide_dust')
         .outputFluids('gtceu:perchloric_acid 1000')
         .duration(120)
         .EUt(1984);
 
-    event.recipes.gtceu.large_chemical_reactor('titanite_proc_3')
+    event.recipes.gtceu.large_chemical_reactor(id('titanite_proc_3'))
         .itemInputs('2x gtceu:sodium_hydroxide_dust')
         .inputFluids('gtceu:titanite_slurry_residue 1000')
         .outputFluids('gtceu:hydroxo_dioxo_titanite_mixture 1000')
         .duration(400)
         .EUt(17500);
 
-    event.recipes.gtceu.electrolyzer('titanite_proc_4')
+    event.recipes.gtceu.electrolyzer(id('titanite_proc_4'))
         .inputFluids('gtceu:hydroxo_dioxo_titanite_mixture 1000')
         .itemOutputs('3x gtceu:sodium_oxide_dust')
         .outputFluids('gtceu:titanite_residue 1000', 'minecraft:water 1000')
         .duration(800)
         .EUt(50000);
 
-    event.recipes.gtceu.large_chemical_reactor('titanite_proc_5')
+    event.recipes.gtceu.large_chemical_reactor(id('titanite_proc_5'))
         .inputFluids('gtceu:titanite_residue 1000', 'gtceu:hydrochloric_acid 4000')
         .outputFluids('gtceu:titanium_tetrachloride_mixture', 'minecraft:water 2000')
         .duration(900)
         .EUt(6400);
 
-    event.recipes.gtceu.centrifuge('titanite_proc_6')
+    event.recipes.gtceu.centrifuge(id('titanite_proc_6'))
         .inputFluids('gtceu:titanium_tetrachloride_mixture 2000')
         .itemOutputs('gtceu:zirconium_tetrachloride_dust')
         .outputFluids('gtceu:titanium_tetrachloride 1000')
         .duration(1200)
         .EUt(23000);
 
-    event.recipes.gtceu.large_chemical_reactor('zirconium_from_zirconium_tetrachloride')
+    event.recipes.gtceu.large_chemical_reactor(id('zirconium_from_zirconium_tetrachloride'))
         .itemInputs('gtceu:zirconium_tetrachloride_dust')
         .inputFluids('gtceu:hydrogen 4000')
         .itemOutputs('gtceu:zirconium_dust')

--- a/kubejs/server_scripts/endgame content/advanced_fusion/auxilary_fusion_1.js
+++ b/kubejs/server_scripts/endgame content/advanced_fusion/auxilary_fusion_1.js
@@ -1,8 +1,9 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
     
     //Controller Blocks
     
-    event.recipes.gtceu.assembly_line('uhv_auxiliary_boosted_fusion_reactor')
+    event.recipes.gtceu.assembly_line(id('uhv_auxiliary_boosted_fusion_reactor'))
         .itemInputs('start_core:auxiliary_fusion_coil_mk1', '4x #gtceu:circuits/uev', 'gtceu:gravi_star', 'gtceu:double_zircalloy_4_plate',
                 '2x gtceu:uv_field_generator', '64x kubejs:uepic_chip', '32x kubejs:uepic_chip', '32x gtceu:ruthenium_trinium_americium_neutronate_single_wire')
         .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 1152', 'gtceu:zirconium_selenide_diiodide 1152')
@@ -18,14 +19,14 @@ ServerEvents.recipes(event => {
 
     //Casings/Coil
     
-    event.recipes.gtceu.assembler('superconducting_coil_uhv') //UHV tier superconducting coil
+    event.recipes.gtceu.assembler(id('superconducting_coil_uhv')) //UHV tier superconducting coil
         .itemInputs('4x gtceu:ruthenium_trinium_americium_neutronate_double_wire', '4x gtceu:niobium_titanium_foil')
         .inputFluids('gtceu:trinium 576')
         .itemOutputs('gtceu:superconducting_coil')
         .duration(100)
         .EUt(GTValues.VA[GTValues.UHV]);
 
-    event.recipes.gtceu.assembler('auxiliary_boosted_fusion_casing_mk1')
+    event.recipes.gtceu.assembler(id('auxiliary_boosted_fusion_casing_mk1'))
         .itemInputs('gtceu:uhv_machine_casing', 'start_core:auxiliary_fusion_coil_mk1', '2x kubejs:uhv_voltage_coil', 'gtceu:uv_field_generator', '6x gtceu:zircalloy_4_plate')
         .inputFluids('gtceu:polyether_ether_ketone 576')
         .itemOutputs('2x start_core:auxiliary_boosted_fusion_casing_mk1')
@@ -34,7 +35,7 @@ ServerEvents.recipes(event => {
         .cleanroom(CleanroomType.STERILE_CLEANROOM);
 
 
-    event.recipes.gtceu.assembler('auxiliary_fusion_coil_mk1')
+    event.recipes.gtceu.assembler(id('auxiliary_fusion_coil_mk1'))
         .itemInputs('1x gtceu:fusion_coil', '2x gtceu:zpm_field_generator', 'gtceu:zpm_electric_pump', '2x gtceu:neutron_reflector', '4x #gtceu:circuits/uv', '4x gtceu:zapolgium_small_fluid_pipe', '4x gtceu:zircalloy_4_plate')
         .inputFluids('gtceu:zirconium_selenide_diiodide 576')
         .itemOutputs('1x start_core:auxiliary_fusion_coil_mk1')

--- a/kubejs/server_scripts/endgame content/complex_components.js
+++ b/kubejs/server_scripts/endgame content/complex_components.js
@@ -1,8 +1,8 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
     
     //Controller Blocks 
-        event.recipes.gtceu.assembly_line('component_part_assembly')
+        event.recipes.gtceu.assembly_line(id('component_part_assembly'))
         .itemInputs('gtceu:uv_assembler','8x gtceu:uv_robot_arm','8x gtceu:uv_conveyor_module',
             '8x gtceu:uv_electric_pump', '4x #gtceu:circuits/uhv', '6x #gtceu:circuits/uv', '8x #gtceu:circuits/zpm')
         .inputFluids('gtceu:soldering_alloy 12528', 'gtceu:lubricant 750')

--- a/kubejs/server_scripts/endgame content/complex_components.js
+++ b/kubejs/server_scripts/endgame content/complex_components.js
@@ -26,14 +26,14 @@ ServerEvents.recipes(event => {
 
     ComponentComposition.forEach(comp => {
         //Component Parts
-    event.recipes.gtceu.component_part_assembly(`${comp.Tier}_voltage_coil`)
+    event.recipes.gtceu.component_part_assembly(id(`${comp.Tier}_voltage_coil`))
         .itemInputs(`gtceu:${comp.TierMaterial}_tiny_fluid_pipe`,`gtceu:long_magnetic_${comp.PrimaryMagnet}_rod`, `32x gtceu:fine_${comp.VoltageCoil}_wire`)
         .inputFluids(`gtceu:${comp.Coolant} 1000`)
         .itemOutputs(`kubejs:${comp.Tier}_voltage_coil`)
         .duration(200)
         .EUt(comp.EUt);
 
-    event.recipes.gtceu.component_part_assembly(`${comp.Tier}_computational_matrix`)
+    event.recipes.gtceu.component_part_assembly(id(`${comp.Tier}_computational_matrix`))
         .itemInputs(`gtceu:${comp.PrimaryMaterial}_frame`, `2x #gtceu:circuits/${comp.Tier}`, `4x #gtceu:circuits/${comp.Tier1Under}`, `6x #gtceu:circuits/${comp.Tier2Under}`,
             `32x gtceu:fine_${comp.WireTypeComputational}_wire`, `${2*(2**comp.Scaler)}x kubejs:qram_chip`)
         .inputFluids(`gtceu:sterilized_growth_medium ${250+comp.Scaler*250}`, `gtceu:indium_tin_lead_cadmium_soldering_alloy ${72+comp.Scaler*72}`)
@@ -41,7 +41,7 @@ ServerEvents.recipes(event => {
         .duration(700)
         .EUt(comp.EUt);
 
-    event.recipes.gtceu.component_part_assembly(`${comp.Tier}_transmission_assembly`)
+    event.recipes.gtceu.component_part_assembly(id(`${comp.Tier}_transmission_assembly`))
         .itemInputs(`gtceu:${comp.PrimaryMaterial}_frame`, `gtceu:${comp.Tier1Under}_electric_motor`, `2x gtceu:${comp.PrimaryMaterial}_rod`, `2x gtceu:${comp.PrimaryMaterial}_ring`,
             `8x gtceu:${comp.PrimaryMaterial}_round`, `64x gtceu:fine_${comp.WireTypeMechanical}_wire`)
         .inputFluids(`gtceu:lubricant ${250+comp.Scaler*250}`)
@@ -49,7 +49,7 @@ ServerEvents.recipes(event => {
         .duration(400)
         .EUt(comp.EUt);
 
-    event.recipes.gtceu.component_part_assembly(`${comp.Tier}_precision_drive_mechanism`)
+    event.recipes.gtceu.component_part_assembly(id(`${comp.Tier}_precision_drive_mechanism`))
         .itemInputs(`gtceu:${comp.PrimaryMaterial}_frame`, `gtceu:${comp.Tier1Under}_conveyor_module`, `#gtceu:circuits/${comp.Tier1Under}`,
             `gtceu:${comp.SupportMaterial}_gear`, `gtceu:small_${comp.PrimaryMaterial}_gear`,`8x gtceu:${comp.PrimaryMaterial}_round`)
         .inputFluids(`gtceu:lubricant ${250+comp.Scaler*250}`, `gtceu:${comp.Rubber} 1152`)
@@ -57,7 +57,7 @@ ServerEvents.recipes(event => {
         .duration(600)
         .EUt(comp.EUt);
 
-    event.recipes.gtceu.component_part_assembly(`${comp.Tier}_microfluidic_flow_valve`)
+    event.recipes.gtceu.component_part_assembly(id(`${comp.Tier}_microfluidic_flow_valve`))
         .itemInputs(`gtceu:${comp.Tier1Under}_fluid_regulator`, `gtceu:${comp.TierMaterial}_small_fluid_pipe`, `2x gtceu:${comp.PrimaryMaterial}_plate`, `6x gtceu:${comp.PrimaryMaterial}_round`,
             `4x gtceu:${comp.Rubber}_ring`, `6x gtceu:${comp.PrimaryMaterial}_ring`)
         .inputFluids(`gtceu:${comp.Plastic} ${396+comp.Scaler*36}`)
@@ -65,7 +65,7 @@ ServerEvents.recipes(event => {
         .duration(400)
         .EUt(comp.EUt);
 
-    event.recipes.gtceu.component_part_assembly(`${comp.Tier}_super_magnetic_core`)
+    event.recipes.gtceu.component_part_assembly(id(`${comp.Tier}_super_magnetic_core`))
         .itemInputs(`gtceu:long_magnetic_${comp.PrimaryMagnet}_rod`,  `2x gtceu:magnetic_${comp.SecondaryMagnet}_rod`,
         `3x gtceu:${comp.PrimaryMaterial}_rod`, `24x gtceu:fine_${comp.WireTypeMechanical}_wire`, `2x gtceu:${comp.TierMaterial}_tiny_fluid_pipe`)
         .inputFluids(`gtceu:${comp.Coolant} 2500`)
@@ -73,21 +73,21 @@ ServerEvents.recipes(event => {
         .duration(500)
         .EUt(comp.EUt);
 
-    event.recipes.gtceu.component_part_assembly(`${comp.Tier}_catalyst_core`)
+    event.recipes.gtceu.component_part_assembly(id(`${comp.Tier}_catalyst_core`))
         .itemInputs(`gtceu:${comp.PrimaryMaterial}_frame`, `gtceu:${comp.Tier1Under}_field_generator`,`gtceu:${comp.CatalystType}`, `gtceu:${comp.GlassType}`, `4x gtceu:${comp.PrimaryMaterial}_rod`, `4x gtceu:${comp.SupportMaterial}_ring`)
         .inputFluids(`gtceu:${comp.Fluid} 576`)
         .itemOutputs(`kubejs:${comp.Tier}_catalyst_core`) 
         .duration(800)
         .EUt(comp.EUt);
 
-    event.recipes.gtceu.component_part_assembly(`${comp.Tier}_high_strength_panel`)
+    event.recipes.gtceu.component_part_assembly(id(`${comp.Tier}_high_strength_panel`))
         .itemInputs(`2x gtceu:double_${comp.PrimaryMaterial}_plate`, `8x gtceu:${comp.SupportMaterial}_screw`, `gtceu:${comp.Tier1Under}_electric_piston`)
         .inputFluids(`gtceu:${comp.TierMaterial} 576`)
         .itemOutputs(`kubejs:${comp.Tier}_high_strength_panel`) 
         .duration(300)
         .EUt(comp.EUt);
 
-    event.recipes.gtceu.component_part_assembly(`${comp.Tier}_micropower_router`)
+    event.recipes.gtceu.component_part_assembly(id(`${comp.Tier}_micropower_router`))
         .itemInputs(`gtceu:${comp.CableType}_double_cable`, `4x gtceu:${comp.CableType}_single_cable`, `4x gtceu:${comp.PrimaryMaterial}_plate`,
         `32x gtceu:fine_${comp.WireTypeComputational}_wire`)
         .inputFluids(`gtceu:${comp.Rubber} 720`)
@@ -97,7 +97,7 @@ ServerEvents.recipes(event => {
 
             //Components
 
-        event.recipes.gtceu.assembly_line(`${comp.Tier}_electric_motor`)
+        event.recipes.gtceu.assembly_line(id(`${comp.Tier}_electric_motor`))
             .itemInputs(`kubejs:${comp.Tier}_super_magnetic_core`, `2x gtceu:long_${comp.PrimaryMaterial}_rod`, `kubejs:${comp.Tier}_transmission_assembly`,`kubejs:${comp.Tier}_micropower_router`, `64x gtceu:fine_${comp.WireTypeMechanical}_wire`)
             .inputFluids(`gtceu:indium_tin_lead_cadmium_soldering_alloy ${288*(2**comp.Scaler)}`, `gtceu:lubricant ${500+comp.Scaler*500}`, `gtceu:${comp.Fluid} 576`)
             .itemOutputs(`gtceu:${comp.Tier}_electric_motor`)
@@ -110,7 +110,7 @@ ServerEvents.recipes(event => {
             .duration(600)
             .EUt(comp.EUt/4);
 
-        event.recipes.gtceu.assembly_line(`${comp.Tier}_electric_pump`)
+        event.recipes.gtceu.assembly_line(id(`${comp.Tier}_electric_pump`))
             .itemInputs(`gtceu:${comp.Tier}_electric_motor`, `gtceu:${comp.TierMaterial}_large_fluid_pipe`, `kubejs:${comp.Tier}_microfluidic_flow_valve`,`kubejs:${comp.Tier}_micropower_router`, `16x gtceu:${comp.Rubber}_ring`, `gtceu:${comp.SupportMaterial}_rotor`)
             .inputFluids(`gtceu:indium_tin_lead_cadmium_soldering_alloy ${288*(2**comp.Scaler)}`, `gtceu:lubricant ${500+comp.Scaler*500}`, `gtceu:${comp.Fluid} 576`)
             .itemOutputs(`gtceu:${comp.Tier}_electric_pump`)
@@ -123,14 +123,14 @@ ServerEvents.recipes(event => {
             .duration(600)
             .EUt(comp.EUt/4);
 
-        event.recipes.gtceu.assembler(`${comp.Tier}_fluid_regulator`)
+        event.recipes.gtceu.assembler(id(`${comp.Tier}_fluid_regulator`))
             .itemInputs(`gtceu:${comp.Tier}_electric_pump`, `2x #gtceu:circuits/${comp.Tier}`)
             .itemOutputs(`gtceu:${comp.Tier}_fluid_regulator`)
             .duration(50)
             .EUt(comp.EUt)
             .circuit(1);
 
-        event.recipes.gtceu.assembly_line(`${comp.Tier}_conveyor_module`)
+        event.recipes.gtceu.assembly_line(id(`${comp.Tier}_conveyor_module`))
             .itemInputs(`2x gtceu:${comp.Tier}_electric_motor`, `kubejs:${comp.Tier}_high_strength_panel`, `kubejs:${comp.Tier}_precision_drive_mechanism`, `kubejs:${comp.Tier}_transmission_assembly`, `kubejs:${comp.Tier}_micropower_router`)
             .inputFluids(`gtceu:indium_tin_lead_cadmium_soldering_alloy ${288*(2**comp.Scaler)}`, `gtceu:lubricant ${500+comp.Scaler*500}`, `gtceu:${comp.Rubber} 3456`, `gtceu:${comp.Fluid} 576`)
             .itemOutputs(`gtceu:${comp.Tier}_conveyor_module`)
@@ -143,7 +143,7 @@ ServerEvents.recipes(event => {
             .duration(600)
             .EUt(comp.EUt/4);
 
-        event.recipes.gtceu.assembly_line(`${comp.Tier}_electric_piston`)
+        event.recipes.gtceu.assembly_line(id(`${comp.Tier}_electric_piston`))
             .itemInputs(`gtceu:${comp.Tier}_electric_motor`, `2x kubejs:${comp.Tier}_high_strength_panel`, `2x kubejs:${comp.Tier}_transmission_assembly`, `kubejs:${comp.Tier}_micropower_router`, `gtceu:${comp.SupportMaterial}_gear`, `gtceu:small_${comp.PrimaryMaterial}_gear`)
             .inputFluids(`gtceu:indium_tin_lead_cadmium_soldering_alloy ${288*(2**comp.Scaler)}`, `gtceu:lubricant ${500+comp.Scaler*500}`, `gtceu:${comp.Fluid} 576`)
             .itemOutputs(`gtceu:${comp.Tier}_electric_piston`)
@@ -156,7 +156,7 @@ ServerEvents.recipes(event => {
             .duration(600)
             .EUt(comp.EUt/4);
 
-        event.recipes.gtceu.assembly_line(`${comp.Tier}_robot_arm`)
+        event.recipes.gtceu.assembly_line(id(`${comp.Tier}_robot_arm`))
             .itemInputs(`4x gtceu:long_${comp.PrimaryMaterial}_rod`, `kubejs:${comp.Tier}_precision_drive_mechanism`, `2x kubejs:${comp.Tier}_transmission_assembly`, `2x gtceu:${comp.Tier}_electric_motor`, `gtceu:${comp.Tier}_electric_piston`, `3x kubejs:${comp.Tier}_computational_matrix`, `2x kubejs:${comp.Tier}_micropower_router`)
             .inputFluids(`gtceu:indium_tin_lead_cadmium_soldering_alloy ${864*(2**comp.Scaler)}`, `gtceu:lubricant ${500+comp.Scaler*500}`, `gtceu:${comp.Fluid} 576`)
             .itemOutputs(`gtceu:${comp.Tier}_robot_arm`)
@@ -169,7 +169,7 @@ ServerEvents.recipes(event => {
             .duration(600)
             .EUt(comp.EUt/4);
 
-        event.recipes.gtceu.assembly_line(`${comp.Tier}_field_generator`)
+        event.recipes.gtceu.assembly_line(id(`${comp.Tier}_field_generator`))
             .itemInputs(`gtceu:${comp.PrimaryMaterial}_frame`, `2x kubejs:${comp.Tier}_high_strength_panel`, `kubejs:${comp.Tier}_catalyst_core`, `2x gtceu:${comp.Tier}_emitter`, `kubejs:${comp.Tier}_computational_matrix`, `64x gtceu:fine_${comp.WireTypeComputational}_wire`, `2x kubejs:${comp.Tier}_micropower_router`)
             .inputFluids(`gtceu:indium_tin_lead_cadmium_soldering_alloy ${864*(2**comp.Scaler)}`, `gtceu:${comp.Fluid} 576`)
             .itemOutputs(`gtceu:${comp.Tier}_field_generator`)
@@ -182,7 +182,7 @@ ServerEvents.recipes(event => {
             .duration(600)
             .EUt(comp.EUt/4);
 
-        event.recipes.gtceu.assembly_line(`${comp.Tier}_emitter`)
+        event.recipes.gtceu.assembly_line(id(`${comp.Tier}_emitter`))
             .itemInputs(`gtceu:${comp.PrimaryMaterial}_frame`, `gtceu:${comp.Tier}_electric_motor`, `4x gtceu:long_${comp.PrimaryMaterial}_rod`, `kubejs:${comp.Tier}_catalyst_core`, `kubejs:${comp.Tier}_computational_matrix`, `64x gtceu:${comp.TierMaterial}_foil`, `2x kubejs:${comp.Tier}_micropower_router`)
             .inputFluids(`gtceu:indium_tin_lead_cadmium_soldering_alloy ${576*(2**comp.Scaler)}`, `gtceu:${comp.Fluid} 576`)
             .itemOutputs(`gtceu:${comp.Tier}_emitter`)
@@ -195,7 +195,7 @@ ServerEvents.recipes(event => {
             .duration(600)
             .EUt(comp.EUt/4);
 
-        event.recipes.gtceu.assembly_line(`${comp.Tier}_sensor`)
+        event.recipes.gtceu.assembly_line(id(`${comp.Tier}_sensor`))
             .itemInputs(`gtceu:${comp.PrimaryMaterial}_frame`, `gtceu:${comp.Tier}_electric_motor`, `4x gtceu:${comp.PrimaryMaterial}_plate`, `kubejs:${comp.Tier}_catalyst_core`, `kubejs:${comp.Tier}_computational_matrix`, `64x gtceu:${comp.TierMaterial}_foil`, `2x kubejs:${comp.Tier}_micropower_router`)
             .inputFluids(`gtceu:indium_tin_lead_cadmium_soldering_alloy ${576*(2**comp.Scaler)}`, `gtceu:${comp.Fluid} 576`)
             .itemOutputs(`gtceu:${comp.Tier}_sensor`)

--- a/kubejs/server_scripts/endgame content/dimensional_pinging.js
+++ b/kubejs/server_scripts/endgame content/dimensional_pinging.js
@@ -1,6 +1,7 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.vibration_laser_engraver('coordinate_crystal')
+    event.recipes.gtceu.vibration_laser_engraver(id('coordinate_crystal'))
         .itemInputs('2x gtceu:exquisite_echo_shard_gem')
         .notConsumable('gtceu:nether_star_lens')
         .notConsumable('gtceu:echo_shard_lens')
@@ -14,7 +15,7 @@ ServerEvents.recipes(event => {
     
     // Machine recipes
     
-    event.recipes.gtceu.assembly_line('dimensional_finder')
+    event.recipes.gtceu.assembly_line(id('dimensional_finder'))
         .itemInputs(
             'gtceu:uv_scanner','16x gtceu:uv_sensor','16x gtceu:uv_sensor','16x gtceu:uv_sensor','16x gtceu:uv_sensor',
             '64x gtceu:fine_trinaquadalloy_wire','64x gtceu:fine_trinaquadalloy_wire', '8x #gtceu:circuits/uv'
@@ -36,7 +37,7 @@ ServerEvents.recipes(event => {
 
     //Coordinate Crystals
     
-    event.recipes.gtceu.dimensional_finder('abydos_coordinate_crystal')
+    event.recipes.gtceu.dimensional_finder(id('abydos_coordinate_crystal'))
         .itemInputs('kubejs:coordinate_crystal', 'minecraft:sand', 'gtceu:uv_sensor')
         .inputFluids('gtceu:naquadria 9072')
         .chancedOutput('kubejs:abydos_coordinate_crystal', 250, 50)
@@ -44,7 +45,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VHA[GTValues.UV])
         .dimension('minecraft:overworld');
 
-    event.recipes.gtceu.dimensional_finder('nether_coordinate_crystal')
+    event.recipes.gtceu.dimensional_finder(id('nether_coordinate_crystal'))
         .itemInputs('kubejs:coordinate_crystal', 'minecraft:netherrack', 'gtceu:uhv_sensor')
         .inputFluids('minecraft:lava 5000')
         .chancedOutput('kubejs:nether_coordinate_crystal', 250, 50)
@@ -52,7 +53,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VHA[GTValues.UHV])
         .dimension('sgjourney:abydos');
 
-    event.recipes.gtceu.dimensional_finder('end_coordinate_crystal')
+    event.recipes.gtceu.dimensional_finder(id('end_coordinate_crystal'))
         .itemInputs('kubejs:coordinate_crystal', 'minecraft:end_stone', 'gtceu:uhv_sensor')
         .inputFluids('gtceu:echo_r 5000')
         .chancedOutput('kubejs:end_coordinate_crystal', 250, 50)
@@ -60,7 +61,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VHA[GTValues.UHV])
         .dimension('sgjourney:abydos');
 
-    /*event.recipes.gtceu.dimensional_finder('lantea_coordinate_crystal')
+    /*event.recipes.gtceu.dimensional_finder(id('lantea_coordinate_crystal'))
         .itemInputs('kubejs:coordinate_crystal', 'minecraft:prismarine', 'gtceu:uev_sensor')
         .inputFluids('gtceu:rhexis 9072') //its just a fluid you cant make
         .chancedOutput('kubejs:lantea_coordinate_crystal', 250, 50)
@@ -68,7 +69,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VHA[GTValues.UEV])
         .dimension('minecraft:the_nether');
 
-    event.recipes.gtceu.dimensional_finder('cavum_coordinate_crystal')
+    event.recipes.gtceu.dimensional_finder(id('cavum_coordinate_crystal'))
         .itemInputs('kubejs:coordinate_crystal', 'minecraft:obsidian', 'gtceu:uiv_sensor')
         .inputFluids('gtceu:rhexis 9072') //its just a fluid you cant make
         .chancedOutput('kubejs:cavum_coordinate_crystal', 250, 50)
@@ -76,7 +77,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VHA[GTValues.UIV])
         .dimension('minecraft:the_end');
         
-    event.recipes.gtceu.dimensional_finder('sea_coordinate_crystal')
+    event.recipes.gtceu.dimensional_finder(id('sea_coordinate_crystal'))
         .itemInputs('kubejs:coordinate_crystal', 'minecraft:water_bucket', 'gtceu:uxv_sensor')
         .inputFluids('gtceu:rhexis 9072') //its just a fluid you cant make
         .chancedOutput('kubejs:sea_coordinate_crystal', 250, 50)
@@ -84,7 +85,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VHA[GTValues.UXV])
         .dimension('minecraft:lantea');
 
-    event.recipes.gtceu.dimensional_finder('void_coordinate_crystal')
+    event.recipes.gtceu.dimensional_finder(id('void_coordinate_crystal'))
         .itemInputs('kubejs:coordinate_crystal', 'minecraft:stone', 'gtceu:opv_sensor')
         .inputFluids('gtceu:rhexis 9072') //its just a fluid you cant make
         .chancedOutput('kubejs:void_coordinate_crystal', 250, 50)

--- a/kubejs/server_scripts/endgame content/exotic_gas_siphon.js
+++ b/kubejs/server_scripts/endgame content/exotic_gas_siphon.js
@@ -1,5 +1,7 @@
 ServerEvents.recipes(event => {
-    event.recipes.gtceu.assembly_line('exotic_gas_siphon')
+    const id = global.id;
+    
+    event.recipes.gtceu.assembly_line(id('exotic_gas_siphon'))
         .itemInputs(
             '1x gtceu:uhv_gas_collector','64x kubejs:uepic_chip','32x gtceu:filter_casing','16x gtceu:sterilizing_filter_casing', '32x gtceu:naquadah_nonuple_fluid_pipe', 
             '16x kubejs:uhv_microfluidic_flow_valve', '8x gtceu:uhv_electric_pump', '4x gtceu:uhv_fluid_regulator', '4x gtceu:pure_netherite_rotor', '8x #gtceu:circuits/uhv',
@@ -21,7 +23,7 @@ ServerEvents.recipes(event => {
             )
         .EUt(GTValues.VHA[GTValues.UEV]);
 
-    event.recipes.gtceu.exotic_gas_siphon('overworld')
+    event.recipes.gtceu.exotic_gas_siphon(id('overworld'))
         .circuit(1)
         .outputFluids('gtceu:nitrogen 140000')
         .outputFluids('gtceu:oxygen 44000')
@@ -31,7 +33,7 @@ ServerEvents.recipes(event => {
         .dimension('minecraft:overworld')
         .duration(1000).EUt(GTValues.VA[GTValues.ZPM])
 
-    event.recipes.gtceu.exotic_gas_siphon('abydos')
+    event.recipes.gtceu.exotic_gas_siphon(id('abydos'))
         .circuit(2)
         .outputFluids('gtceu:helium_3 32000')
         .outputFluids('gtceu:argon 1500')
@@ -45,7 +47,7 @@ ServerEvents.recipes(event => {
         .dimension('sgjourney:abydos')
         .duration(1000).EUt(GTValues.VA[GTValues.ZPM]);
 
-    event.recipes.gtceu.exotic_gas_siphon('nether')
+    event.recipes.gtceu.exotic_gas_siphon(id('nether'))
         .circuit(3)
         .outputFluids('gtceu:sulfur_dioxide 15000')
         .outputFluids('gtceu:helium_3 5000')
@@ -56,7 +58,7 @@ ServerEvents.recipes(event => {
         .dimension('minecraft:the_nether')
         .duration(1000).EUt(GTValues.VA[GTValues.ZPM])
 
-    event.recipes.gtceu.exotic_gas_siphon('end')
+    event.recipes.gtceu.exotic_gas_siphon(id('end'))
         .circuit(4)
         .outputFluids('gtceu:radon 1000')
         .outputFluids('gtceu:tritium 10000')

--- a/kubejs/server_scripts/endgame content/gate recipe.js
+++ b/kubejs/server_scripts/endgame content/gate recipe.js
@@ -11,7 +11,7 @@ ServerEvents.recipes(event => {
         O: 'gtceu:object_holder',
         G: 'minecraft:glass',
         S: 'minecraft:smooth_stone'
-    });
+    }).id('start:shaped/classic_stargate_display');
 
     //Multiblock Recipes
     

--- a/kubejs/server_scripts/endgame content/gate recipe.js
+++ b/kubejs/server_scripts/endgame content/gate recipe.js
@@ -1,5 +1,5 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     //Non Mandatory Display Controller
     event.shaped(Item.of('gtceu:classic_stargate_display'), [
@@ -15,7 +15,7 @@ ServerEvents.recipes(event => {
 
     //Multiblock Recipes
     
-    event.recipes.gtceu.assembly_line('heat_chamber')
+    event.recipes.gtceu.assembly_line(id('heat_chamber'))
         .itemInputs('gtceu:iridium_frame', '4x #gtceu:circuits/zpm', 'gtceu:double_rhodium_plated_palladium_plate', 
                 'gtceu:double_tritanium_plate', 'gtceu:zpm_field_generator', '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip', 
                 '32x gtceu:uhpic_chip', '48x gtceu:dragonsteel_single_wire')
@@ -30,7 +30,7 @@ ServerEvents.recipes(event => {
         .duration(36000)
         .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.assembly_line('super_heat_chamber')
+    event.recipes.gtceu.assembly_line(id('super_heat_chamber'))
             .itemInputs('gtceu:heat_chamber', '4x #gtceu:circuits/uv', 'gtceu:double_dragonsteel_plate', 
                     'gtceu:double_titanium_carbide_plate', 'gtceu:uv_field_generator', '64x gtceu:uhpic_chip', 
                     '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip', '32x gtceu:uhpic_chip', '48x gtceu:prismalium_single_wire')
@@ -45,7 +45,7 @@ ServerEvents.recipes(event => {
             .duration(46000)
             .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.assembly_line('large_rotor_machine')
+    event.recipes.gtceu.assembly_line(id('large_rotor_machine'))
         .itemInputs('gtceu:shellite_frame', '4x #gtceu:circuits/luv', 'gtceu:double_vanadium_gallium_plate', 
                 'gtceu:double_red_steel_plate', 'gtceu:luv_field_generator', '2x gtceu:luv_electric_motor', '64x gtceu:uhpic_chip', 
                 '32x gtceu:uhpic_chip', '4x gtceu:advanced_power_thruster', '4x gtceu:hssg_spring')
@@ -60,7 +60,7 @@ ServerEvents.recipes(event => {
         .duration(12000)
         .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.assembly_line('runic_engraver')
+    event.recipes.gtceu.assembly_line(id('runic_engraver'))
             .itemInputs('gtceu:lumium_frame', '4x #gtceu:circuits/uv', 'gtceu:double_tantalum_carbide_plate', 
                     'gtceu:double_titanium_carbide_plate', '2x gtceu:uv_field_generator', '4x gtceu:uv_emitter', '64x gtceu:uhpic_chip', 
                     '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip', '48x gtceu:blue_alloy_screw', 'gtceu:gravi_star')
@@ -75,7 +75,7 @@ ServerEvents.recipes(event => {
             .duration(82000)
             .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.assembly_line('quantum_compressor')
+    event.recipes.gtceu.assembly_line(id('quantum_compressor'))
             .itemInputs('gtceu:melodium_frame', '3x #gtceu:circuits/uv', 'gtceu:double_trinaquadalloy_plate', 
                     'gtceu:double_trinaquadalloy_plate', '2x gtceu:uv_field_generator', '16x gtceu:uv_electric_piston', '64x gtceu:uhpic_chip', 
                     '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip', 
@@ -85,7 +85,7 @@ ServerEvents.recipes(event => {
             .duration(42000)
             .EUt(GTValues.VHA[GTValues.UV]);
     
-    event.recipes.gtceu.assembly_line('stargate_component_assembly')
+    event.recipes.gtceu.assembly_line(id('stargate_component_assembly'))
             .itemInputs('gtceu:prismalium_frame', '4x #gtceu:circuits/uhv', '2x gtceu:uv_field_generator', '8x gtceu:gravi_star', 
                     '4x gtceu:uv_robot_arm', '4x gtceu:uv_robot_arm', '4x gtceu:uv_robot_arm', '4x gtceu:uv_robot_arm', 
                     '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip', 
@@ -101,7 +101,7 @@ ServerEvents.recipes(event => {
             )
             .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.assembly_line('gate_assembly')
+    event.recipes.gtceu.assembly_line(id('gate_assembly'))
             .itemInputs('gtceu:ancient_runicalium_frame', '32x #gtceu:circuits/uhv', '8x gtceu:uhv_field_generator', '8x kubejs:uhv_catalyst_core', 
                     '16x gtceu:uhv_robot_arm', '16x gtceu:uhv_robot_arm', '16x gtceu:uhv_robot_arm', '16x gtceu:uhv_robot_arm', 
                     '64x kubejs:uepic_chip', '64x kubejs:uepic_chip', '64x kubejs:uepic_chip', '64x kubejs:uepic_chip', 
@@ -117,7 +117,7 @@ ServerEvents.recipes(event => {
             )
             .EUt(GTValues.VHA[GTValues.UHV]);
                 
-    event.recipes.gtceu.assembly_line('drackion_runic_laser_gen')
+    event.recipes.gtceu.assembly_line(id('drackion_runic_laser_gen'))
             .itemInputs('gtceu:exquisite_runic_laser_source_base_gem', '2x gtceu:uv_field_generator', '4x gtceu:uv_sensor', '4x gtceu:uv_emitter', 
                 '16x gtceu:energy_cluster', '16x gtceu:energy_cluster', '16x gtceu:energy_cluster','16x gtceu:energy_cluster', 
                 '4x #gtceu:circuits/uhv', '16x gtceu:uv_voltage_coil', '4x gtceu:neutron_reflector', '24x gtceu:stellarium_screw',
@@ -133,14 +133,14 @@ ServerEvents.recipes(event => {
             .duration(64000)
             .EUt(GTValues.VHA[GTValues.ZPM]);
 
-    event.recipes.gtceu.assembler('laser_casing')
+    event.recipes.gtceu.assembler(id('laser_casing'))
         .itemInputs('6x gtceu:double_stellarium_plate', 'gtceu:stellarium_frame', 'kubejs:runic_wave_generator', 'gtceu:uv_field_generator', 'gtceu:uv_emitter')
         .itemOutputs('kubejs:laser_casing')
         .duration(12000)
         .EUt(GTValues.VHA[GTValues.UV])
         .circuit(7);
 
-    event.recipes.gtceu.assembler('inscribe_casing')
+    event.recipes.gtceu.assembler(id('inscribe_casing'))
         .itemInputs('6x gtceu:double_ancient_runicalium_plate', 'gtceu:ancient_runicalium_frame', 'kubejs:runic_wave_generator', 'gtceu:uhv_field_generator', 'gtceu:uhv_emitter')
         .itemOutputs('kubejs:inscribe_casing')
         .duration(36000)
@@ -149,13 +149,13 @@ ServerEvents.recipes(event => {
 
     //Void Line
 
-    event.recipes.gtceu.extractor('echo_fluid')
+    event.recipes.gtceu.extractor(id('echo_fluid'))
         .itemInputs('minecraft:echo_shard')
         .outputFluids('gtceu:echo_r 144')
         .duration(8000)
         .EUt(GTValues.VHA[GTValues.LuV]);
 
-    event.recipes.gtceu.fluid_solidifier('raw_void_ingot')
+    event.recipes.gtceu.fluid_solidifier(id('raw_void_ingot'))
         .itemInputs('gtceu:neutronium_ingot')
         .inputFluids('gtceu:echo_r 144')
         .itemOutputs('gtceu:raw_void_ingot')
@@ -164,7 +164,7 @@ ServerEvents.recipes(event => {
 
     event.remove({output: 'gtceu:hot_void_ingot'});
 
-    event.recipes.gtceu.heat_chamber('crude_to_void_ingot')
+    event.recipes.gtceu.heat_chamber(id('crude_to_void_ingot'))
         .itemInputs('gtceu:raw_void_ingot')
         .itemOutputs('gtceu:hot_void_ingot')
         .blastFurnaceTemp(10799)
@@ -177,7 +177,7 @@ ServerEvents.recipes(event => {
         Fluid.of('gtceu:xenon 10')
     );
 
-    event.recipes.gtceu.bender('nether_star_foil')
+    event.recipes.gtceu.bender(id('nether_star_foil'))
             .itemInputs('gtceu:nether_star_plate')
             .itemOutputs('4x gtceu:nether_star_foil')
             .duration(300)
@@ -185,7 +185,7 @@ ServerEvents.recipes(event => {
             .EUt(GTValues.VA[GTValues.IV]);
 
     //Classic Gate Components
-    event.recipes.gtceu.assembly_line('classic_stargate_computer_core')
+    event.recipes.gtceu.assembly_line(id('classic_stargate_computer_core'))
         .itemInputs('gtceu:stellarium_frame', '4x kubejs:computational_super_matrix', '16x gtceu:ruthenium_trinium_americium_neutronate_octal_wire', '16x gtceu:ruthenium_trinium_americium_neutronate_octal_wire',
             '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip', '64x gtceu:fine_trinaquadalloy_wire', '64x gtceu:fine_trinaquadalloy_wire')
         .inputFluids('gtceu:soldering_alloy 72000', 'gtceu:sterilized_growth_medium 13500')
@@ -199,7 +199,7 @@ ServerEvents.recipes(event => {
         )
         .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.assembly_line('crystal_interface')
+    event.recipes.gtceu.assembly_line(id('crystal_interface'))
             .itemInputs('kubejs:stellarium_casing', '2x gtceu:double_iridium_plate', 'gtceu:uv_voltage_coil', 
                     '4x gtceu:stellarium_hex_wire', '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip', 
                     '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip', 
@@ -215,35 +215,35 @@ ServerEvents.recipes(event => {
             )
             .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.assembler('clasic_dhd')
+    event.recipes.gtceu.assembler(id('clasic_dhd'))
             .itemInputs('gtceu:atomic_casing', 'gtceu:computer_monitor_cover', 'gtceu:uv_field_generator', 'gtceu:uv_emitter', 'gtceu:uv_sensor', '8x gtceu:uhpic_chip', 'kubejs:runic_engraved_plating', '4x kubejs:runic_pathway_engraved_plating')
             .inputFluids('gtceu:soldering_alloy 1728')
             .itemOutputs('sgjourney:classic_dhd')
             .duration(8000)
             .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.stargate_component_assembly('classic_stargate_base_block')
+    event.recipes.gtceu.stargate_component_assembly(id('classic_stargate_base_block'))
         .itemInputs('sgjourney:classic_stargate_ring_block','24x kubejs:runic_pathway_engraved_plating', '16x kubejs:runic_engraved_plating','16x kubejs:stargate_rod', 'kubejs:classic_stargate_computer_core', '64x gtceu:uhpic_chip')
         .inputFluids('gtceu:soldering_alloy 12000', 'gtceu:naquadria 36000', 'gtceu:sterilized_growth_medium 8000')
         .itemOutputs('sgjourney:classic_stargate_base_block')
         .duration(48000)
         .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.stargate_component_assembly('classic_stargate_ring_block')
+    event.recipes.gtceu.stargate_component_assembly(id('classic_stargate_ring_block'))
         .itemInputs('gtceu:stellarium_frame', '36x gtceu:double_naquadah_alloy_plate', '8x kubejs:runic_pathway_engraved_plating','56x kubejs:stargate_rod', '64x gtceu:fine_trinaquadalloy_wire','64x gtceu:fine_trinaquadalloy_wire')
         .inputFluids('gtceu:soldering_alloy 12000', 'gtceu:naquadria 56000')
         .itemOutputs('sgjourney:classic_stargate_ring_block')
         .duration(20000)
         .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.stargate_component_assembly('classic_stargate_chevron_block')
+    event.recipes.gtceu.stargate_component_assembly(id('classic_stargate_chevron_block'))
         .itemInputs('sgjourney:classic_stargate_ring_block','12x kubejs:runic_pathway_engraved_plating', '8x kubejs:runic_engraved_plating','12x kubejs:stargate_rod','kubejs:classic_chevron_disk','32x gtceu:fine_stellarium_wire')
         .inputFluids('gtceu:soldering_alloy 12000', 'gtceu:naquadria 32000', 'gtceu:radon 62000')
         .itemOutputs('sgjourney:classic_stargate_chevron_block')
         .duration(32000)
         .EUt(GTValues.VHA[GTValues.UHV]);
     
-    event.recipes.gtceu.assembly_line('compuation_super_matrix')
+    event.recipes.gtceu.assembly_line(id('compuation_super_matrix'))
         .itemInputs('gtceu:melodium_frame', '16x #gtceu:circuits/uhv', '16x #gtceu:circuits/uhv', '16x #gtceu:circuits/uhv', 
                 '16x #gtceu:circuits/uhv', '16x #gtceu:circuits/uhv', '16x #gtceu:circuits/uhv', '16x #gtceu:circuits/uhv', '48x gtceu:prismalium_screw')
         .inputFluids('gtceu:soldering_alloy 40000')
@@ -257,19 +257,19 @@ ServerEvents.recipes(event => {
         .duration(12000)
         .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.large_rotor_machine('crude_stargate_rod')
+    event.recipes.gtceu.large_rotor_machine(id('crude_stargate_rod'))
         .itemInputs('32x gtceu:neutronium_foil', '48x gtceu:weapon_grade_naquadah_foil', '32x gtceu:neutronium_foil', '48x gtceu:weapon_grade_naquadah_foil', '16x gtceu:nether_star_foil', '48x gtceu:weapon_grade_naquadah_foil', 'gtceu:long_void_rod', '48x gtceu:weapon_grade_naquadah_foil', '32x gtceu:neutronium_foil')
         .itemOutputs('kubejs:crude_stargate_rod')
         .duration(1600)
         .EUt(GTValues.VHA[GTValues.LuV]);
     
-    event.recipes.gtceu.super_pressure_heat_chamber('stargate_rod')
+    event.recipes.gtceu.super_pressure_heat_chamber(id('stargate_rod'))
         .itemInputs('kubejs:crude_stargate_rod')
         .itemOutputs('kubejs:stargate_rod')
         .duration(2400)
         .EUt(GTValues.VHA[GTValues.LuV]);
 
-    event.recipes.gtceu.assembly_line('classic_chevron_disk')
+    event.recipes.gtceu.assembly_line(id('classic_chevron_disk'))
         .itemInputs('gtceu:prismalium_frame', 'gtceu:exquisite_naquadic_netherite_gem', '8x #gtceu:circuits/uhv', '6x gtceu:uv_sensor', '6x gtceu:uv_emitter', '6x gtceu:uv_field_generator', '64x gtceu:uhpic_chip', '64x gtceu:uhpic_chip')
         .inputFluids('gtceu:naquadria 48000', 'gtceu:borosilicate_glass 136000')
         .itemOutputs('kubejs:classic_chevron_disk')
@@ -285,26 +285,26 @@ ServerEvents.recipes(event => {
     //Ancient Gate
         
         //Gate Rods
-        event.recipes.gtceu.large_rotor_machine('untreated_infernal_stargate_rod')
+        event.recipes.gtceu.large_rotor_machine(id('untreated_infernal_stargate_rod'))
             .itemInputs('32x gtceu:void_foil', '16x kubejs:stargate_rod', '32x gtceu:void_foil', '16x kubejs:stargate_rod', 'kubejs:inferno_fragment', '16x kubejs:stargate_rod', 'gtceu:long_void_rod', '16x kubejs:stargate_rod', '32x gtceu:void_foil')
             .itemOutputs('kubejs:untreated_infernal_stargate_rod')
             .duration(1600)
             .EUt(GTValues.VHA[GTValues.UV]);
 
-        event.recipes.gtceu.large_rotor_machine('untreated_abyssal_stargate_rod')
+        event.recipes.gtceu.large_rotor_machine(id('untreated_abyssal_stargate_rod'))
             .itemInputs('32x gtceu:void_foil', '16x kubejs:stargate_rod', '32x gtceu:void_foil', '16x kubejs:stargate_rod', 'kubejs:abyss_fragment', '16x kubejs:stargate_rod', 'gtceu:long_void_rod', '16x kubejs:stargate_rod', '32x gtceu:void_foil')
             .itemOutputs('kubejs:untreated_abyssal_stargate_rod')
             .duration(1600)
             .EUt(GTValues.VHA[GTValues.UV]);
 
-        event.recipes.gtceu.super_pressure_heat_chamber('infernal_stargate_rod')
+        event.recipes.gtceu.super_pressure_heat_chamber(id('infernal_stargate_rod'))
             .itemInputs('64x minecraft:blaze_rod','kubejs:untreated_infernal_stargate_rod','64x minecraft:blaze_rod')
             .inputFluids('gtceu:blaze 64000')
             .itemOutputs('kubejs:infernal_stargate_rod')
             .duration(2400)
             .EUt(GTValues.VHA[GTValues.UHV]);
 
-        event.recipes.gtceu.super_pressure_heat_chamber('abyssal_stargate_rod')
+        event.recipes.gtceu.super_pressure_heat_chamber(id('abyssal_stargate_rod'))
             .itemInputs('64x minecraft:echo_shard','kubejs:untreated_abyssal_stargate_rod','64x minecraft:echo_shard')
             .inputFluids('thermal:ender 64000')
             .itemOutputs('kubejs:abyssal_stargate_rod')
@@ -312,7 +312,7 @@ ServerEvents.recipes(event => {
             .EUt(GTValues.VHA[GTValues.UHV]);
 
         //DHD
-        event.recipes.gtceu.assembly_line('milky_way_gate')
+        event.recipes.gtceu.assembly_line(id('milky_way_gate'))
             .itemInputs('sgjourney:classic_dhd', '8x gtceu:uhv_field_generator', '8x gtceu:uhv_emitter', '8x gtceu:uhv_sensor', '64x kubejs:uepic_chip', '8x kubejs:runic_engraved_plating', '32x kubejs:runic_energized_pathway_plating', '32x kubejs:runic_energized_transportation_plating')
             .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 13824')
             .itemOutputs('sgjourney:milky_way_dhd')
@@ -326,7 +326,7 @@ ServerEvents.recipes(event => {
             .EUt(GTValues.VA[GTValues.UEV])
 
         //Chevrons
-        event.recipes.gtceu.assembly_line('classic_chevron_assembly')
+        event.recipes.gtceu.assembly_line(id('classic_chevron_assembly'))
             .itemInputs('gtceu:stellarium_frame', 'kubejs:classic_chevron_disk', 'kubejs:classic_chevron_disk', 'kubejs:classic_chevron_disk', '6x #gtceu:circuits/uev', '8x kubejs:uhv_catalyst_core', '24x kubejs:uhv_super_magnetic_core', '12x kubejs:uhv_high_strength_panel')
             .inputFluids('gtceu:utopian_akreyrium 24000', 'gtceu:naquadria 56000', 'gtceu:borosilicate_glass 180000')
             .itemOutputs('kubejs:classic_chevron_assembly')
@@ -339,7 +339,7 @@ ServerEvents.recipes(event => {
                 )
             .EUt(GTValues.VHA[GTValues.UHV]);
 
-        event.recipes.gtceu.assembly_line('ancient_chevron_disk')
+        event.recipes.gtceu.assembly_line(id('ancient_chevron_disk'))
             .itemInputs('gtceu:ancient_runicalium_frame', 'kubejs:classic_chevron_disk', '2x kubejs:classic_chevron_assembly', '6x gtceu:uhv_sensor', '6x gtceu:uhv_emitter', '6x gtceu:uhv_field_generator', '64x kubejs:uepic_chip', '64x kubejs:uepic_chip')
             .inputFluids('gtceu:utopian_akreyrium 48000', 'gtceu:naquadria 96000', 'gtceu:borosilicate_glass 196000')
             .itemOutputs('kubejs:ancient_chevron_disk')
@@ -353,7 +353,7 @@ ServerEvents.recipes(event => {
             .EUt(GTValues.VHA[GTValues.UEV]);
 
         //Ancient Encoded Computational Unit
-        event.recipes.gtceu.assembly_line('ancient_stargate_computer_core')
+        event.recipes.gtceu.assembly_line(id('ancient_stargate_computer_core'))
             .itemInputs('gtceu:ancient_runicalium_frame','6x kubejs:computational_super_matrix','16x gtceu:iron_selenide_over_strontium_titanium_oxide_octal_wire','16x gtceu:iron_selenide_over_strontium_titanium_oxide_octal_wire',
                 '64x kubejs:uepic_chip','64x kubejs:uepic_chip','24x #gtceu:circuits/uev','kubejs:draconic_coordinate_core')
             .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 128000', 'gtceu:sterilized_growth_medium 54000')
@@ -368,14 +368,14 @@ ServerEvents.recipes(event => {
             .EUt(GTValues.VA[GTValues.UEV]);
 
         //Draconic Coordinate Core
-        event.recipes.gtceu.super_pressure_heat_chamber('draconic_coordinate_core')
+        event.recipes.gtceu.super_pressure_heat_chamber(id('draconic_coordinate_core'))
             .itemInputs('kubejs:hell_core','kubejs:void_core')
             .inputFluids('gtceu:blaze 50000','thermal:ender 50000')
             .itemOutputs('kubejs:draconic_coordinate_core')
             .duration(30000)
             .EUt(GTValues.VA[GTValues.UEV]);
 
-        event.recipes.gtceu.assembly_line('empty_coordinate_core')
+        event.recipes.gtceu.assembly_line(id('empty_coordinate_core'))
             .itemInputs('gtceu:ancient_runicalium_frame','64x kubejs:uhv_high_strength_panel','64x kubejs:uhv_high_strength_panel','48x gtceu:uhv_field_generator', '32x kubejs:uhv_catalyst_core', '32x kubejs:uhv_catalyst_core','16x gtceu:uhv_sensor','16x gtceu:uhv_emitter')
             .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 120000','gtceu:utopian_akreyrium 75000','gtceu:neutronium 18000')
             .itemOutputs('kubejs:empty_coordinate_core')
@@ -388,21 +388,21 @@ ServerEvents.recipes(event => {
                 )
             .EUt(GTValues.VA[GTValues.UHV]);
 
-        event.recipes.gtceu.injection_mixer('hell_core')
+        event.recipes.gtceu.injection_mixer(id('hell_core'))
             .itemInputs('kubejs:empty_coordinate_core','kubejs:inferno_fragment','kubejs:inferno_fragment','32x gtceu:netherrack_dust','16x minecraft:blaze_powder','8x gtceu:debris_dust')
             .inputFluids('minecraft:lava 250000','gtceu:blaze 50000','gtceu:utopian_akreyrium 32000')
             .itemOutputs('kubejs:hell_core')
             .duration(9000)
             .EUt(GTValues.VH[GTValues.UEV]);
 
-        event.recipes.gtceu.injection_mixer('void_core')
+        event.recipes.gtceu.injection_mixer(id('void_core'))
             .itemInputs('kubejs:empty_coordinate_core','kubejs:abyss_fragment','kubejs:abyss_fragment','32x gtceu:endstone_dust','16x minecraft:ender_pearl','8x minecraft:echo_shard')
             .inputFluids('gtceu:echo_r 250000','thermal:ender 50000','gtceu:utopian_akreyrium 32000')
             .itemOutputs('kubejs:void_core')
             .duration(9000)
             .EUt(GTValues.VH[GTValues.UEV]);
 
-        event.recipes.gtceu.assembly_line('inferno_fragment')
+        event.recipes.gtceu.assembly_line(id('inferno_fragment'))
             .itemInputs('16x gtceu:quantum_star', '16x minecraft:blaze_rod','16x gtceu:quantum_star', '16x minecraft:blaze_rod','16x gtceu:quantum_star', '16x minecraft:blaze_rod','16x gtceu:quantum_star', '16x minecraft:blaze_rod',
                 '16x gtceu:quantum_star', '16x minecraft:blaze_rod','16x gtceu:quantum_star', '16x minecraft:blaze_rod','16x gtceu:quantum_star', '16x minecraft:blaze_rod','16x gtceu:quantum_star', '16x minecraft:blaze_rod')
             .inputFluids('gtceu:neutronium 24000','gtceu:utopian_akreyrium 18000','gtceu:blaze 6000')
@@ -416,7 +416,7 @@ ServerEvents.recipes(event => {
                 )
             .EUt(GTValues.VHA[GTValues.UEV]);
 
-        event.recipes.gtceu.assembly_line('abyss_fragment')
+        event.recipes.gtceu.assembly_line(id('abyss_fragment'))
             .itemInputs('16x gtceu:quantum_star', '16x minecraft:echo_shard','16x gtceu:quantum_star', '16x minecraft:echo_shard','16x gtceu:quantum_star', '16x minecraft:echo_shard','16x gtceu:quantum_star', '16x minecraft:echo_shard',
                 '16x gtceu:quantum_star', '16x minecraft:echo_shard','16x gtceu:quantum_star', '16x minecraft:echo_shard','16x gtceu:quantum_star', '16x minecraft:echo_shard','16x gtceu:quantum_star', '16x minecraft:echo_shard')
             .inputFluids('gtceu:neutronium 24000','gtceu:utopian_akreyrium 18000','gtceu:echo_r 6000')
@@ -431,21 +431,21 @@ ServerEvents.recipes(event => {
             .EUt(GTValues.VHA[GTValues.UEV]);
 
         //Ancient Gate Blocks
-        event.recipes.gtceu.stargate_component_assembly('ancient_stargate_ring_block')
+        event.recipes.gtceu.stargate_component_assembly(id('ancient_stargate_ring_block'))
             .itemInputs('gtceu:ancient_runicalium_frame', '36x gtceu:double_zircalloy_4_plate', '24x kubejs:runic_stabilization_plating', '48x kubejs:stargate_rod', 'kubejs:abyssal_stargate_rod', 'kubejs:infernal_stargate_rod', '64x gtceu:fine_trinaquadalloy_wire', '64x gtceu:fine_trinaquadalloy_wire', '64x gtceu:fine_trinaquadalloy_wire')
             .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 16000', 'gtceu:utopian_akreyrium 48000', 'gtceu:naquadria 128000')
             .itemOutputs('kubejs:ancient_stargate_ring_block')
             .duration(20000)
             .EUt(GTValues.VHA[GTValues.UEV]);
 
-        event.recipes.gtceu.stargate_component_assembly('ancient_stargate_chevron_block')
+        event.recipes.gtceu.stargate_component_assembly(id('ancient_stargate_chevron_block'))
             .itemInputs('kubejs:ancient_stargate_ring_block', '12x kubejs:runic_energized_pathway_plating', '8x kubejs:runic_energized_transportation_plating', '32x kubejs:stargate_rod', 'kubejs:ancient_chevron_disk', '64x gtceu:fine_ancient_runicalium_wire')
             .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 16000', 'gtceu:utopian_akreyrium 24000', 'gtceu:naquadria 72000', 'gtceu:radon 132000')
             .itemOutputs('kubejs:ancient_stargate_chevron_block')
             .duration(32000)
             .EUt(GTValues.VHA[GTValues.UEV]);
 
-        event.recipes.gtceu.stargate_component_assembly('ancient_stargate_base_block')
+        event.recipes.gtceu.stargate_component_assembly(id('ancient_stargate_base_block'))
             .itemInputs('kubejs:ancient_stargate_ring_block', '24x kubejs:runic_energized_pathway_plating', '16x kubejs:runic_energized_transportation_plating', '40x kubejs:stargate_rod', 'kubejs:ancient_stargate_computer_core', '64x kubejs:uepic_chip')
             .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 16000', 'gtceu:utopian_akreyrium 24000', 'gtceu:naquadria 72000', 'gtceu:sterilized_growth_medium 18000')
             .itemOutputs('kubejs:ancient_stargate_base_block')
@@ -453,7 +453,7 @@ ServerEvents.recipes(event => {
             .EUt(GTValues.VHA[GTValues.UEV]);
 
         //THE Ancient Gate
-        event.recipes.gtceu.gate_assembly('ancient_gate')
+        event.recipes.gtceu.gate_assembly(id('ancient_gate'))
             .itemInputs('14x kubejs:ancient_stargate_ring_block', '9x kubejs:ancient_stargate_chevron_block', 'kubejs:ancient_stargate_base_block')
             .inputFluids('gtceu:naquadria 72000', 'gtceu:liquid_nether_air 250000', 'gtceu:liquid_ender_air 250000')
             .itemOutputs('sgjourney:milky_way_stargate {BlockEntityTag:{LocalPointOfOrigin:1b}}')

--- a/kubejs/server_scripts/endgame content/hpca_components.js
+++ b/kubejs/server_scripts/endgame content/hpca_components.js
@@ -1,12 +1,14 @@
 ServerEvents.recipes(event => {
-    event.recipes.gtceu.heat_chamber('graphite_nanoparticle_coolant')
+    const id = global.id;
+    
+    event.recipes.gtceu.heat_chamber(id('graphite_nanoparticle_coolant'))
         .itemInputs('32x gtceu:graphite_dust')
         .inputFluids('gtceu:utopian_akreyrium 2000', 'gtceu:pcb_coolant 5000')
         .outputFluids('gtceu:akreyrium_pcb_graphite_nanoparticle_coolant 4000')
         .duration(250)
         .EUt(GTValues.VHA[GTValues.ZPM])
 
-    event.recipes.gtceu.assembly_line('nanofluidic_heat_sink')
+    event.recipes.gtceu.assembly_line(id('nanofluidic_heat_sink'))
         .itemInputs(
             'gtceu:hpca_heat_sink_component', '4x #gtceu:circuits/zpm',
             '64x gtceu:fine_copper_wire', '64x gtceu:fine_copper_wire',

--- a/kubejs/server_scripts/endgame content/nether_lines/adamantine_line.js
+++ b/kubejs/server_scripts/endgame content/nether_lines/adamantine_line.js
@@ -1,6 +1,6 @@
 ServerEvents.recipes(event => {
     const id = global.id;
-
+    
     event.recipes.gtceu.molten_destabilizing(id('molten_adamantamite_mixture'))
         .inputFluids('gtceu:molten_adamantamite_mixture 300000')
         .outputFluids('gtceu:adamantamite 200000')

--- a/kubejs/server_scripts/endgame content/nether_lines/adamantine_line.js
+++ b/kubejs/server_scripts/endgame content/nether_lines/adamantine_line.js
@@ -1,7 +1,7 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.molten_destabilizing('molten_adamantamite_mixture')
+    event.recipes.gtceu.molten_destabilizing(id('molten_adamantamite_mixture'))
         .inputFluids('gtceu:molten_adamantamite_mixture 300000')
         .outputFluids('gtceu:adamantamite 200000')
         .outputFluids('gtceu:highly_unstable_nether_magma 25000')
@@ -10,14 +10,14 @@ ServerEvents.recipes(event => {
         .duration(3600)
         .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.electrolyzer('adamantamite_dust')
+    event.recipes.gtceu.electrolyzer(id('adamantamite_dust'))
         .inputFluids('gtceu:adamantamite 1000')
         .outputFluids('gtceu:mystical_nether_magma 250')
         .itemOutputs('gtceu:adamantamite_dust','gtceu:small_adamantamite_dust')
         .duration(140)
         .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.heat_chamber('adamantamite_metaltide')
+    event.recipes.gtceu.heat_chamber(id('adamantamite_metaltide'))
         .itemInputs('gtceu:adamantamite_dust')
         .itemInputs('6x gtceu:carbon_dust')
         .itemOutputs('gtceu:adamantamite_metaltide_dust')
@@ -25,7 +25,7 @@ ServerEvents.recipes(event => {
         .duration(260)
         .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.large_chemical_reactor('adamantamite_magnide')
+    event.recipes.gtceu.large_chemical_reactor(id('adamantamite_magnide'))
         .itemInputs('gtceu:adamantamite_metaltide_dust')
         .itemInputs('2x gtceu:sodium_dust')
         .itemOutputs('gtceu:adamantamite_magnide_dust')
@@ -33,7 +33,7 @@ ServerEvents.recipes(event => {
         .duration(100)
         .EUt(GTValues.VHA[GTValues.UEV]);
 
-    event.recipes.gtceu.large_chemical_reactor('adamantamite_titite')
+    event.recipes.gtceu.large_chemical_reactor(id('adamantamite_titite'))
         .itemInputs('gtceu:adamantamite_magnide_dust')
         .inputFluids('gtceu:hydrochloric_acid 4000')
         .itemOutputs('gtceu:adamantamite_titite_dust')
@@ -42,7 +42,7 @@ ServerEvents.recipes(event => {
         .duration(360)
         .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.electric_blast_furnace('adamantine_5')
+    event.recipes.gtceu.electric_blast_furnace(id('adamantine_5'))
         .itemInputs('gtceu:adamantamite_titite_dust')
         .itemInputs('8x gtceu:magnesium_dust')
         .inputFluids('gtceu:oxygen 8000')
@@ -53,7 +53,7 @@ ServerEvents.recipes(event => {
         .blastFurnaceTemp(8000)
         .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.large_chemical_reactor('adamantine_hydroxide')
+    event.recipes.gtceu.large_chemical_reactor(id('adamantine_hydroxide'))
         .itemInputs('1x gtceu:adamantine_5_dust')
         .inputFluids('gtceu:nitric_acid 3000')
         .itemOutputs('1x gtceu:adamantine_hydroxide_dust')
@@ -61,7 +61,7 @@ ServerEvents.recipes(event => {
         .duration(120)
         .EUt(GTValues.VHA[GTValues.UEV]);
 
-    event.recipes.gtceu.chemical_plant('adamantine')
+    event.recipes.gtceu.chemical_plant(id('adamantine'))
         .itemInputs('gtceu:adamantine_hydroxide_dust')
         .itemInputs('3x gtceu:sodium_dust')
         .itemOutputs('gtceu:adamantine_dust')

--- a/kubejs/server_scripts/endgame content/nether_lines/atomic_nether_sludge_line.js
+++ b/kubejs/server_scripts/endgame content/nether_lines/atomic_nether_sludge_line.js
@@ -1,6 +1,7 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.manifold_centrifuge('atomic_nether_sludge_decomp')
+    event.recipes.gtceu.manifold_centrifuge(id('atomic_nether_sludge_decomp'))
         .itemInputs('5x gtceu:atomic_nether_sludge_dust')
         .inputFluids('gtceu:hexafluorobromic_acid 2500')
         .outputFluids('gtceu:caesium_oganesson_hexanitrate_tetrafluorouranate 2500')
@@ -12,32 +13,32 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.UEV]);
 
     //Og Lines
-    event.recipes.gtceu.electrolyzer('caesium_oganesson_hexanitrate_tetrafluorouranate_decomp')
+    event.recipes.gtceu.electrolyzer(id('caesium_oganesson_hexanitrate_tetrafluorouranate_decomp'))
         .inputFluids('gtceu:caesium_oganesson_hexanitrate_tetrafluorouranate 1000')
         .outputFluids('gtceu:uranium_tetrafluoride 1000', 'gtceu:caesium_oganesson_hexanitrate 1000')
         .duration(238)
         .EUt(GTValues.VHA[GTValues.UV]);
     
-    event.recipes.gtceu.large_chemical_reactor('uranium_tetrafluoride_to_uranium_dioxide')
+    event.recipes.gtceu.large_chemical_reactor(id('uranium_tetrafluoride_to_uranium_dioxide'))
         .inputFluids('gtceu:uranium_tetrafluoride 1000', 'minecraft:water 2000')
         .outputFluids('gtceu:hydrofluoric_acid 4000')
         .itemOutputs('1x gtceu:uraninite_dust')
         .duration(850)
         .EUt(GTValues.V[GTValues.LuV]);
 
-    event.recipes.gtceu.large_chemical_reactor('caesium_oganesson_hexanitrate_breakage')
+    event.recipes.gtceu.large_chemical_reactor(id('caesium_oganesson_hexanitrate_breakage'))
         .inputFluids('gtceu:caesium_oganesson_hexanitrate 1000', 'minecraft:water 3000')
         .outputFluids('gtceu:caesium_oganesson_trioxide 1000', 'gtceu:nitric_acid 6000')
         .duration(640)
         .EUt(GTValues.V[GTValues.UV]);
 
-    event.recipes.gtceu.large_chemical_reactor('caesium_oganesson_separation')
+    event.recipes.gtceu.large_chemical_reactor(id('caesium_oganesson_separation'))
         .inputFluids('gtceu:caesium_oganesson_trioxide 1000', 'gtceu:nitric_acid 6000')
         .outputFluids('minecraft:water 3000', 'gtceu:caesium_nitrate 2000', 'gtceu:oganesson_tetranitrate 1000')
         .duration(320)
         .EUt(GTValues.VA[GTValues.UEV]);
 
-    event.recipes.gtceu.large_chemical_reactor('oganesson_decomp')
+    event.recipes.gtceu.large_chemical_reactor(id('oganesson_decomp'))
         .inputFluids('gtceu:oganesson_tetranitrate 1000', 'gtceu:sulfuric_acid 2000')
         .outputFluids('gtceu:nitric_acid 4000', 'gtceu:oganesson 1000')
         .itemOutputs('10x gtceu:sulfate_dust')
@@ -45,14 +46,14 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.V[GTValues.UHV]);
 
     //Fl Lines
-    event.recipes.gtceu.centrifuge('flerovium_hexaoxide_octafluorosulfatoplutonate_enriched_rare_earth_decomp')
+    event.recipes.gtceu.centrifuge(id('flerovium_hexaoxide_octafluorosulfatoplutonate_enriched_rare_earth_decomp'))
         .itemInputs('7x gtceu:flerovium_hexaoxide_octafluorosulfatoplutonate_enriched_rare_earth_dust')
         .itemOutputs('6x gtceu:rare_earth_dust', '1x gtceu:flerovium_hexaoxide_octafluorosulfatoplutonate_dust')
         .cleanroom(CleanroomType.CLEANROOM)
         .duration(120)
         .EUt(GTValues.V[GTValues.ZPM]);
 
-    event.recipes.gtceu.nuclear_fission('flerovium_hexaoxide_octafluorosulfatoplutonate_decay')
+    event.recipes.gtceu.nuclear_fission(id('flerovium_hexaoxide_octafluorosulfatoplutonate_decay'))
         .itemInputs('1x gtceu:flerovium_hexaoxide_octafluorosulfatoplutonate_dust')
         .inputFluids('gtceu:distilled_water 25000')
         .itemOutputs('1x gtceu:flerovium_hexadecafluoride_di_sulfur_trioxide_dust')
@@ -60,13 +61,13 @@ ServerEvents.recipes(event => {
         .duration(3)
         .EUt(GTValues.VA[GTValues.ZPM]*-2)
 
-    event.recipes.gtceu.large_chemical_reactor('flerovium_hexadecafluoride_di_sulfur_trioxide_silvering')
+    event.recipes.gtceu.large_chemical_reactor(id('flerovium_hexadecafluoride_di_sulfur_trioxide_silvering'))
         .itemInputs('1x gtceu:flerovium_hexadecafluoride_di_sulfur_trioxide_dust', '2x gtceu:silver_oxide_dust')
         .itemOutputs('2x gtceu:silver_sulfate_dust', '1x gtceu:flerovium_hexadecafluoride_dust')
         .duration(280)
         .EUt(GTValues.V[GTValues.UHV]);
 
-    event.recipes.gtceu.large_chemical_reactor('flerovium_hexadecafluoride_mass_defluorization')
+    event.recipes.gtceu.large_chemical_reactor(id('flerovium_hexadecafluoride_mass_defluorization'))
         .itemInputs('1x gtceu:flerovium_hexadecafluoride_dust')
         .inputFluids('gtceu:hydrogen 12000')
         .outputFluids('gtceu:hydrofluoric_acid 12000')
@@ -74,7 +75,7 @@ ServerEvents.recipes(event => {
         .duration(800)
         .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.electric_blast_furnace('flerovium_tetrafluoride_heat_separation')
+    event.recipes.gtceu.electric_blast_furnace(id('flerovium_tetrafluoride_heat_separation'))
         .itemInputs('1x gtceu:flerovium_tetrafluoride_dust')
         .inputFluids('gtceu:hydrogen 4000')
         .outputFluids('gtceu:hydrofluoric_acid 4000')
@@ -84,14 +85,14 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.V[GTValues.UHV]);
 
     //Sg Po Lines
-    event.recipes.gtceu.electrolyzer('seaborgium_cerium_tricarbon_tetrakis_orthosilicate_linked_dipolonium_diplatinum_tris_pyrophosphate_decomp')
+    event.recipes.gtceu.electrolyzer(id('seaborgium_cerium_tricarbon_tetrakis_orthosilicate_linked_dipolonium_diplatinum_tris_pyrophosphate_decomp'))
         .itemInputs('2x gtceu:seaborgium_cerium_tricarbon_tetrakis_orthosilicate_linked_dipolonium_diplatinum_tris_pyrophosphate_dust')
         .itemOutputs('1x gtceu:seaborgium_cerium_tricarbon_tetrakis_orthosilicate_dust', '1x gtceu:dipolonium_diplatinum_tris_pyrophosphate_dust')
         .duration(960)
         .EUt(GTValues.VA[GTValues.UV]);
 
     //Sg Lines
-    event.recipes.gtceu.chemical_bath('seaborgium_cerium_tricarbon_tetrakis_orthosilicate_acid_dipping')
+    event.recipes.gtceu.chemical_bath(id('seaborgium_cerium_tricarbon_tetrakis_orthosilicate_acid_dipping'))
         .itemInputs('1x gtceu:seaborgium_cerium_tricarbon_tetrakis_orthosilicate_dust')
         .inputFluids('gtceu:sulfuric_acid 8000')
         .outputFluids('gtceu:silicic_acid 4000')
@@ -99,21 +100,21 @@ ServerEvents.recipes(event => {
         .duration(480)
         .EUt(GTValues.V[GTValues.UHV]);
 
-    event.recipes.gtceu.centrifuge('silicic_acid_decomp')
+    event.recipes.gtceu.centrifuge(id('silicic_acid_decomp'))
         .inputFluids('gtceu:silicic_acid 1000')
         .outputFluids('minecraft:water 1000')
         .itemOutputs('1x gtceu:silicon_dioxide_dust')
         .duration(114)
         .EUt(GTValues.V[GTValues.MV]);
 
-    event.recipes.gtceu.chemical_plant('seaborgium_cerium_tricarbon_octasulfate_restructure')
+    event.recipes.gtceu.chemical_plant(id('seaborgium_cerium_tricarbon_octasulfate_restructure'))
         .itemInputs('1x gtceu:seaborgium_cerium_tricarbon_octasulfate_dust', '2x gtceu:chromium_trioxide_dust')
         .outputFluids('gtceu:carbon_dioxide 3000')
         .itemOutputs('1x gtceu:cerium_4_sulfate_dust', '1x gtceu:chromium_sulfate_dust', '1x gtceu:seaborgium_trisulfate_dust')
         .duration(500)
         .EUt(GTValues.VH[GTValues.UEV]);
 
-    event.recipes.gtceu.large_chemical_reactor('cerium_4_sulfate_decomp')
+    event.recipes.gtceu.large_chemical_reactor(id('cerium_4_sulfate_decomp'))
         .itemInputs('1x gtceu:cerium_4_sulfate_dust')
         .inputFluids('minecraft:water 2000')
         .outputFluids('gtceu:sulfuric_acid 2000')
@@ -121,7 +122,7 @@ ServerEvents.recipes(event => {
         .duration(251)
         .EUt(GTValues.V[GTValues.EV]);
 
-    event.recipes.gtceu.large_chemical_reactor('seaborgium_trisulfate_hydration')
+    event.recipes.gtceu.large_chemical_reactor(id('seaborgium_trisulfate_hydration'))
         .itemInputs('1x gtceu:seaborgium_trisulfate_dust')
         .inputFluids('minecraft:water 3000')
         .outputFluids('gtceu:sulfuric_acid 3000')
@@ -129,14 +130,14 @@ ServerEvents.recipes(event => {
         .duration(440)
         .EUt(GTValues.V[GTValues.UHV]);
 
-    event.recipes.gtceu.large_chemical_reactor('seaborgium_trioxide_base_reaction')
+    event.recipes.gtceu.large_chemical_reactor(id('seaborgium_trioxide_base_reaction'))
         .itemInputs('1x gtceu:seaborgium_trioxide_dust', '2x gtceu:sodium_hydroxide_dust')
         .outputFluids('minecraft:water 1000')
         .itemOutputs('1x gtceu:sodium_seaborgate_dust')
         .duration(120)
         .EUt(GTValues.VA[GTValues.UEV]);
 
-    event.recipes.gtceu.large_chemical_reactor('sodium_seaborgate_acid_reaction')
+    event.recipes.gtceu.large_chemical_reactor(id('sodium_seaborgate_acid_reaction'))
         .itemInputs('1x gtceu:sodium_seaborgate_dust')
         .inputFluids('gtceu:hydrochloric_acid 2000')
         .itemOutputs('1x gtceu:seaborgium_dioxide_dust', '2x gtceu:salt_dust')
@@ -144,7 +145,7 @@ ServerEvents.recipes(event => {
         .duration(140)
         .EUt(GTValues.V[GTValues.UV]);
 
-    event.recipes.gtceu.electric_blast_furnace('seaborgium_dioxide_heating')
+    event.recipes.gtceu.electric_blast_furnace(id('seaborgium_dioxide_heating'))
         .itemInputs('1x gtceu:seaborgium_dioxide_dust')
         .inputFluids('gtceu:hydrogen 4000')
         .itemOutputs('1x gtceu:hot_seaborgium_ingot')
@@ -154,7 +155,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VHA[GTValues.UEV]);
 
     //Po Lines
-    event.recipes.gtceu.chemical_bath('dipolonium_diplatinum_tris_pyrophosphate_bathing')
+    event.recipes.gtceu.chemical_bath(id('dipolonium_diplatinum_tris_pyrophosphate_bathing'))
         .itemInputs('1x gtceu:dipolonium_diplatinum_tris_pyrophosphate_dust')
         .inputFluids('gtceu:hydrochloric_acid 4000')
         .itemOutputs('2x gtceu:platinum_raw_dust', '2x gtceu:polonium_pyrophosphate_dust')
@@ -162,7 +163,7 @@ ServerEvents.recipes(event => {
         .duration(200)
         .EUt(GTValues.VA[GTValues.UV]);
 
-    event.recipes.gtceu.large_chemical_reactor('polonium_pyrophosphate_chlorination')
+    event.recipes.gtceu.large_chemical_reactor(id('polonium_pyrophosphate_chlorination'))
         .itemInputs('1x gtceu:polonium_pyrophosphate_dust')
         .inputFluids('gtceu:hydrochloric_acid 4000')
         .itemOutputs('1x gtceu:polonium_tetrachloride_dust')
@@ -170,13 +171,13 @@ ServerEvents.recipes(event => {
         .duration(480)
         .EUt(GTValues.V[GTValues.UHV]);
 
-    event.recipes.gtceu.large_chemical_reactor('polonium_tetrachloride_base_reaction')
+    event.recipes.gtceu.large_chemical_reactor(id('polonium_tetrachloride_base_reaction'))
         .itemInputs('1x gtceu:polonium_tetrachloride_dust', '4x gtceu:sodium_hydroxide_dust')
         .itemOutputs('4x gtceu:salt_dust', '1x gtceu:polonium_hydroxide_dust')
         .duration(2400)
         .EUt(GTValues.VA[GTValues.ZPM]);
 
-    event.recipes.gtceu.large_chemical_reactor('polonium_hydroxide_carbonation')
+    event.recipes.gtceu.large_chemical_reactor(id('polonium_hydroxide_carbonation'))
         .itemInputs('1x gtceu:polonium_hydroxide_dust')
         .inputFluids('gtceu:carbon_monoxide 1000')
         .outputFluids('minecraft:water 2000')
@@ -184,20 +185,20 @@ ServerEvents.recipes(event => {
         .duration(260)
         .EUt(GTValues.V[GTValues.UHV]);
 
-    event.recipes.gtceu.electric_blast_furnace('polonium_carbonate_heating')
+    event.recipes.gtceu.electric_blast_furnace(id('polonium_carbonate_heating'))
         .itemInputs('1x gtceu:polonium_carbonate_dust', '2x gtceu:calcium_dust')
         .itemOutputs('6x gtceu:calcium_carbonate_dust', '1x gtceu:hot_polonium_ingot')
         .duration(1400)
         .blastFurnaceTemp(13499)
         .EUt(GTValues.VA[GTValues.UIV]);
 
-    event.recipes.gtceu.large_chemical_reactor('pyrophosphoric_acid_hydrating')
+    event.recipes.gtceu.large_chemical_reactor(id('pyrophosphoric_acid_hydrating'))
         .inputFluids('gtceu:pyrophosphoric_acid 1000', 'minecraft:water 1000')
         .outputFluids('gtceu:orthophosphoric_acid 2000')
         .duration(240)
         .EUt(GTValues.V[GTValues.EV]);
 
-    event.recipes.gtceu.large_chemical_reactor('orthophosphoric_acid_neutralizing')
+    event.recipes.gtceu.large_chemical_reactor(id('orthophosphoric_acid_neutralizing'))
         .inputFluids('gtceu:orthophosphoric_acid 1000')
         .itemInputs('3x gtceu:sodium_hydroxide_dust')
         .outputFluids('minecraft:water 3000')
@@ -206,14 +207,14 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VH[GTValues.IV]);
 
     //At and Hf lines
-    event.recipes.gtceu.electrolyzer('hafnium_thorium_iron_magnesium_disilicate_monosulfate_bonded_iron_2_barium_diastatide_trisulfate_decomp')
+    event.recipes.gtceu.electrolyzer(id('hafnium_thorium_iron_magnesium_disilicate_monosulfate_bonded_iron_2_barium_diastatide_trisulfate_decomp'))
         .itemInputs('2x gtceu:hafnium_thorium_iron_magnesium_disilicate_monosulfate_bonded_iron_2_barium_diastatide_trisulfate_dust')
         .itemOutputs('1x gtceu:hafnium_thorium_iron_magnesium_disilicate_monosulfate_dust', '1x gtceu:iron_2_barium_diastatide_trisulfate_dust')
         .duration(800)
         .EUt(GTValues.VA[GTValues.ZPM]);
 
     //At lines
-    event.recipes.gtceu.large_chemical_reactor('iron_2_barium_diastatide_trisulfate_iron_stripping')
+    event.recipes.gtceu.large_chemical_reactor(id('iron_2_barium_diastatide_trisulfate_iron_stripping'))
         .itemInputs('1x gtceu:iron_2_barium_diastatide_trisulfate_dust')
         .inputFluids('gtceu:hydrochloric_acid 6000')
         .outputFluids('gtceu:iron_iii_chloride 2000', 'gtceu:sulfuric_acid 3000')
@@ -221,7 +222,7 @@ ServerEvents.recipes(event => {
         .duration(400)
         .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.chemical_bath('barium_diastatide_hydration')
+    event.recipes.gtceu.chemical_bath(id('barium_diastatide_hydration'))
         .itemInputs('1x gtceu:barium_diastatide_dust')
         .inputFluids('minecraft:water 2000')
         .itemOutputs('1x gtceu:barium_hydroxide_dust')
@@ -229,7 +230,7 @@ ServerEvents.recipes(event => {
         .duration(600)
         .EUt(GTValues.V[GTValues.UV]);
 
-    event.recipes.gtceu.large_chemical_reactor('hydroastatic_acid_neutralizing')
+    event.recipes.gtceu.large_chemical_reactor(id('hydroastatic_acid_neutralizing'))
         .inputFluids('gtceu:hydroastatic_acid 1000')
         .itemInputs('1x gtceu:sodium_hydroxide_dust')
         .outputFluids('minecraft:water 1000')
@@ -237,14 +238,14 @@ ServerEvents.recipes(event => {
         .duration(1600)
         .EUt(GTValues.VA[GTValues.ZPM]);
 
-    event.recipes.gtceu.large_chemical_reactor('sodium_astatide_nitration')
+    event.recipes.gtceu.large_chemical_reactor(id('sodium_astatide_nitration'))
         .itemInputs('1x gtceu:sodium_astatide_dust')
         .inputFluids('gtceu:nitrogen_dioxide 1000')
         .itemOutputs('1x gtceu:astatine_dust', '4x gtceu:sodium_nitrite_dust')
         .duration(180)
         .EUt(GTValues.VHA[GTValues.UEV]);
 
-    event.recipes.gtceu.large_chemical_reactor('barium_hydroxide_carbonization')
+    event.recipes.gtceu.large_chemical_reactor(id('barium_hydroxide_carbonization'))
         .itemInputs('1x gtceu:barium_hydroxide_dust')
         .inputFluids('gtceu:carbon_dioxide 1000')
         .outputFluids('minecraft:water 1000')
@@ -254,20 +255,20 @@ ServerEvents.recipes(event => {
 
 
     //Hf Lines
-    event.recipes.gtceu.large_chemical_reactor('hafnium_thorium_iron_magnesium_disilicate_monosulfate_base_reaction')
+    event.recipes.gtceu.large_chemical_reactor(id('hafnium_thorium_iron_magnesium_disilicate_monosulfate_base_reaction'))
         .itemInputs('1x gtceu:hafnium_thorium_iron_magnesium_disilicate_monosulfate_dust', '6x gtceu:potassium_hydroxide_dust')
         .itemOutputs('7x gtceu:potassium_sulfate_dust', '2x gtceu:magnesium_hydroxide_dust', '1x gtceu:hafnium_thorium_iron_2_hydroxide_potassium_disilicate_dust')
         .duration(640)
         .EUt(GTValues.VA[GTValues.UV]);
 
-    event.recipes.gtceu.extractor('magnesium_hydroxide_seperation')
+    event.recipes.gtceu.extractor(id('magnesium_hydroxide_seperation'))
         .itemInputs('1x gtceu:magnesium_hydroxide_dust')
         .itemOutputs('1x gtceu:magnesia_dust')
         .outputFluids('minecraft:water 1000')
         .duration(320)
         .EUt(GTValues.V[GTValues.MV]);
 
-    event.recipes.gtceu.chemical_plant('hafnium_thorium_iron_2_hydroxide_potassium_disilicate_acid_dipping')
+    event.recipes.gtceu.chemical_plant(id('hafnium_thorium_iron_2_hydroxide_potassium_disilicate_acid_dipping'))
         .itemInputs('1x gtceu:hafnium_thorium_iron_2_hydroxide_potassium_disilicate_dust')
         .inputFluids('gtceu:hydrochloric_acid 8000')
         .itemOutputs('4x gtceu:potassium_hydroxide_dust', '2x gtceu:silicon_dioxide_dust', '1x gtceu:iron_2_hydroxide_dust', '1x gtceu:hafnium_thorium_octachloride_dust')
@@ -275,14 +276,14 @@ ServerEvents.recipes(event => {
         .duration(840)
         .EUt(GTValues.VA[GTValues.UHV]);
 
-    event.recipes.gtceu.large_chemical_reactor('iron_2_hydroxide_neutralization')
+    event.recipes.gtceu.large_chemical_reactor(id('iron_2_hydroxide_neutralization'))
         .itemInputs('1x gtceu:iron_2_hydroxide_dust')
         .inputFluids('gtceu:hydrochloric_acid 2000')
         .outputFluids('minecraft:water 2000', 'gtceu:iron_ii_chloride 1000')
         .duration(200)
         .EUt(GTValues.VA[GTValues.HV]);
 
-    event.recipes.gtceu.large_chemical_reactor('hafnium_thorium_octachloride_hydration')
+    event.recipes.gtceu.large_chemical_reactor(id('hafnium_thorium_octachloride_hydration'))
         .itemInputs('1x gtceu:hafnium_thorium_octachloride_dust')
         .inputFluids('minecraft:water 4000')
         .outputFluids('gtceu:hydrochloric_acid 8000')
@@ -290,7 +291,7 @@ ServerEvents.recipes(event => {
         .duration(300)
         .EUt(GTValues.VA[GTValues.UHV]);
 
-    event.recipes.gtceu.electric_blast_furnace('thorium_dioxide')
+    event.recipes.gtceu.electric_blast_furnace(id('thorium_dioxide'))
         .itemInputs('1x gtceu:thorium_dioxide_dust', '2x gtceu:carbon_dust')
         .outputFluids('gtceu:carbon_monoxide 2000')
         .itemOutputs('1x gtceu:thorium_dust')
@@ -298,14 +299,14 @@ ServerEvents.recipes(event => {
         .blastFurnaceTemp(4950)
         .EUt(GTValues.VHA[GTValues.EV]);
 
-    event.recipes.gtceu.electric_blast_furnace('hafnium_dioxide_heat_treating')
+    event.recipes.gtceu.electric_blast_furnace(id('hafnium_dioxide_heat_treating'))
         .itemInputs('1x gtceu:hafnium_dioxide_dust', '2x gtceu:sodium_bicarbonate_dust')
         .outputFluids('gtceu:carbon_dioxide 2000', 'gtceu:steam 1000')
         .itemOutputs('1x gtceu:sodium_hafnate_dust')
         .duration(8600)
         .EUt(GTValues.VH[GTValues.LuV]);
 
-    event.recipes.gtceu.large_chemical_reactor('hafnium_chlorination')
+    event.recipes.gtceu.large_chemical_reactor(id('hafnium_chlorination'))
         .itemInputs('1x gtceu:sodium_hafnate_dust')
         .inputFluids('gtceu:hydrochloric_acid 6000')
         .outputFluids('gtceu:brackish_water 2000')
@@ -313,7 +314,7 @@ ServerEvents.recipes(event => {
         .duration(720)
         .EUt(GTValues.V[GTValues.ZPM]);
 
-    event.recipes.gtceu.electric_blast_furnace('hafnium_hexachloride_to_ingot')
+    event.recipes.gtceu.electric_blast_furnace(id('hafnium_hexachloride_to_ingot'))
         .itemInputs('1x gtceu:hafnium_hexachloride_dust', '3x gtceu:magnesium_dust')
         .itemOutputs('9x gtceu:magnesium_chloride_dust', '1x gtceu:hot_hafnium_ingot')
         .duration(720)

--- a/kubejs/server_scripts/endgame content/nether_lines/calamatium_isovol_line.js
+++ b/kubejs/server_scripts/endgame content/nether_lines/calamatium_isovol_line.js
@@ -1,28 +1,28 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.chemical_plant('estalt_dissolving')
+    event.recipes.gtceu.chemical_plant(id('estalt_dissolving'))
         .itemInputs('6x gtceu:estalt_dust')
         .inputFluids('gtceu:fluoroantimonic_acid 2000')
         .outputFluids('gtceu:impure_calamatium_solution 1000', 'gtceu:impure_isovol_solution 1000', 'gtceu:fluorine 4000')
         .duration(1200)
         .EUt(100000);
 
-    event.recipes.gtceu.centrifuge('impure_calamatium_solution')
+    event.recipes.gtceu.centrifuge(id('impure_calamatium_solution'))
         .inputFluids('gtceu:impure_calamatium_solution 1000')
         .itemOutputs('4x gtceu:antimony_trifluoride_dust')
         .outputFluids('gtceu:calamatium_solution 1000')
         .duration(600)
         .EUt(100000);
 
-    event.recipes.gtceu.centrifuge('calamatium_solution')
+    event.recipes.gtceu.centrifuge(id('calamatium_solution'))
         .inputFluids('gtceu:calamatium_solution 1000')
         .itemOutputs('gtceu:calamatium_fluoride_dust')
         .outputFluids('gtceu:hydrogen 2000')
         .duration(600)
         .EUt(30000);
 
-    event.recipes.gtceu.large_chemical_reactor('calamatium_fluoride')
+    event.recipes.gtceu.large_chemical_reactor(id('calamatium_fluoride'))
         .itemInputs('gtceu:calamatium_fluoride_dust')
         .inputFluids('minecraft:water 1000')
         .itemOutputs('gtceu:calamatium_dust')
@@ -31,14 +31,14 @@ ServerEvents.recipes(event => {
         .duration(600)
         .EUt(30000);
 
-    event.recipes.gtceu.centrifuge('impure_isovol_solution')
+    event.recipes.gtceu.centrifuge(id('impure_isovol_solution'))
         .inputFluids('gtceu:impure_isovol_solution 1000')
         .itemOutputs('4x gtceu:antimony_trifluoride_dust')
         .outputFluids('gtceu:isovol_solution 1000')
         .duration(600)
         .EUt(100000);
 
-    event.recipes.gtceu.centrifuge('isovol_solution')
+    event.recipes.gtceu.centrifuge(id('isovol_solution'))
         .inputFluids('gtceu:isovol_solution 1000')
         .itemOutputs('gtceu:isovol_fluoride_dust')
         .outputFluids('gtceu:hydrogen 2000')
@@ -46,7 +46,7 @@ ServerEvents.recipes(event => {
         .EUt(30000);
 
 
-    event.recipes.gtceu.large_chemical_reactor('isovol_fluoride')
+    event.recipes.gtceu.large_chemical_reactor(id('isovol_fluoride'))
         .itemInputs('gtceu:isovol_fluoride_dust')
         .inputFluids('minecraft:water 1000')
         .itemOutputs('gtceu:isovol_dust')

--- a/kubejs/server_scripts/endgame content/nether_lines/enriched_estalt_line.js
+++ b/kubejs/server_scripts/endgame content/nether_lines/enriched_estalt_line.js
@@ -1,21 +1,21 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.mixer('enriched_estaltadyne_slurry')
+    event.recipes.gtceu.mixer(id('enriched_estaltadyne_slurry'))
         .inputFluids('gtceu:enriched_estaltadyne_solution 1000')
         .inputFluids('gtceu:perchloric_acid 2000')
         .outputFluids('gtceu:enriched_estaltadyne_slurry 1000')
         .duration(240)
         .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.chemical_plant('enriched_estaltadyne_naquide_slurry_mixture')
+    event.recipes.gtceu.chemical_plant(id('enriched_estaltadyne_naquide_slurry_mixture'))
         .inputFluids('gtceu:enriched_estaltadyne_slurry 1000')
         .itemInputs('1x gtceu:enriched_naquadah_dust')
         .outputFluids('gtceu:enriched_estaltadyne_naquide_slurry_mixture 1000')
         .duration(200)
         .EUt(GTValues.VA[GTValues.UHV]);
 
-    event.recipes.gtceu.heat_chamber('hyper_enriched_estaltadyne_slurry_mixture')
+    event.recipes.gtceu.heat_chamber(id('hyper_enriched_estaltadyne_slurry_mixture'))
         .inputFluids('gtceu:enriched_estaltadyne_naquide_slurry_mixture 1000')
         .itemInputs('2x gtceu:ionized_sculk_dust', '1x gtceu:calcium_dust')
         .outputFluids('gtceu:hyper_enriched_estaltadyne_slurry_mixture 1000')
@@ -23,14 +23,14 @@ ServerEvents.recipes(event => {
         .duration(250)
         .EUt(GTValues.VHA[GTValues.UEV]);
 
-    event.recipes.gtceu.centrifuge('hyper_enriched_estaltadyne_slurry_mixture_decomposition')
+    event.recipes.gtceu.centrifuge(id('hyper_enriched_estaltadyne_slurry_mixture_decomposition'))
         .inputFluids('gtceu:hyper_enriched_estaltadyne_slurry_mixture 1000')
         .itemOutputs('1x gtceu:calcium_perchlorate_dust')
         .outputFluids('gtceu:hyper_enriched_estaltadyne_slurry_residue 1000')
         .duration(280)
         .EUt(GTValues.VH[GTValues.UHV]);
 
-    event.recipes.gtceu.large_chemical_reactor('hyper_enriched_estaltadyne_slurry_residue_sodium_addition')
+    event.recipes.gtceu.large_chemical_reactor(id('hyper_enriched_estaltadyne_slurry_residue_sodium_addition'))
         .inputFluids('gtceu:hyper_enriched_estaltadyne_slurry_residue 1000')
         .itemInputs('3x gtceu:sodium_oxide_dust')
         .outputFluids('gtceu:sodium_hyper_enriched_estaltadyne_sludge 1000')
@@ -38,21 +38,21 @@ ServerEvents.recipes(event => {
         .duration(80)
         .EUt(GTValues.V[GTValues.UEV]);
 
-    event.recipes.gtceu.centrifuge('hyper_enriched_estaltadyne_concentrate')
+    event.recipes.gtceu.centrifuge(id('hyper_enriched_estaltadyne_concentrate'))
         .inputFluids('gtceu:sodium_hyper_enriched_estaltadyne_sludge 1000')
         .itemOutputs('2x gtceu:sodium_over_sculk_dust')
         .outputFluids('gtceu:hyper_enriched_estaltadyne_concentrate 1000')
         .duration(820)
         .EUt(GTValues.VA[GTValues.UV]);
 
-    event.recipes.gtceu.electrolyzer('enriched_estalt')
+    event.recipes.gtceu.electrolyzer(id('enriched_estalt'))
         .inputFluids('gtceu:hyper_enriched_estaltadyne_concentrate 1000')    
         .itemOutputs('2x gtceu:enriched_estalt_dust')
         .outputFluids('gtceu:enriched_mystical_concentrate 1000')
         .duration(190)
         .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.manifold_centrifuge('enriched_mystical_concentrate_decomposition')
+    event.recipes.gtceu.manifold_centrifuge(id('enriched_mystical_concentrate_decomposition'))
         .inputFluids('gtceu:enriched_mystical_concentrate 3000')
         .outputFluids('gtceu:enriched_mythrillic_mixture 1000')
         .outputFluids('gtceu:enriched_estaltadyne_mixture 1000')

--- a/kubejs/server_scripts/endgame content/nether_lines/estalt_line.js
+++ b/kubejs/server_scripts/endgame content/nether_lines/estalt_line.js
@@ -1,7 +1,7 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.molten_destabilizing('molten_estaltadyne_mixture')
+    event.recipes.gtceu.molten_destabilizing(id('molten_estaltadyne_mixture'))
         .inputFluids('gtceu:molten_estaltadyne_mixture 300000')
         .outputFluids('gtceu:estaltadyne 200000')
         .outputFluids('gtceu:highly_unstable_nether_magma 50000')
@@ -10,14 +10,14 @@ ServerEvents.recipes(event => {
         .duration(3600)
         .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.electrolyzer('estaltadyne_dust')
+    event.recipes.gtceu.electrolyzer(id('estaltadyne_dust'))
         .inputFluids('gtceu:estaltadyne 1000')
         .outputFluids('gtceu:mystical_nether_magma 250')
         .itemOutputs('gtceu:estaltadyne_dust','gtceu:small_estaltadyne_dust')
         .duration(140)
         .EUt(GTValues.V[GTValues.UHV]);
 
-    event.recipes.gtceu.heat_chamber('metmalic_estaltadyne_dust')
+    event.recipes.gtceu.heat_chamber(id('metmalic_estaltadyne_dust'))
         .itemInputs('1x gtceu:estaltadyne_dust')
         .itemInputs('2x gtceu:carbon_dust')
         .itemOutputs('1x gtceu:metmalic_estaltadyne_dust')
@@ -25,14 +25,14 @@ ServerEvents.recipes(event => {
         .duration(240)
         .EUt(GTValues.VH[GTValues.UEV]);
 
-    event.recipes.gtceu.electrolyzer('magnemalic_estaltadyne_dust')
+    event.recipes.gtceu.electrolyzer(id('magnemalic_estaltadyne_dust'))
         .itemInputs('1x gtceu:metmalic_estaltadyne_dust')
         .itemOutputs('2x gtceu:aluminium_dust')
         .itemOutputs('1x gtceu:magnemalic_estaltadyne_dust')
         .duration(600)
         .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.chemical_plant('tytite_estaltadyne_dust')
+    event.recipes.gtceu.chemical_plant(id('tytite_estaltadyne_dust'))
         .itemInputs('1x gtceu:magnemalic_estaltadyne_dust')
         .itemInputs('15x gtceu:sodium_hydroxide_dust')
         .inputFluids('gtceu:oxygen 15000')
@@ -41,7 +41,7 @@ ServerEvents.recipes(event => {
         .duration(460)
         .EUt(GTValues.VA[GTValues.UHV]);
 
-    event.recipes.gtceu.electric_blast_furnace('estaltadyne_hydride_dust')
+    event.recipes.gtceu.electric_blast_furnace(id('estaltadyne_hydride_dust'))
         .itemInputs('1x gtceu:tytite_estaltadyne_dust')
         .inputFluids('gtceu:hydrofluoric_acid 9000')
         .itemOutputs('1x gtceu:estaltadyne_hydride_dust')
@@ -50,7 +50,7 @@ ServerEvents.recipes(event => {
         .duration(220)
         .EUt(GTValues.VHA[GTValues.UEV]);
 
-    event.recipes.gtceu.large_chemical_reactor('estalt_dust')
+    event.recipes.gtceu.large_chemical_reactor(id('estalt_dust'))
         .itemInputs('1x gtceu:estaltadyne_hydride_dust')
         .itemInputs('15x gtceu:phosphate_dust')
         .itemOutputs('4x gtceu:estalt_dust')

--- a/kubejs/server_scripts/endgame content/nether_lines/magmas.js
+++ b/kubejs/server_scripts/endgame content/nether_lines/magmas.js
@@ -1,8 +1,8 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     //Mystical Magma
-    event.recipes.gtceu.cyclonic_sifter('mystical_nether_magma')
+    event.recipes.gtceu.cyclonic_sifter(id('mystical_nether_magma'))
         .inputFluids('gtceu:highly_unstable_nether_magma 100000')
         .chancedInput('1x kubejs:ancient_netherite_reinforced_mesh', 1000, -150)
         .outputFluids('gtceu:mystical_nether_magma 7000')
@@ -10,13 +10,13 @@ ServerEvents.recipes(event => {
         .duration(1050)
         .EUt(GTValues.VA[GTValues.UEV]*3/11);
 
-    event.recipes.gtceu.polarizer('nether_dust_activation')
+    event.recipes.gtceu.polarizer(id('nether_dust_activation'))
         .itemInputs('1x gtceu:deactivated_nether_dust')
         .itemOutputs('1x gtceu:activated_nether_dust')
         .duration(360)
         .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.manifold_centrifuge('mystical_nether_magma_deconstruction')
+    event.recipes.gtceu.manifold_centrifuge(id('mystical_nether_magma_deconstruction'))
         .inputFluids('gtceu:mystical_nether_magma 3000')
         .outputFluids('gtceu:estaltadyne_nether_magma 1000')
         .outputFluids('gtceu:adamantamite_nether_magma 1000')
@@ -24,7 +24,7 @@ ServerEvents.recipes(event => {
         .duration(480)
         .EUt(GTValues.VHA[GTValues.UHV]*3/5);
 
-    event.recipes.gtceu.molten_destabilizing('adamantamite_nether_magma_deconstruction')
+    event.recipes.gtceu.molten_destabilizing(id('adamantamite_nether_magma_deconstruction'))
         .inputFluids('gtceu:adamantamite_nether_magma 10000')
         .outputFluids('gtceu:highly_unstable_nether_magma 3000')
         .outputFluids('gtceu:molten_adamantamite_mixture 6000')
@@ -32,7 +32,7 @@ ServerEvents.recipes(event => {
         .duration(1200)
         .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.molten_destabilizing('mythrillic_nether_magma_deconstruction')
+    event.recipes.gtceu.molten_destabilizing(id('mythrillic_nether_magma_deconstruction'))
         .inputFluids('gtceu:mythrillic_nether_magma 10000')
         .outputFluids('gtceu:highly_unstable_nether_magma 3000')
         .outputFluids('gtceu:molten_mythrillic_mixture 6000')
@@ -40,7 +40,7 @@ ServerEvents.recipes(event => {
         .duration(1200)
         .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.molten_destabilizing('estaltadyne_nether_magma_deconstruction')
+    event.recipes.gtceu.molten_destabilizing(id('estaltadyne_nether_magma_deconstruction'))
         .inputFluids('gtceu:estaltadyne_nether_magma 10000')
         .outputFluids('gtceu:highly_unstable_nether_magma 3000')
         .outputFluids('gtceu:molten_estaltadyne_mixture 6000')
@@ -67,7 +67,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VHA[GTValues.UHV]); 
 
     //Debris Magma
-    event.recipes.gtceu.centrifuge('debris_rich_nether_magma_deconstruction')
+    event.recipes.gtceu.centrifuge(id('debris_rich_nether_magma_deconstruction'))
         .inputFluids('gtceu:debris_rich_nether_magma 250000')
         .outputFluids('minecraft:lava 200000')
         .outputFluids('gtceu:debris 49000')
@@ -75,13 +75,13 @@ ServerEvents.recipes(event => {
         .duration(3600)
         .EUt(GTValues.VA[GTValues.UHV]);
 
-    event.recipes.gtceu.fluid_solidifier('debris_dust_from_liquid')
+    event.recipes.gtceu.fluid_solidifier(id('debris_dust_from_liquid'))
         .inputFluids('gtceu:debris 144')
         .itemOutputs('1x gtceu:debris_dust')
         .duration(20)
         .EUt(GTValues.VHA[GTValues.IV]);
         
-    event.recipes.gtceu.fluid_solidifier('ancient_debris_from_liquid')
+    event.recipes.gtceu.fluid_solidifier(id('ancient_debris_from_liquid'))
         .inputFluids('gtceu:ancient_debris 576')
         .itemOutputs('1x minecraft:ancient_debris')
         .duration(100)

--- a/kubejs/server_scripts/endgame content/nether_lines/misc.js
+++ b/kubejs/server_scripts/endgame content/nether_lines/misc.js
@@ -1,7 +1,7 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.heat_chamber('nether_star_concentrate')
+    event.recipes.gtceu.heat_chamber(id('nether_star_concentrate'))
         .itemInputs('5x gtceu:nether_star_dust')
         .inputFluids('gtceu:blitz 720','gtceu:blizz 720','gtceu:basalz 720','gtceu:blaze 720')
         .outputFluids('gtceu:nether_star_concentrate 432')
@@ -9,39 +9,39 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VHA[GTValues.UEV]);
 
     //Sculk Variant
-    event.recipes.gtceu.polarizer('ionized_sculk_dust')
+    event.recipes.gtceu.polarizer(id('ionized_sculk_dust'))
         .itemInputs('gtceu:sculk_dust')
         .itemOutputs('gtceu:ionized_sculk_dust')
         .duration(300)
         .EUt(GTValues.VA[GTValues.UV]);
 
-    event.recipes.gtceu.large_chemical_reactor('sodium_over_sculk_to_echo')
+    event.recipes.gtceu.large_chemical_reactor(id('sodium_over_sculk_to_echo'))
         .itemInputs('2x gtceu:sodium_over_sculk_dust','3x gtceu:silicon_dioxide_dust')
         .itemOutputs('2x gtceu:sodium_dust','5x gtceu:echo_shard_dust')
         .duration(80)
         .EUt(GTValues.VHA[GTValues.UIV]);
 
     //Plasmas/Fusion
-    event.recipes.gtceu.fusion_reactor('magmatic_plasma')
+    event.recipes.gtceu.fusion_reactor(id('magmatic_plasma'))
         .inputFluids('gtceu:highly_unstable_nether_magma 2560', 'gtceu:iron_plasma 128')
         .outputFluids('gtceu:magmatic_plasma 64')
         .duration(132)
         .EUt(66666)
         .fusionStartEU(720000000);
         
-    event.recipes.gtceu.plasma_generator('magmatic_plasma')
+    event.recipes.gtceu.plasma_generator(id('magmatic_plasma'))
         .inputFluids('gtceu:magmatic_plasma 1')
         .outputFluids('gtceu:highly_unstable_nether_magma 1')
         .duration(333)
         .EUt(-2048);
 
-    event.recipes.gtceu.plasma_generator('argon_plasma')
+    event.recipes.gtceu.plasma_generator(id('argon_plasma'))
         .inputFluids('gtceu:argon_plasma 1')
         .outputFluids('gtceu:argon 1')
         .duration(80)
         .EUt(-2048);
 
-    event.recipes.gtceu.fusion_reactor('aurourium')
+    event.recipes.gtceu.fusion_reactor(id('aurourium'))
         .inputFluids('gtceu:nether_star_concentrate 64', 'gtceu:seaborgium 64')
         .outputFluids('gtceu:aurourium 32')
         .duration(80)
@@ -49,7 +49,7 @@ ServerEvents.recipes(event => {
         .fusionStartEU(888888888);
     
     //Ancient Netherite
-    event.recipes.gtceu.assembler('ancient_netherite_reinforced_mesh')
+    event.recipes.gtceu.assembler(id('ancient_netherite_reinforced_mesh'))
         .itemInputs('1x kubejs:netherite_reinforced_mesh', '4x gtceu:ancient_netherite_rod', '1x gtceu:ancient_netherite_ingot')
         .inputFluids('gtceu:niobium_nitride 576')
         .itemOutputs('1x kubejs:ancient_netherite_reinforced_mesh')
@@ -57,7 +57,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VHA[GTValues.UHV]);
 
     event.remove({id: /^blast_ancient_netherite.*/});
-    event.recipes.gtceu.electric_blast_furnace('hot_ancient_netherite_ingot')
+    event.recipes.gtceu.electric_blast_furnace(id('hot_ancient_netherite_ingot'))
         .itemInputs('4x minecraft:gold_ingot','4x gtceu:ancient_debris_dust')
         .inputFluids('gtceu:argon 2000')
         .itemOutputs('1x gtceu:hot_ancient_netherite_ingot')
@@ -65,14 +65,14 @@ ServerEvents.recipes(event => {
         .duration(3000)
         .EUt(GTValues.VHA[GTValues.UHV]*2/3);
 
-    event.recipes.gtceu.macerator('ancient_debris_dust')
+    event.recipes.gtceu.macerator(id('ancient_debris_dust'))
         .itemInputs('minecraft:ancient_debris')
         .itemOutputs('4x gtceu:ancient_debris_dust')
         .duration(124)
         .EUt(380644);
 
     //Quantum Cooling
-    event.recipes.gtceu.super_cooler('bec_og')
+    event.recipes.gtceu.super_cooler(id('bec_og'))
         .inputFluids('gtceu:oganesson 500')
         .inputFluids('gtceu:superstate_helium_3 7500')
         .outputFluids('gtceu:bec_og 500')
@@ -80,7 +80,7 @@ ServerEvents.recipes(event => {
         .duration(320)
         .EUt(GTValues.VHA[GTValues.UEV]);
 
-    event.recipes.gtceu.super_cooler('superstate_helium_3')
+    event.recipes.gtceu.super_cooler(id('superstate_helium_3'))
         .inputFluids('gtceu:helium_3 5000')
         .inputFluids('gtceu:liquid_helium 5000')
         .outputFluids('gtceu:superstate_helium_3 5000')

--- a/kubejs/server_scripts/endgame content/nether_lines/mythril_line.js
+++ b/kubejs/server_scripts/endgame content/nether_lines/mythril_line.js
@@ -1,7 +1,7 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.molten_destabilizing('molten_mythrillic_mixture')
+    event.recipes.gtceu.molten_destabilizing(id('molten_mythrillic_mixture'))
         .inputFluids('gtceu:molten_mythrillic_mixture 300000')
         .outputFluids('gtceu:mythrillic 200000')
         .outputFluids('gtceu:highly_unstable_nether_magma 25000')
@@ -10,21 +10,21 @@ ServerEvents.recipes(event => {
         .duration(3600)
         .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.electrolyzer('mythrillic_dust')
+    event.recipes.gtceu.electrolyzer(id('mythrillic_dust'))
         .inputFluids('gtceu:mythrillic 1000')
         .outputFluids('gtceu:mystical_nether_magma 250')
         .itemOutputs('gtceu:mythrillic_dust','gtceu:small_mythrillic_dust')
         .duration(140)
         .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.heat_chamber('mythrillic_carbinide')
+    event.recipes.gtceu.heat_chamber(id('mythrillic_carbinide'))
         .itemInputs('gtceu:mythrillic_dust')
         .itemOutputs('gtceu:mythrillic_carbinide_dust')
         .outputFluids('gtceu:hydrogen 14000')
         .duration(180)
         .EUt(GTValues.VHA[GTValues.UEV]);
 
-    event.recipes.gtceu.electric_blast_furnace('mythrillic_metlide')
+    event.recipes.gtceu.electric_blast_furnace(id('mythrillic_metlide'))
         .itemInputs('gtceu:mythrillic_carbinide_dust')
         .inputFluids('gtceu:oxygen 12000')
         .itemOutputs('gtceu:mythrillic_metlide_dust')
@@ -33,14 +33,14 @@ ServerEvents.recipes(event => {
         .blastFurnaceTemp(7250)
         .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.electromagnetic_separator('mythrillic_metnide')
+    event.recipes.gtceu.electromagnetic_separator(id('mythrillic_metnide'))
         .itemInputs('gtceu:mythrillic_metlide_dust')
         .itemOutputs('gtceu:mythrillic_metnide_dust')
         .itemOutputs('2x gtceu:vanadium_dust')
         .duration(600)
         .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.large_chemical_reactor('mythrillic_hydride')
+    event.recipes.gtceu.large_chemical_reactor(id('mythrillic_hydride'))
         .itemInputs('gtceu:mythrillic_metnide_dust')
         .inputFluids('gtceu:hydrochloric_acid 12000')
         .itemOutputs('6x gtceu:mythrillic_hydride_dust')
@@ -48,7 +48,7 @@ ServerEvents.recipes(event => {
         .duration(520)
         .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.electric_blast_furnace('mythril')
+    event.recipes.gtceu.electric_blast_furnace(id('mythril'))
         .itemInputs('gtceu:mythrillic_hydride_dust')
         .itemInputs('gtceu:sulfur_dust')
         .itemOutputs('gtceu:mythril_dust')

--- a/kubejs/server_scripts/endgame content/nether_lines/nether_alloys.js
+++ b/kubejs/server_scripts/endgame content/nether_lines/nether_alloys.js
@@ -1,5 +1,5 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     const gas =['_gas','']
     const material = ['mythrolic_alloy','magmada_alloy','starium_alloy','seaborgium_palladium_enriched_estalt_flerovium_alloy']
@@ -40,7 +40,7 @@ ServerEvents.recipes(event => {
     });
 
     //Hellforge
-    event.recipes.gtceu.hellforge('mythrolic_alloy')
+    event.recipes.gtceu.hellforge(id('mythrolic_alloy'))
         .inputFluids('gtceu:mythril 720')
         .inputFluids('gtceu:osmium 288')
         .inputFluids('gtceu:tantalum 288')
@@ -53,7 +53,7 @@ ServerEvents.recipes(event => {
         .duration(7200)
         .EUt(GTValues.VHA[GTValues.UEV]);
 
-    event.recipes.gtceu.hellforge('magmada_alloy')
+    event.recipes.gtceu.hellforge(id('magmada_alloy'))
         .inputFluids('gtceu:adamantine 576')
         .inputFluids('gtceu:neutronium 144')
         .inputFluids('gtceu:tungsten 432')
@@ -66,7 +66,7 @@ ServerEvents.recipes(event => {
         .duration(6400)
         .EUt(GTValues.VHA[GTValues.UEV]);
 
-    event.recipes.gtceu.hellforge('starium_alloy')
+    event.recipes.gtceu.hellforge(id('starium_alloy'))
         .inputFluids('gtceu:nether_star_concentrate 576')
         .inputFluids('gtceu:estalt 288')
         .inputFluids('gtceu:pure_netherite 288')
@@ -79,7 +79,7 @@ ServerEvents.recipes(event => {
         .duration(5120)
         .EUt(GTValues.VHA[GTValues.UEV]);
 
-    event.recipes.gtceu.hellforge('seaborgium_palladium_enriched_estalt_flerovium_alloy')
+    event.recipes.gtceu.hellforge(id('seaborgium_palladium_enriched_estalt_flerovium_alloy'))
         .inputFluids('gtceu:seaborgium 576')
         .inputFluids('gtceu:palladium 1152')
         .inputFluids('gtceu:enriched_estalt 432')

--- a/kubejs/server_scripts/endgame content/post_wetware_circuits.js
+++ b/kubejs/server_scripts/endgame content/post_wetware_circuits.js
@@ -1,7 +1,7 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.assembly_line('wetware_based_runic_neuroloom')
+    event.recipes.gtceu.assembly_line(id('wetware_based_runic_neuroloom'))
         .itemInputs('2x gtceu:ancient_runicalium_frame', '4x gtceu:wetware_processor_mainframe', '64x gtceu:advanced_smd_diode', '64x gtceu:advanced_smd_capacitor', '64x gtceu:advanced_smd_transistor',
             '64x gtceu:advanced_smd_resistor', '64x gtceu:advanced_smd_inductor', '64x gtceu:polyether_ether_ketone_foil', '64x gtceu:polyether_ether_ketone_foil', '48x kubejs:qram_chip', 
             '24x gtceu:ruthenium_trinium_americium_neutronate_double_wire', '32x gtceu:tritanium_plate')
@@ -16,7 +16,7 @@ ServerEvents.recipes(event => {
         )
         .EUt(GTValues.VHA[GTValues.UEV]);
 
-    event.recipes.gtceu.circuit_assembler('draconic_wetware_circuit_board')
+    event.recipes.gtceu.circuit_assembler(id('draconic_wetware_circuit_board'))
         .itemInputs('32x gtceu:wetware_circuit_board', '4x gtceu:petri_dish', 'gtceu:uhv_electric_pump', 'gtceu:uhv_sensor', '2x #gtceu:circuits/zpm', '4x gtceu:stellarium_foil')
         .inputFluids('gtceu:sterilized_growth_medium 6000')
         .itemOutputs('32x kubejs:draconic_wetware_circuit_board')
@@ -24,7 +24,7 @@ ServerEvents.recipes(event => {
         .cleanroom(CleanroomType.CLEANROOM)
         .EUt(GTValues.VHA[GTValues.UV]);
 
-    // event.recipes.gtceu.circuit_assembler('draconic_neuro_processing_unit')
+    // event.recipes.gtceu.circuit_assembler(id('draconic_neuro_processing_unit'))
     //     .itemInputs('kubejs:draconic_wetware_printed_circuit_board', '8x kubejs:draconic_brain_matter_cells', '16x gtceu:polybenzimidazole_small_fluid_pipe', '16x gtceu:blue_steel_plate', '32x gtceu:silicone_rubber_foil', '16x gtceu:tritanium_bolt')
     //     .inputFluids('gtceu:sterilized_growth_medium 500')
     //     .itemOutputs('1x kubejs:draconic_neuro_processing_unit')
@@ -32,7 +32,7 @@ ServerEvents.recipes(event => {
     //     .cleanroom(CleanroomType.CLEANROOM)
     //     .EUt(GTValues.VHA[GTValues.UV]);
 
-    // event.recipes.gtceu.circuit_assembler('draconic_wetware_microchip_processor')
+    // event.recipes.gtceu.circuit_assembler(id('draconic_wetware_microchip_processor'))
     //     .itemInputs('kubejs:draconic_neuro_processing_unit', 'gtceu:crystal_cpu', 'gtceu:qbit_cpu_chip', '12x gtceu:advanced_smd_capacitor', '12x gtceu:advanced_smd_transistor', '16x gtceu:fine_yttrium_barium_cuprate_wire')
     //     .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 72')
     //     .itemOutputs('3x kubejs:draconic_wetware_microchip_processor')
@@ -40,7 +40,7 @@ ServerEvents.recipes(event => {
     //     .cleanroom(CleanroomType.CLEANROOM)
     //     .EUt(GTValues.VHA[GTValues.UV]);
 
-    // event.recipes.gtceu.circuit_assembler('draconic_wetware_microchip_processor_cheap')
+    // event.recipes.gtceu.circuit_assembler(id('draconic_wetware_microchip_processor_cheap'))
     //     .itemInputs('kubejs:draconic_neuro_processing_unit', 'gtceu:highly_advanced_soc', '16x gtceu:fine_yttrium_barium_cuprate_wire', '8x gtceu:iron_selenide_over_strontium_titanium_oxide_bolt')
     //     .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 72')
     //     .itemOutputs('6x kubejs:draconic_wetware_microchip_processor')
@@ -48,7 +48,7 @@ ServerEvents.recipes(event => {
     //     .cleanroom(CleanroomType.CLEANROOM)
     //     .EUt(GTValues.VHA[GTValues.UEV]);
 
-    // event.recipes.gtceu.circuit_assembler('draconic_processor')
+    // event.recipes.gtceu.circuit_assembler(id('draconic_processor'))
     //     .itemInputs('kubejs:draconic_neuro_processing_unit', 'gtceu:crystal_cpu', 'gtceu:qbit_cpu_chip', '12x gtceu:advanced_smd_capacitor', '12x gtceu:advanced_smd_transistor', '16x gtceu:fine_iron_selenide_over_strontium_titanium_oxide_wire')
     //     .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 72')
     //     .itemOutputs('2x kubejs:draconic_wetware_processor')
@@ -56,7 +56,7 @@ ServerEvents.recipes(event => {
     //     .cleanroom(CleanroomType.CLEANROOM)
     //     .EUt(GTValues.VHA[GTValues.UV]);
 
-    // event.recipes.gtceu.circuit_assembler('draconic_processor_assembly')
+    // event.recipes.gtceu.circuit_assembler(id('draconic_processor_assembly'))
     //     .itemInputs('kubejs:draconic_wetware_printed_circuit_board', '2x kubejs:draconic_wetware_processor', '8x gtceu:advanced_smd_inductor', '16x gtceu:advanced_smd_capacitor', '18x kubejs:qram_chip', '24x gtceu:fine_iron_selenide_over_strontium_titanium_oxide_wire')
     //     .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 144')
     //     .itemOutputs('2x kubejs:draconic_wetware_processor_assembly')
@@ -64,7 +64,7 @@ ServerEvents.recipes(event => {
     //     .cleanroom(CleanroomType.CLEANROOM)
     //     .EUt(GTValues.VHA[GTValues.UV]);
 
-    // event.recipes.gtceu.assembly_line('draconic_processor_supercomputer')
+    // event.recipes.gtceu.assembly_line(id('draconic_processor_supercomputer'))
     //     .itemInputs('kubejs:draconic_wetware_printed_circuit_board', '2x kubejs:draconic_wetware_processor_assembly', '16x gtceu:advanced_smd_diode', '8x kubejs:3d_nor_chip', '24x kubejs:qram_chip', '32x gtceu:fine_iron_selenide_over_strontium_titanium_oxide_wire', '64x gtceu:polyether_ether_ketone_foil', '4x gtceu:tritanium_plate')
     //     .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 1152')
     //     .itemOutputs('kubejs:draconic_wetware_processor_computer')
@@ -77,7 +77,7 @@ ServerEvents.recipes(event => {
     //     )
     //     .EUt(GTValues.VHA[GTValues.UHV]);
 
-    // event.recipes.gtceu.assembly_line('draconic_processor_mainframe')
+    // event.recipes.gtceu.assembly_line(id('draconic_processor_mainframe'))
     //     .itemInputs('2x gtceu:neutronium_frame', '2x kubejs:draconic_wetware_processor_computer', '48x gtceu:advanced_smd_diode', '48x gtceu:advanced_smd_capacitor', '48x gtceu:advanced_smd_transistor', '48x gtceu:advanced_smd_resistor', '48x gtceu:advanced_smd_inductor', '64x gtceu:polyether_ether_ketone_foil', '32x gtceu:polyether_ether_ketone_foil', '24x kubejs:qram_chip', '2x gtceu:ruthenium_trinium_americium_neutronate_double_wire', '16x gtceu:tritanium_plate')
     //     .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 2880', 'gtceu:polyether_ether_ketone 1152')
     //     .itemOutputs('kubejs:draconic_wetware_processor_mainframe')

--- a/kubejs/server_scripts/endgame content/recipes.js
+++ b/kubejs/server_scripts/endgame content/recipes.js
@@ -197,7 +197,7 @@ ServerEvents.recipes(event => {
             N: 'gtceu:small_neutronium_gear',
             Z: 'gtceu:zalloy_gear',
             C: 'gtceu:uhv_machine_hull'
-    });
+    }).id('start:shaped/uhv_rotor_holder');
 
     event.shaped(Item.of('gtceu:uev_rotor_holder'), [
         'NZN',
@@ -207,6 +207,6 @@ ServerEvents.recipes(event => {
         N: 'gtceu:small_mythrolic_alloy_gear',
         Z: 'gtceu:starium_alloy_gear',
         C: 'gtceu:uev_machine_hull'
-});
+    }).id('start:shaped/uev_rotor_holder');
 
 });

--- a/kubejs/server_scripts/endgame content/recipes.js
+++ b/kubejs/server_scripts/endgame content/recipes.js
@@ -1,132 +1,132 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.assembler('netherite_reinforced_mesh')
+    event.recipes.gtceu.assembler(id('netherite_reinforced_mesh'))
         .itemInputs('1x gtceu:carbon_fiber_mesh', '4x gtceu:netherite_rod', '1x minecraft:netherite_ingot')
         .inputFluids('gtceu:epoxy 288')
         .itemOutputs('kubejs:netherite_reinforced_mesh')
         .duration(100)
         .EUt(GTValues.VA[GTValues.IV]);
 
-    event.recipes.gtceu.mixer('new_soldering_alloy')
+    event.recipes.gtceu.mixer(id('new_soldering_alloy'))
         .itemInputs('14x gtceu:indium_dust', '3x gtceu:tin_dust', '2x gtceu:lead_dust', 'gtceu:cadmium_dust')
         .itemOutputs('20x gtceu:indium_tin_lead_cadmium_soldering_alloy_dust')
         .duration(400)
         .EUt(45000);
     
-    event.recipes.gtceu.chemical_reactor('strontium_oxide')
+    event.recipes.gtceu.chemical_reactor(id('strontium_oxide'))
         .itemInputs('gtceu:strontium_dust')
         .inputFluids('gtceu:oxygen 1000')
         .itemOutputs('2x gtceu:strontium_oxide_dust')
         .duration(360)
         .EUt(320);
 
-    event.recipes.gtceu.large_chemical_reactor('strontium_oxide')
+    event.recipes.gtceu.large_chemical_reactor(id('strontium_oxide'))
         .itemInputs('gtceu:strontium_dust')
         .inputFluids('gtceu:oxygen 1000')
         .itemOutputs('2x gtceu:strontium_oxide_dust')
         .duration(360)
         .EUt(320);
 
-    event.recipes.gtceu.chemical_reactor('titanium_oxide')
+    event.recipes.gtceu.chemical_reactor(id('titanium_oxide'))
         .itemInputs('gtceu:titanium_dust')
         .inputFluids('gtceu:oxygen 1000')
         .itemOutputs('2x gtceu:titanium_oxide_dust')
         .duration(360)
         .EUt(320);
 
-    event.recipes.gtceu.large_chemical_reactor('titanium_oxide')
+    event.recipes.gtceu.large_chemical_reactor(id('titanium_oxide'))
         .itemInputs('gtceu:titanium_dust')
         .inputFluids('gtceu:oxygen 1000')
         .itemOutputs('2x gtceu:titanium_oxide_dust')
         .duration(360)
         .EUt(320);
 
-    event.recipes.gtceu.mixer('strontium_titanium_oxide')
+    event.recipes.gtceu.mixer(id('strontium_titanium_oxide'))
         .itemInputs('gtceu:strontium_oxide_dust', 'gtceu:titanium_oxide_dust')
         .itemOutputs('2x gtceu:strontium_titanium_oxide_dust')
         .duration(400)
         .EUt(420);
 
-    event.recipes.gtceu.chemical_reactor('iron_selenide')
+    event.recipes.gtceu.chemical_reactor(id('iron_selenide'))
         .itemInputs('gtceu:iron_dust', 'gtceu:selenium_dust')
         .itemOutputs('gtceu:iron_selenide_dust')
         .duration(360)
         .EUt(1460);
 
-    event.recipes.gtceu.large_chemical_reactor('iron_selenide')
+    event.recipes.gtceu.large_chemical_reactor(id('iron_selenide'))
         .itemInputs('gtceu:iron_dust', 'gtceu:selenium_dust')
         .itemOutputs('gtceu:iron_selenide_dust')
         .duration(360)
         .EUt(1460);
 
-    event.recipes.gtceu.mixer('iron_selenide_over_strontium_titanium_oxide')
+    event.recipes.gtceu.mixer(id('iron_selenide_over_strontium_titanium_oxide'))
         .itemInputs('gtceu:iron_selenide_dust', 'gtceu:strontium_titanium_oxide_dust')
         .itemOutputs('2x gtceu:iron_selenide_over_strontium_titanium_oxide_dust')
         .duration(1200)
         .EUt(240000);
 
-    event.recipes.gtceu.large_chemical_reactor('iron_titanium_oxide')
+    event.recipes.gtceu.large_chemical_reactor(id('iron_titanium_oxide'))
         .itemInputs('15x gtceu:ferrosilite_dust', '6x gtceu:titanium_oxide_dust')
         .itemOutputs('gtceu:iron_titanium_oxide_dust', '9x gtceu:silicon_dioxide_dust')
         .duration(4800)
         .EUt(GTValues.VA[GTValues.LuV]);
 
-    event.recipes.gtceu.mixer('astatine_bis_tritelluride_cobo_selenium')
+    event.recipes.gtceu.mixer(id('astatine_bis_tritelluride_cobo_selenium'))
         .itemInputs('gtceu:astatine_dust', 'gtceu:bismuth_tritelluride_dust', '4x gtceu:cobalt_dust', 'gtceu:selenium_dust')
         .itemOutputs('gtceu:astatine_bis_tritelluride_cobo_selenium_dust')
         .duration(360)
         .circuit(3)
         .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.mixer('astatine_bis_tritelluride_cobo_selenium_over_iron_titanium_oxide_dust')
+    event.recipes.gtceu.mixer(id('astatine_bis_tritelluride_cobo_selenium_over_iron_titanium_oxide_dust'))
         .itemInputs('gtceu:astatine_bis_tritelluride_cobo_selenium_dust', 'gtceu:iron_titanium_oxide_dust')
         .itemOutputs('gtceu:astatine_bis_tritelluride_cobo_selenium_over_iron_titanium_oxide_dust')
         .duration(480)
         .circuit(1)
         .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.polarizer('magnetic_zapolgium')
+    event.recipes.gtceu.polarizer(id('magnetic_zapolgium'))
         .itemInputs('gtceu:zapolgium_ingot')
         .itemOutputs('gtceu:magnetic_zapolgium_ingot')
         .duration(80)
         .EUt(GTValues.VA[GTValues.UV]);
 
-    event.recipes.gtceu.polarizer('magnetic_pure_netherite')
+    event.recipes.gtceu.polarizer(id('magnetic_pure_netherite'))
         .itemInputs('gtceu:pure_netherite_ingot')
         .itemOutputs('gtceu:magnetic_pure_netherite_ingot')
         .duration(80)
         .EUt(GTValues.VA[GTValues.LuV])
 
-    event.recipes.gtceu.mixer('cerium_tritelluride')
+    event.recipes.gtceu.mixer(id('cerium_tritelluride'))
         .itemInputs('gtceu:cerium_dust', '3x gtceu:tellurium_dust')
         .itemOutputs('4x gtceu:cerium_tritelluride_dust')
         .duration(900)
         .circuit(4)
         .EUt((GTValues.VHA[GTValues.UHV]));
 
-    event.recipes.gtceu.mixer('polonium_bismide')
+    event.recipes.gtceu.mixer(id('polonium_bismide'))
         .itemInputs('gtceu:polonium_dust', 'gtceu:bismuth_dust')
         .itemOutputs('2x gtceu:polonium_bismide_dust')
         .duration(600)
         .circuit(2)
         .EUt((GTValues.VHA[GTValues.UEV]));
 
-    event.recipes.gtceu.assembler('zalloy_coil')
+    event.recipes.gtceu.assembler(id('zalloy_coil'))
         .itemInputs('8x gtceu:zalloy_double_wire', '8x gtceu:neutronium_foil')
         .inputFluids('gtceu:tritanium 144')
         .itemOutputs('kubejs:zalloy_coil_block')
         .duration(1000)
         .EUt(GTValues.VHA[GTValues.UHV]);
 
-    event.recipes.gtceu.assembler('magmada_alloy')
+    event.recipes.gtceu.assembler(id('magmada_alloy'))
         .itemInputs('8x gtceu:magmada_alloy_double_wire', '8x gtceu:lepton_coalescing_superalloy_foil')
         .inputFluids('gtceu:zalloy 144')
         .itemOutputs('kubejs:magmada_alloy_coil_block')
         .duration(1100)
         .EUt(GTValues.VHA[GTValues.UEV]);
 
-    event.recipes.gtceu.chemical_reactor('uepic_wafer')
+    event.recipes.gtceu.chemical_reactor(id('uepic_wafer'))
         .itemInputs('gtceu:uhpic_wafer','4x gtceu:silicon_carbide_over_bismuth_tritelluride_dust')
         .inputFluids('gtceu:neutronium 576')
         .itemOutputs('kubejs:uepic_wafer')
@@ -134,14 +134,14 @@ ServerEvents.recipes(event => {
         .EUt((GTValues.VA[GTValues.UV]))
         .cleanroom(CleanroomType.CLEANROOM);
 
-    event.recipes.gtceu.cutter('uepic_chip')
+    event.recipes.gtceu.cutter(id('uepic_chip'))
         .itemInputs('kubejs:uepic_wafer')
         .itemOutputs('2x kubejs:uepic_chip')
         .duration(900)
         .EUt((GTValues.VA[GTValues.UV]))
         .cleanroom(CleanroomType.STERILE_CLEANROOM);
 
-    event.recipes.gtceu.circuit_assembler('3d_nand_chip')
+    event.recipes.gtceu.circuit_assembler(id('3d_nand_chip'))
         .itemInputs('64x gtceu:nand_memory_chip', '12x gtceu:cerium_tritelluride_bolt', '2x #gtceu:circuits/iv')
         .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 216')
         .itemOutputs('6x kubejs:3d_nand_chip')
@@ -149,7 +149,7 @@ ServerEvents.recipes(event => {
         .EUt((GTValues.VA[GTValues.ZPM]))
         .cleanroom(CleanroomType.STERILE_CLEANROOM);
 
-    event.recipes.gtceu.circuit_assembler('3d_nor_chip')
+    event.recipes.gtceu.circuit_assembler(id('3d_nor_chip'))
         .itemInputs('64x gtceu:nor_memory_chip', '12x gtceu:cerium_tritelluride_bolt', '2x #gtceu:circuits/iv')
         .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 216')
         .itemOutputs('6x kubejs:3d_nor_chip')
@@ -157,7 +157,7 @@ ServerEvents.recipes(event => {
         .EUt((GTValues.VA[GTValues.ZPM]))
         .cleanroom(CleanroomType.STERILE_CLEANROOM);
 
-    event.recipes.gtceu.chemical_reactor('qram')
+    event.recipes.gtceu.chemical_reactor(id('qram'))
         .itemInputs('gtceu:ram_wafer','2x gtceu:silicon_carbide_over_bismuth_tritelluride_dust')
         .inputFluids('gtceu:radon 250')
         .itemOutputs('kubejs:qram_wafer')
@@ -165,14 +165,14 @@ ServerEvents.recipes(event => {
         .EUt((GTValues.VA[GTValues.UV]))
         .cleanroom(CleanroomType.STERILE_CLEANROOM);
 
-    event.recipes.gtceu.cutter('qram_chip')
+    event.recipes.gtceu.cutter(id('qram_chip'))
         .itemInputs('kubejs:qram_wafer')
         .itemOutputs('12x kubejs:qram_chip')
         .duration(900)
         .EUt((GTValues.VA[GTValues.UHV]))
         .cleanroom(CleanroomType.STERILE_CLEANROOM);
 
-    event.recipes.gtceu.chemical_plant('borax')
+    event.recipes.gtceu.chemical_plant(id('borax'))
         .itemInputs('12x gtceu:boron_dust', '6x gtceu:sodium_bisulfate_dust')
         .inputFluids('minecraft:water 39000')
         .itemOutputs('3x gtceu:borax_dust')
@@ -180,7 +180,7 @@ ServerEvents.recipes(event => {
         .duration(800)
         .EUt((GTValues.VA[GTValues.ZPM]))
 
-    event.recipes.gtceu.mixer('thorium_plut_duranide_241')
+    event.recipes.gtceu.mixer(id('thorium_plut_duranide_241'))
         .itemInputs('4x gtceu:thorium_dust', 'gtceu:duranium_dust', '3x gtceu:plutonium_241_dust')
         .itemOutputs('8x gtceu:thorium_plut_duranide_241_dust')
         .circuit(4)

--- a/kubejs/server_scripts/endgame content/runic.js
+++ b/kubejs/server_scripts/endgame content/runic.js
@@ -1,8 +1,9 @@
-
 ServerEvents.recipes(event => {
-    event.recipes.gtceu.mixer('screret_dust')
+    const id = global.id;
+
+    event.recipes.gtceu.mixer(id('runic_laser_source_base_dust'))
     .itemInputs('2x gtceu:naquadic_netherite_dust', '10x gtceu:tritanium_dust', '5x gtceu:trinium_dust')
-    .itemOutputs('17x gtceu:screret_runic_laser_source_base_dust')
+    .itemOutputs('17x gtceu:runic_laser_source_base_dust')
     .duration(12000)
     .EUt(GTValues.VHA[GTValues.UV]);
 
@@ -65,7 +66,7 @@ ServerEvents.recipes(event => {
 
     }
 
-    event.recipes.gtceu.assembler('runic_tablet')
+    event.recipes.gtceu.assembler(id('runic_tablet'))
         .itemInputs('kubejs:runic_tablet_1','kubejs:runic_tablet_2','kubejs:runic_tablet_3','kubejs:runic_tablet_4','kubejs:runic_tablet_5','kubejs:runic_tablet_6')
         .inputFluids('gtceu:naquadria 11520')
         .itemOutputs('kubejs:runic_tablet_complete')
@@ -88,42 +89,42 @@ ServerEvents.recipes(event => {
         .duration(600)
         .EUt(GTValues.VHA[GTValues.UV]);
     })
-    event.recipes.gtceu.runic_inscribe_manipulate('runic_energized_transportation_plating')
+    event.recipes.gtceu.runic_inscribe_manipulate(id('runic_energized_transportation_plating'))
         .itemInputs('3x kubejs:runic_engraved_plating', 'kubejs:runic_energized_plating', 'kubejs:runic_transportation_engraved_plating')
         .inputFluids('gtceu:dense_electron_akreyrium 1000', 'gtceu:dense_muon_akreyrium 1000', 'gtceu:dense_tau_akreyrium 1000')
         .itemOutputs('kubejs:runic_energized_transportation_plating')
         .duration(6000)
         .EUt(GTValues.VA[GTValues.UHV]);
 
-    event.recipes.gtceu.runic_inscribe_manipulate('runic_energized_pathway_plating')
+    event.recipes.gtceu.runic_inscribe_manipulate(id('runic_energized_pathway_plating'))
         .itemInputs('3x kubejs:runic_engraved_plating', 'kubejs:runic_energized_plating', 'kubejs:runic_pathway_engraved_plating')
         .inputFluids('gtceu:dense_electron_akreyrium 1000', 'gtceu:dense_muon_akreyrium 1000', 'gtceu:dense_tau_akreyrium 1000')
         .itemOutputs('kubejs:runic_energized_pathway_plating')
         .duration(6000)
         .EUt(GTValues.VA[GTValues.UHV]);
 
-    event.recipes.gtceu.runic_inscribe_manipulate('runic_pathway_casing')
+    event.recipes.gtceu.runic_inscribe_manipulate(id('runic_pathway_casing'))
         .itemInputs('gtceu:void_frame', '12x gtceu:dense_naquadah_plate', '6x kubejs:runic_pathway_engraved_plating')
         .inputFluids('gtceu:naquadria 2592', 'gtceu:utopian_akreyrium 864')
         .itemOutputs('kubejs:runic_pathway_casing')
         .duration(4000)
         .EUt(GTValues.VA[GTValues.UHV]);
 
-    event.recipes.gtceu.runic_inscribe_manipulate('runic_stabilization_casing')
+    event.recipes.gtceu.runic_inscribe_manipulate(id('runic_stabilization_casing'))
         .itemInputs('gtceu:void_frame', '12x gtceu:dense_naquadah_alloy_plate', '6x kubejs:runic_stabilization_plating')
         .inputFluids('gtceu:naquadria 2592', 'gtceu:utopian_akreyrium 864')
         .itemOutputs('kubejs:runic_stabilization_casing')
         .duration(4000)
         .EUt(GTValues.VA[GTValues.UHV]);
 
-    event.recipes.gtceu.runic_inscribe_manipulate('runic_transportation_casing')
+    event.recipes.gtceu.runic_inscribe_manipulate(id('runic_transportation_casing'))
         .itemInputs('gtceu:void_frame', '12x gtceu:dense_trinaquadalloy_plate', '6x kubejs:runic_transportation_engraved_plating')
         .inputFluids('gtceu:naquadria 2592', 'gtceu:utopian_akreyrium 864')
         .itemOutputs('kubejs:runic_transportation_casing')
         .duration(4000)
         .EUt(GTValues.VA[GTValues.UHV]);
 
-    event.recipes.gtceu.assembly_line('runic_inscribe_manipulate')
+    event.recipes.gtceu.assembly_line(id('runic_inscribe_manipulate'))
         .itemInputs('gtceu:ancient_runicalium_frame', '2x kubejs:uhv_catalyst_core','16x kubejs:uhv_high_strength_panel', '4x #gtceu:circuits/uev', '64x kubejs:uepic_chip', '64x kubejs:uepic_chip',
              '64x kubejs:uepic_chip', '8x gtceu:uhv_field_generator', '8x gtceu:uhv_electric_piston', '16x gtceu:uhv_emitter', '12x kubejs:uhv_precision_drive_mechanism','2x gtceu:uhv_fluid_regulator')
         .inputFluids('gtceu:hsse 25920', 'gtceu:hssg 25920', 'gtceu:hsss 25920')

--- a/kubejs/server_scripts/endgame content/uhv+_machines.js
+++ b/kubejs/server_scripts/endgame content/uhv+_machines.js
@@ -32,7 +32,7 @@ input.forEach(i=>{
     //Machines
     event.shaped(Item.of(`gtceu:${i.tier}_machine_casing`), 
         ['PPP','PWP','PPP'], 
-        {P: `gtceu:${i.main}_plate`,W: '#forge:tools/wrenches'});
+        {P: `gtceu:${i.main}_plate`,W: '#forge:tools/wrenches'}).id(`start:shaped/${i.tier}_machine_casing`);
     event.recipes.gtceu.assembler(`${i.tier}_machine_casing`) 
         .itemInputs(`8x gtceu:${i.main}_plate`) 
         .circuit(8) 
@@ -41,7 +41,7 @@ input.forEach(i=>{
         .EUt(16);
     event.shaped(Item.of(`gtceu:${i.tier}_machine_hull`),
         ['   ','LPL','CMC'],
-        {P: `gtceu:${i.main}_plate`,L: `gtceu:${i.plastic}_plate`,C: `gtceu:${i.cable}_single_cable`, M: `gtceu:${i.tier}_machine_casing`});
+        {P: `gtceu:${i.main}_plate`,L: `gtceu:${i.plastic}_plate`,C: `gtceu:${i.cable}_single_cable`, M: `gtceu:${i.tier}_machine_casing`}).id(`start:shaped/${i.tier}_machine_hull`);
     event.recipes.gtceu.assembler(`${i.tier}_machine_hull`) 
         .itemInputs(`gtceu:${i.tier}_machine_casing`, `2x gtceu:${i.cable}_single_cable`) 
         .inputFluids(`gtceu:${i.plastic} 288`) 
@@ -50,136 +50,136 @@ input.forEach(i=>{
         .EUt(16);
     event.shaped(Item.of(`gtceu:${i.tier}_electric_furnace`),
         ['IWI','WHW','CWC'], 
-        {I: `#gtceu:circuits/${i.tier}`, W: `gtceu:${i.wire}_double_wire`, C: `gtceu:${i.cable}_single_cable`, H: `gtceu:${i.tier}_machine_hull`});
+        {I: `#gtceu:circuits/${i.tier}`, W: `gtceu:${i.wire}_double_wire`, C: `gtceu:${i.cable}_single_cable`, H: `gtceu:${i.tier}_machine_hull`}).id(`start:shaped/${i.tier}_electric_furnace`);
     event.shaped(Item.of(`gtceu:${i.tier}_alloy_smelter`), 
         ['IWI','WHW','CWC'], 
-        {I: `#gtceu:circuits/${i.tier}`, W: `gtceu:${i.wire}_quadruple_wire`, C: `gtceu:${i.cable}_single_cable`, H: `gtceu:${i.tier}_machine_hull`});
+        {I: `#gtceu:circuits/${i.tier}`, W: `gtceu:${i.wire}_quadruple_wire`, C: `gtceu:${i.cable}_single_cable`, H: `gtceu:${i.tier}_machine_hull`}).id(`start:shaped/${i.tier}_alloy_smelter`);
     event.shaped(Item.of(`gtceu:${i.tier}_arc_furnace`), 
         ['CGC','IHI','PPP'], 
-        {I: `#gtceu:circuits/${i.tier}`, G: `gtceu:graphite_dust`, C: `gtceu:${i.cable}_quadruple_cable`, H: `gtceu:${i.tier}_machine_hull`, P: `gtceu:${i.main}_plate`});
+        {I: `#gtceu:circuits/${i.tier}`, G: `gtceu:graphite_dust`, C: `gtceu:${i.cable}_quadruple_cable`, H: `gtceu:${i.tier}_machine_hull`, P: `gtceu:${i.main}_plate`}).id(`start:shaped/${i.tier}_arc_furnace`);
     event.shaped(Item.of(`gtceu:${i.tier}_assembler`), 
         ['AIA','VHV','CIC'], 
-        {I: `#gtceu:circuits/${i.tier}`, C: `gtceu:${i.cable}_single_cable`, H: `gtceu:${i.tier}_machine_hull`, A: `gtceu:${i.tier}_robot_arm`, V: `gtceu:${i.tier}_conveyor_module`});
+        {I: `#gtceu:circuits/${i.tier}`, C: `gtceu:${i.cable}_single_cable`, H: `gtceu:${i.tier}_machine_hull`, A: `gtceu:${i.tier}_robot_arm`, V: `gtceu:${i.tier}_conveyor_module`}).id(`start:shaped/${i.tier}_assembler`);
     event.shaped(Item.of(`gtceu:${i.tier}_autoclave`), 
         ['PGP','PHP','IUI'], 
-        {I: `#gtceu:circuits/${i.tier}`, G: `gtceu:${i.glass}`, H: `gtceu:${i.tier}_machine_hull`,P: `gtceu:${i.main}_plate`, U: `gtceu:${i.tier}_electric_pump`});
+        {I: `#gtceu:circuits/${i.tier}`, G: `gtceu:${i.glass}`, H: `gtceu:${i.tier}_machine_hull`,P: `gtceu:${i.main}_plate`, U: `gtceu:${i.tier}_electric_pump`}).id(`start:shaped/${i.tier}_autoclave`);
     event.shaped(Item.of(`gtceu:${i.tier}_bender`), 
         ['SPS','IHI','MCM'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`, C: `gtceu:${i.cable}_single_cable`,P: `gtceu:${i.main}_plate`, M: `gtceu:${i.tier}_electric_motor`, S: `gtceu:${i.tier}_electric_piston`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`, C: `gtceu:${i.cable}_single_cable`,P: `gtceu:${i.main}_plate`, M: `gtceu:${i.tier}_electric_motor`, S: `gtceu:${i.tier}_electric_piston`}).id(`start:shaped/${i.tier}_bender`);
     event.shaped(Item.of(`gtceu:${i.tier}_brewery`), 
         ['GUG','CHC','ISI'], 
-        {G: `gtceu:${i.glass}`, I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`, C: `gtceu:${i.cable}_single_cable`, U: `gtceu:${i.tier}_electric_pump`, S: `gtceu:${i.wire}_spring`});
+        {G: `gtceu:${i.glass}`, I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`, C: `gtceu:${i.cable}_single_cable`, U: `gtceu:${i.tier}_electric_pump`, S: `gtceu:${i.wire}_spring`}).id(`start:shaped/${i.tier}_brewery`);
     event.shaped(Item.of(`gtceu:${i.tier}_canner`), 
         ['CUC','IHI','GGG'], 
-        {G: `gtceu:${i.glass}`, I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`, C: `gtceu:${i.cable}_single_cable`, U: `gtceu:${i.tier}_electric_pump`});
+        {G: `gtceu:${i.glass}`, I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`, C: `gtceu:${i.cable}_single_cable`, U: `gtceu:${i.tier}_electric_pump`}).id(`start:shaped/${i.tier}_canner`);
     event.shaped(Item.of(`gtceu:${i.tier}_centrifuge`), 
         ['IMI','CHC','IMI'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, M: `gtceu:${i.tier}_electric_motor`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, M: `gtceu:${i.tier}_electric_motor`}).id(`start:shaped/${i.tier}_centrifuge`);
     event.shaped(Item.of(`gtceu:${i.tier}_chemical_bath`), 
         ['VGC','UGV','IHI'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, U: `gtceu:${i.tier}_electric_pump`, V: `gtceu:${i.tier}_conveyor_module`, G: `gtceu:${i.glass}`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, U: `gtceu:${i.tier}_electric_pump`, V: `gtceu:${i.tier}_conveyor_module`, G: `gtceu:${i.glass}`}).id(`start:shaped/${i.tier}_chemical_bath`);
     event.shaped(Item.of(`gtceu:${i.tier}_chemical_reactor`), 
         ['ERE','CMC','IHI'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, E: `gtceu:${i.plastic}_large_fluid_pipe`, R: `gtceu:${i.main}_rotor`, M: `gtceu:${i.tier}_electric_motor`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, E: `gtceu:${i.plastic}_large_fluid_pipe`, R: `gtceu:${i.main}_rotor`, M: `gtceu:${i.tier}_electric_motor`}).id(`start:shaped/${i.tier}_chemical_reactor`);
     event.shaped(Item.of(`gtceu:${i.tier}_compressor`), 
         [' I ','SHS','CIC'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, S: `gtceu:${i.tier}_electric_piston`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, S: `gtceu:${i.tier}_electric_piston`}).id(`start:shaped/${i.tier}_compressor`);
     event.shaped(Item.of(`gtceu:${i.tier}_cutter`), 
         ['CIG','VHB','ICM'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, V: `gtceu:${i.tier}_conveyor_module`, M: `gtceu:${i.tier}_electric_motor`, G: `gtceu:${i.glass}`, B: `gtceu:${i.buzz}_buzz_saw_blade`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, V: `gtceu:${i.tier}_conveyor_module`, M: `gtceu:${i.tier}_electric_motor`, G: `gtceu:${i.glass}`, B: `gtceu:${i.buzz}_buzz_saw_blade`}).id(`start:shaped/${i.tier}_cutter`);
     event.shaped(Item.of(`gtceu:${i.tier}_distillery`), 
         ['GSG','IHI','CUC'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, G: `gtceu:${i.glass}`, S: `gtceu:${i.wire}_spring`, U: `gtceu:${i.tier}_electric_pump`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, G: `gtceu:${i.glass}`, S: `gtceu:${i.wire}_spring`, U: `gtceu:${i.tier}_electric_pump`}).id(`start:shaped/${i.tier}_distillery`);
     event.shaped(Item.of(`gtceu:${i.tier}_electrolyzer`), 
         ['WGW','WHW','ICI'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, G: `gtceu:${i.glass}`, W: `gtceu:${i.elctrlyzWire}_single_wire`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, G: `gtceu:${i.glass}`, W: `gtceu:${i.elctrlyzWire}_single_wire`}).id(`start:shaped/${i.tier}_electrolyzer`);
     event.shaped(Item.of(`gtceu:${i.tier}_electromagnetic_separator`), 
         ['VCW','CHG','ICW'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, G: `gtceu:${i.mag}_rod`, W: `gtceu:${i.cable}_octal_wire`, V: `gtceu:${i.tier}_conveyor_module`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, G: `gtceu:${i.mag}_rod`, W: `gtceu:${i.cable}_octal_wire`, V: `gtceu:${i.tier}_conveyor_module`}).id(`start:shaped/${i.tier}_electromagnetic_separator`);
     event.shaped(Item.of(`gtceu:${i.tier}_extractor`), 
         ['GIG','SHU','CIC'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, G: `gtceu:${i.glass}`, U: `gtceu:${i.tier}_electric_pump`, S: `gtceu:${i.tier}_electric_piston`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, G: `gtceu:${i.glass}`, U: `gtceu:${i.tier}_electric_pump`, S: `gtceu:${i.tier}_electric_piston`}).id(`start:shaped/${i.tier}_extractor`);
     event.shaped(Item.of(`gtceu:${i.tier}_extruder`), 
         ['WWI','SHE','WWI'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,S: `gtceu:${i.tier}_electric_piston`, W: `gtceu:${i.wire}_quadruple_wire`, E: `gtceu:${i.pipe}_normal_fluid_pipe`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,S: `gtceu:${i.tier}_electric_piston`, W: `gtceu:${i.wire}_quadruple_wire`, E: `gtceu:${i.pipe}_normal_fluid_pipe`}).id(`start:shaped/${i.tier}_extruder`);
     event.shaped(Item.of(`gtceu:${i.tier}_fermenter`), 
         ['CUC','GHG','CIC'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, G: `gtceu:${i.glass}`, U: `gtceu:${i.tier}_electric_pump`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, G: `gtceu:${i.glass}`, U: `gtceu:${i.tier}_electric_pump`}).id(`start:shaped/${i.tier}_fermenter`);
     event.shaped(Item.of(`gtceu:${i.tier}_fluid_heater`), 
         ['WGW','UHU','CIC'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, G: `gtceu:${i.glass}`, U: `gtceu:${i.tier}_electric_pump`, W: `gtceu:${i.wire}_quadruple_wire`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, G: `gtceu:${i.glass}`, U: `gtceu:${i.tier}_electric_pump`, W: `gtceu:${i.wire}_quadruple_wire`}).id(`start:shaped/${i.tier}_fluid_heater`);
     event.shaped(Item.of(`gtceu:${i.tier}_fluid_solidifier`), 
         ['UGU','CHC','IRI'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`,G: `gtceu:${i.glass}`,R: 'minecraft:chest', U: `gtceu:${i.tier}_electric_pump`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`,G: `gtceu:${i.glass}`,R: 'minecraft:chest', U: `gtceu:${i.tier}_electric_pump`}).id(`start:shaped/${i.tier}_fluid_solidifier`);
     event.shaped(Item.of(`gtceu:${i.tier}_forge_hammer`), 
         ['CSC','IHI','CRC'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`,S: `gtceu:${i.tier}_electric_piston`,R: 'minecraft:anvil'});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`,S: `gtceu:${i.tier}_electric_piston`,R: 'minecraft:anvil'}).id(`start:shaped/${i.tier}_forge_hammer`);
     event.shaped(Item.of(`gtceu:${i.tier}_forming_press`), 
         ['CSC','IHI','CSC'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`,S: `gtceu:${i.tier}_electric_piston`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`,S: `gtceu:${i.tier}_electric_piston`}).id(`start:shaped/${i.tier}_forming_press`);
     event.shaped(Item.of(`gtceu:${i.tier}_lathe`), 
         ['CIC','MHR','ICS'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, S: `gtceu:${i.tier}_electric_piston`, M: `gtceu:${i.tier}_electric_motor`, R: 'gtceu:tungsten_grinding_head'});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, S: `gtceu:${i.tier}_electric_piston`, M: `gtceu:${i.tier}_electric_motor`, R: 'gtceu:tungsten_grinding_head'}).id(`start:shaped/${i.tier}_lathe`);
     event.shaped(Item.of(`gtceu:${i.tier}_scanner`), 
         ['IEI','CHC','ISI'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, E: `gtceu:${i.tier}_emitter`, S: `gtceu:${i.tier}_sensor`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, E: `gtceu:${i.tier}_emitter`, S: `gtceu:${i.tier}_sensor`}).id(`start:shaped/${i.tier}_scanner`);
     event.shaped(Item.of(`gtceu:${i.tier}_mixer`), 
         ['GRG','GMG','IHI'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`, G: `gtceu:${i.glass}`, R: `gtceu:${i.main}_rotor`, M: `gtceu:${i.tier}_electric_motor`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`, G: `gtceu:${i.glass}`, R: `gtceu:${i.main}_rotor`, M: `gtceu:${i.tier}_electric_motor`}).id(`start:shaped/${i.tier}_mixer`);
     event.shaped(Item.of(`gtceu:${i.tier}_ore_washer`), 
         ['RGR','IMI','CHC'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, G: `gtceu:${i.glass}`, R: `gtceu:${i.main}_rotor`, M: `gtceu:${i.tier}_electric_motor`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, G: `gtceu:${i.glass}`, R: `gtceu:${i.main}_rotor`, M: `gtceu:${i.tier}_electric_motor`}).id(`start:shaped/${i.tier}_ore_washer`);
     event.shaped(Item.of(`gtceu:${i.tier}_packer`), 
         ['RIR','AHV','CIC'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, A: `gtceu:${i.tier}_robot_arm`, V: `gtceu:${i.tier}_conveyor_module`, R: 'minecraft:chest'});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, A: `gtceu:${i.tier}_robot_arm`, V: `gtceu:${i.tier}_conveyor_module`, R: 'minecraft:chest'}).id(`start:shaped/${i.tier}_packer`);
     event.shaped(Item.of(`gtceu:${i.tier}_polarizer`), 
         ['WGW','CHC','WGW'], 
-        {H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`,G: `gtceu:${i.mag}_rod`,W: `gtceu:${i.cable}_octal_wire`});
+        {H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`,G: `gtceu:${i.mag}_rod`,W: `gtceu:${i.cable}_octal_wire`}).id(`start:shaped/${i.tier}_polarizer`);
     event.shaped(Item.of(`gtceu:${i.tier}_laser_engraver`), 
         ['SES','IHI','CIC'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, E: `gtceu:${i.tier}_emitter`, S: `gtceu:${i.tier}_electric_piston`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, E: `gtceu:${i.tier}_emitter`, S: `gtceu:${i.tier}_electric_piston`}).id(`start:shaped/${i.tier}_laser_engraver`);
     event.shaped(Item.of(`gtceu:${i.tier}_sifter`), 
         ['CFC','SHS','IFI'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, F: `gtceu:item_filter`, S: `gtceu:${i.tier}_electric_piston`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, F: `gtceu:item_filter`, S: `gtceu:${i.tier}_electric_piston`}).id(`start:shaped/${i.tier}_sifter`);
     event.shaped(Item.of(`gtceu:${i.tier}_thermal_centrifuge`), 
         ['IMI','WHW','CMC'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, M: `gtceu:${i.tier}_electric_motor`, W: `gtceu:${i.wire}_quadruple_wire`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, M: `gtceu:${i.tier}_electric_motor`, W: `gtceu:${i.wire}_quadruple_wire`}).id(`start:shaped/${i.tier}_thermal_centrifuge`);
     event.shaped(Item.of(`gtceu:${i.tier}_wiremill`), 
         ['MCM','IHI','MCM'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, M: `gtceu:${i.tier}_electric_motor`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, M: `gtceu:${i.tier}_electric_motor`}).id(`start:shaped/${i.tier}_wiremill`);
     event.shaped(Item.of(`gtceu:${i.tier}_circuit_assembler`), 
         ['AIE','VHV','CIC'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, A: `gtceu:${i.tier}_robot_arm`, V: `gtceu:${i.tier}_conveyor_module`, E: `gtceu:${i.tier}_emitter`});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, A: `gtceu:${i.tier}_robot_arm`, V: `gtceu:${i.tier}_conveyor_module`, E: `gtceu:${i.tier}_emitter`}).id(`start:shaped/${i.tier}_circuit_assembler`);
     event.shaped(Item.of(`gtceu:${i.tier}_macerator`), 
         ['SMR','CCH','IIC'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, S: `gtceu:${i.tier}_electric_piston`, M: `gtceu:${i.tier}_electric_motor`, R: 'gtceu:tungsten_grinding_head'});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, S: `gtceu:${i.tier}_electric_piston`, M: `gtceu:${i.tier}_electric_motor`, R: 'gtceu:tungsten_grinding_head'}).id(`start:shaped/${i.tier}_macerator`);
     event.shaped(Item.of(`gtceu:${i.tier}_gas_collector`), 
         ['BFB','UHU','BIB'], 
-        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`, U: `gtceu:${i.tier}_electric_pump`, F: 'gtceu:fluid_filter', B: 'minecraft:iron_bars'});
+        {I: `#gtceu:circuits/${i.tier}`, H: `gtceu:${i.tier}_machine_hull`, U: `gtceu:${i.tier}_electric_pump`, F: 'gtceu:fluid_filter', B: 'minecraft:iron_bars'}).id(`start:shaped/${i.tier}_gas_collector`);
     event.shaped(Item.of(`gtceu:${i.tier}_rock_crusher`), 
         ['SMR','CHC','GGG'], 
-        {H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, S: `gtceu:${i.tier}_electric_piston`, M: `gtceu:${i.tier}_electric_motor`, R: 'gtceu:tungsten_grinding_head',G: `gtceu:${i.glass}`});
+        {H: `gtceu:${i.tier}_machine_hull`,C: `gtceu:${i.cable}_single_cable`, S: `gtceu:${i.tier}_electric_piston`, M: `gtceu:${i.tier}_electric_motor`, R: 'gtceu:tungsten_grinding_head',G: `gtceu:${i.glass}`}).id(`start:shaped/${i.tier}_rock_crusher`);
     event.shaped(Item.of(`gtceu:${i.tier}_muffler_hatch`), 
         ['HM','PR'], 
-        {H: `gtceu:${i.tier}_machine_hull`, M: `gtceu:${i.tier}_electric_motor`, P: `gtceu:${i.pipe}_normal_fluid_pipe`, R: `gtceu:${i.main}_rotor`});
+        {H: `gtceu:${i.tier}_machine_hull`, M: `gtceu:${i.tier}_electric_motor`, P: `gtceu:${i.pipe}_normal_fluid_pipe`, R: `gtceu:${i.main}_rotor`}).id(`start:shaped/${i.tier}_muffler_hatch`);
    
     const transformer = [{amps:'1a',cableThickness:'single'},{amps:'2a',cableThickness:'double'},{amps:'4a',cableThickness:'quadruple'},{amps:'16a',cableThickness:'hex'}]
     transformer.forEach(r => {
     event.shaped(Item.of(`gtceu:${i.tier}_transformer_${r.amps}`), 
         ['CLL','UH ','CLL'], 
-        {H: `gtceu:${i.tier}_machine_hull`,L: `gtceu:${i.cable}_${r.cableThickness}_cable`,U: `gtceu:${i.cable1up}_${r.cableThickness}_cable`,C: `${i.chip}_chip`});
+        {H: `gtceu:${i.tier}_machine_hull`,L: `gtceu:${i.cable}_${r.cableThickness}_cable`,U: `gtceu:${i.cable1up}_${r.cableThickness}_cable`,C: `${i.chip}_chip`}).id(`start:shaped/${i.tier}_transformer_${r.amps}`);
     });
 
     const buffer = [{size:'4x',cbleThickness:'quadruple'},{size:'8x',cbleThickness:'octal'},{size:'16x',cbleThickness:'hex'}]
     buffer.forEach(b=>{
     event.shaped(Item.of(`gtceu:${i.tier}_battery_buffer_${b.size}`), 
         ['   ','WCW','WHW'], 
-        {H: `gtceu:${i.tier}_machine_hull`,W: `gtceu:${i.wire}_${b.cbleThickness}_wire`, C: 'minecraft:chest'});
+        {H: `gtceu:${i.tier}_machine_hull`,W: `gtceu:${i.wire}_${b.cbleThickness}_wire`, C: 'minecraft:chest'}).id(`start:shaped/${i.tier}_battery_buffer_${b.size}`);
     });
 
     event.shaped(Item.of(`gtceu:${i.tier}_charger_4x`), 
         ['WRW','WHW','CIC'], 
-        {H: `gtceu:${i.tier}_machine_hull`,W: `gtceu:${i.wire}_quadruple_wire`, R: 'minecraft:chest',I: `#gtceu:circuits/${i.tier}`,C: `gtceu:${i.cable}_single_cable`});
+        {H: `gtceu:${i.tier}_machine_hull`,W: `gtceu:${i.wire}_quadruple_wire`, R: 'minecraft:chest',I: `#gtceu:circuits/${i.tier}`,C: `gtceu:${i.cable}_single_cable`}).id(`start:shaped/${i.tier}_charger_4x`);
 
     const energyIO = [{type:'input',powerTr:'single_cable',math4a:'4',laserType:'target',laserPart:'sensor'},{type:'output',powerTr:'spring',math4a:'1',laserType:'source',laserPart:'emitter'}]
     energyIO.forEach(e=>{
@@ -259,35 +259,35 @@ input.forEach(i=>{
     hatchScale.forEach(h=>{
     event.shaped(Item.of(`gtceu:uhv_input_hatch_${h.type}`), 
         ['P','H'], 
-        {H: `gtceu:uhv_input_hatch`, P: `gtceu:zapolgium_${h.pipe}_fluid_pipe`});
+        {H: `gtceu:uhv_input_hatch`, P: `gtceu:zapolgium_${h.pipe}_fluid_pipe`}).id(`start:shaped/uhv_input_hatch_${h.type}`);
     event.shaped(Item.of(`gtceu:uhv_input_hatch_${h.type}`), 
         ['S','H'], 
-        {S: `#forge:tools/screwdrivers`, H: `gtceu:uhv_output_hatch_${h.type}`});
+        {S: `#forge:tools/screwdrivers`, H: `gtceu:uhv_output_hatch_${h.type}`}).id(`start:shaped/uhv_input_hatch_${h.type}_flip`);
     event.shaped(Item.of(`gtceu:uhv_output_hatch_${h.type}`), 
         ['H','P'], 
-        {H: `gtceu:uhv_output_hatch`, P: `gtceu:zapolgium_${h.pipe}_fluid_pipe`});
+        {H: `gtceu:uhv_output_hatch`, P: `gtceu:zapolgium_${h.pipe}_fluid_pipe`}).id(`start:shaped/uhv_output_hatch_${h.type}`);
     event.shaped(Item.of(`gtceu:uhv_output_hatch_${h.type}`), 
         ['S','H'], 
-        {S: `#forge:tools/screwdrivers`, H: `gtceu:uhv_input_hatch_${h.type}`});
+        {S: `#forge:tools/screwdrivers`, H: `gtceu:uhv_input_hatch_${h.type}`}).id(`start:shaped/uhv_output_hatch_${h.type}_flip`);
     });
-    event.shaped(Item.of(`gtceu:uhv_dual_input_hatch`), 
+    event.shaped(Item.of('gtceu:uhv_dual_input_hatch'), 
         ['S','H'], 
-        {S: `#forge:tools/screwdrivers`, H: `gtceu:uhv_dual_output_hatch`});
-    event.shaped(Item.of(`gtceu:uhv_dual_output_hatch`), 
+        {S: '#forge:tools/screwdrivers', H: 'gtceu:uhv_dual_output_hatch'}).id('start:shaped/uhv_dual_input_hatch_flip');
+    event.shaped(Item.of('gtceu:uhv_dual_output_hatch'), 
         ['S','H'], 
-        {S: `#forge:tools/screwdrivers`, H: `gtceu:uhv_dual_input_hatch`});
-    event.shaped(Item.of(`gtceu:uhv_input_hatch`), 
+        {S: '#forge:tools/screwdrivers', H: 'gtceu:uhv_dual_input_hatch'}).id('start:shaped/uhv_dual_output_hatch_flip');
+    event.shaped(Item.of('gtceu:uhv_input_hatch'), 
         ['S','H'], 
-        {S: `#forge:tools/screwdrivers`, H: `gtceu:uhv_output_hatch`});
-    event.shaped(Item.of(`gtceu:uhv_output_hatch`), 
+        {S: '#forge:tools/screwdrivers', H: 'gtceu:uhv_output_hatch'}).id('start:shaped/uhv_input_hatch');
+    event.shaped(Item.of('gtceu:uhv_output_hatch'), 
         ['S','H'], 
-        {S: `#forge:tools/screwdrivers`, H: `gtceu:uhv_input_hatch`});
-    event.shaped(Item.of(`gtceu:uhv_input_bus`), 
+        {S: '#forge:tools/screwdrivers', H: 'gtceu:uhv_input_hatch'}).id('start:shaped/uhv_output_hatch');
+    event.shaped(Item.of('gtceu:uhv_input_bus'), 
         ['S','H'], 
-        {S: `#forge:tools/screwdrivers`, H: `gtceu:uhv_output_bus`});
-    event.shaped(Item.of(`gtceu:uhv_output_bus`), 
+        {S: '#forge:tools/screwdrivers', H: 'gtceu:uhv_output_bus'}).id('start:shaped/uhv_input_bus');
+    event.shaped(Item.of('gtceu:uhv_output_bus'), 
         ['S','H'], 
-        {S: `#forge:tools/screwdrivers`, H: `gtceu:uhv_input_bus`});
+        {S: '#forge:tools/screwdrivers', H: 'gtceu:uhv_input_bus'}).id('start:shaped/uhv_output_bus');
 
     //Parallel Hatches
     const ParaTier = [
@@ -298,7 +298,7 @@ input.forEach(i=>{
     ParaTier.forEach(t=>{
         event.shaped(Item.of(`start_core:${t.tier}_parallel_hatch`),
         ['SCE','CHC','BCB'], 
-        {S: `gtceu:${t.tier}_sensor`, E: `gtceu:${t.tier}_emitter`, C: `#gtceu:circuits/${t.tier1up}`, H: `gtceu:${t.tier}_machine_hull`, B: `gtceu:${t.cable}_double_cable`});
+        {S: `gtceu:${t.tier}_sensor`, E: `gtceu:${t.tier}_emitter`, C: `#gtceu:circuits/${t.tier1up}`, H: `gtceu:${t.tier}_machine_hull`, B: `gtceu:${t.cable}_double_cable`}).id(`start:shaped/${t.tier}_parallel_hatch`);
     
         event.recipes.gtceu.assembler(`${t.tier}_absolute_parallel_hatch`)
             .itemInputs(

--- a/kubejs/server_scripts/endgame content/uhv+_machines.js
+++ b/kubejs/server_scripts/endgame content/uhv+_machines.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     event.remove({not: {output: 'gtceu:uhv_ultimate_battery'},output: /gtceu:uhv.*/});
     event.remove({input: /gtceu:uhv.*/})
@@ -13,7 +14,7 @@ ServerEvents.recipes(event => {
     event.remove({output: /gtceu:max.*/})
     event.remove({input: /gtceu:max.*/})
 
-event.recipes.gtceu.packer('uhv_ultimate_battery')
+event.recipes.gtceu.packer(id('uhv_ultimate_battery'))
     .itemInputs('gtceu:uhv_ultimate_battery')
     .itemOutputs('gtceu:empty_tier_iii_battery','gtceu:max_battery')
     .circuit(2)

--- a/kubejs/server_scripts/endgame content/ultimate_multis/machines.js
+++ b/kubejs/server_scripts/endgame content/ultimate_multis/machines.js
@@ -1,7 +1,7 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.assembly_line('cyclonic_sifter')
+    event.recipes.gtceu.assembly_line(id('cyclonic_sifter'))
         .itemInputs('gtceu:uhv_machine_hull', '12x #gtceu:circuits/uhv','56x kubejs:uepic_chip', '16x gtceu:stellarium_gear',
             '8x gtceu:uhv_electric_pump', '4x gtceu:uhv_electric_motor', '2x gtceu:uhv_field_generator', '6x gtceu:pure_netherite_gear')
         .inputFluids('gtceu:polyether_ether_ketone 4000','gtceu:gritty_akreyrium 280000')
@@ -15,7 +15,7 @@ ServerEvents.recipes(event => {
         )
         .EUt(GTValues.VA[GTValues.UV]); 
 
-    event.recipes.gtceu.assembly_line('manifold_centrifuge')
+    event.recipes.gtceu.assembly_line(id('manifold_centrifuge'))
         .itemInputs(
             'gtceu:uhv_machine_hull', '24x #gtceu:circuits/uhv','64x kubejs:uepic_chip', '32x kubejs:uepic_chip',
             '18x gtceu:double_thacoloy_nq_42x_plate','16x gtceu:neutronium_large_fluid_pipe','16x gtceu:pure_netherite_foil',
@@ -31,7 +31,7 @@ ServerEvents.recipes(event => {
         )
         .EUt(GTValues.VA[GTValues.UV]); 
 
-    event.recipes.gtceu.assembly_line('injection_mixer')
+    event.recipes.gtceu.assembly_line(id('injection_mixer'))
         .itemInputs(
             'gtceu:uhv_machine_hull', '24x #gtceu:circuits/uhv', '12x gtceu:double_astrenalloy_nx_plate','64x kubejs:uepic_chip','8x gtceu:neutronium_huge_fluid_pipe',
             '4x gtceu:pure_netherite_rotor','4x gtceu:small_zalloy_gear','6x gtceu:uhv_electric_pump')
@@ -46,7 +46,7 @@ ServerEvents.recipes(event => {
         )
         .EUt(GTValues.VA[GTValues.UV]); 
 
-    event.recipes.gtceu.assembly_line('molten_destabilizer')
+    event.recipes.gtceu.assembly_line(id('molten_destabilizer'))
         .itemInputs(
             'gtceu:uhv_machine_hull', '6x #gtceu:circuits/uhv', '4x gtceu:dense_naquadria_plate','64x gtceu:uhpic_chip','4x gtceu:neutronium_huge_fluid_pipe',
             '4x gtceu:pure_netherite_rotor','4x gtceu:small_pure_netherite_gear','24x gtceu:uv_electric_pump')

--- a/kubejs/server_scripts/endgame content/ultimate_multis/material_lines.js
+++ b/kubejs/server_scripts/endgame content/ultimate_multis/material_lines.js
@@ -1,5 +1,5 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     // Boron Nitride (Mixing Casing)
     event.recipes.gtceu.chemical_plant("boron_nitride")
@@ -9,14 +9,14 @@ ServerEvents.recipes(event => {
         .duration(600)
         .EUt(100000);
 
-    event.recipes.gtceu.large_chemical_reactor('boron_trioxide')
+    event.recipes.gtceu.large_chemical_reactor(id('boron_trioxide'))
         .itemInputs('2x gtceu:boron_dust')
         .inputFluids('gtceu:oxygen 3000')
         .itemOutputs('1x gtceu:boron_trioxide_dust')
         .duration(100)
         .EUt(GTValues.VHA[GTValues.IV])
 
-    event.recipes.gtceu.large_chemical_reactor('boron_nitride')
+    event.recipes.gtceu.large_chemical_reactor(id('boron_nitride'))
         .itemInputs('1x gtceu:boron_trioxide_dust')
         .inputFluids('gtceu:ammonia 2000')
         .itemOutputs('2x gtceu:boron_nitride_dust')
@@ -32,14 +32,14 @@ ServerEvents.recipes(event => {
         .duration(900)
         .EUt(100000);
 
-    event.recipes.gtceu.large_chemical_reactor('tungsten_trioxide')
+    event.recipes.gtceu.large_chemical_reactor(id('tungsten_trioxide'))
         .itemInputs('1x gtceu:tungsten_dust')
         .inputFluids('gtceu:oxygen 3000')
         .itemOutputs('1x gtceu:tungsten_trioxide_dust')
         .duration(400)
         .EUt(GTValues.VHA[GTValues.LuV])
 
-    event.recipes.gtceu.large_chemical_reactor('thallium_tungstate')
+    event.recipes.gtceu.large_chemical_reactor(id('thallium_tungstate'))
         .itemInputs('2x gtceu:thallium_dust', '1x gtceu:tungsten_trioxide_dust')
         .inputFluids('gtceu:oxygen 1000')
         .itemOutputs('1x gtceu:thallium_tungstate_dust')

--- a/kubejs/server_scripts/gregification/ae2/ae2.js
+++ b/kubejs/server_scripts/gregification/ae2/ae2.js
@@ -1,7 +1,7 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.macerator('fluix_dust')
+    event.recipes.gtceu.macerator(id('fluix_dust'))
         .itemInputs('ae2:fluix_crystal')
         .itemOutputs('ae2:fluix_dust')
         .duration(88)
@@ -17,84 +17,84 @@ ServerEvents.recipes(event => {
         'ae2:certus_quartz_crystal'
     );
 
-    event.recipes.gtceu.polarizer('charged_certus')
+    event.recipes.gtceu.polarizer(id('charged_certus'))
         .itemInputs('ae2:certus_quartz_crystal')
         .itemOutputs('ae2:charged_certus_quartz_crystal')
         .duration(200)
         .EUt(10);
 
-    event.recipes.gtceu.mixer('fluix_crystal')
+    event.recipes.gtceu.mixer(id('fluix_crystal'))
         .itemInputs('ae2:charged_certus_quartz_crystal', 'minecraft:redstone', 'minecraft:quartz')
         .inputFluids('minecraft:water 250')
         .itemOutputs('2x ae2:fluix_crystal')
         .duration(200)
         .EUt(65);
 
-    event.recipes.gtceu.alloy_smelter('printed_calculation_circuit')
+    event.recipes.gtceu.alloy_smelter(id('printed_calculation_circuit'))
         .itemInputs('gtceu:certus_quartz_plate')
         .notConsumable('ae2:calculation_processor_press')
         .itemOutputs('ae2:printed_calculation_processor')
         .duration(200)
         .EUt(65);
 
-     event.recipes.gtceu.alloy_smelter('printed_engineering_circuit')
+     event.recipes.gtceu.alloy_smelter(id('printed_engineering_circuit'))
         .itemInputs('gtceu:diamond_plate')
         .notConsumable('ae2:engineering_processor_press')
         .itemOutputs('ae2:printed_engineering_processor')
         .duration(200)
         .EUt(65);
 
-    event.recipes.gtceu.alloy_smelter('printed_logic_circuit')
+    event.recipes.gtceu.alloy_smelter(id('printed_logic_circuit'))
         .itemInputs('#forge:plates/gold')
         .notConsumable('ae2:logic_processor_press')
         .itemOutputs('ae2:printed_logic_processor')
         .duration(200)
         .EUt(65);
 
-    event.recipes.gtceu.alloy_smelter('printed_silicon')
+    event.recipes.gtceu.alloy_smelter(id('printed_silicon'))
         .itemInputs('gtceu:silicon_plate')
         .notConsumable('ae2:silicon_press')
         .itemOutputs('ae2:printed_silicon')
         .duration(200)
         .EUt(65);
 
-    event.recipes.gtceu.alloy_smelter('calculation_circuit')
+    event.recipes.gtceu.alloy_smelter(id('calculation_circuit'))
         .itemInputs('ae2:printed_calculation_processor', 'ae2:printed_silicon')
         .itemOutputs('ae2:calculation_processor')
         .duration(200)
         .EUt(65);
 
-    event.recipes.gtceu.alloy_smelter('engineering_circuit')
+    event.recipes.gtceu.alloy_smelter(id('engineering_circuit'))
         .itemInputs('ae2:printed_engineering_processor', 'ae2:printed_silicon')
         .itemOutputs('ae2:engineering_processor')
         .duration(200)
         .EUt(65);
 
-    event.recipes.gtceu.alloy_smelter('logic_circuit')
+    event.recipes.gtceu.alloy_smelter(id('logic_circuit'))
         .itemInputs('ae2:printed_logic_processor', 'ae2:printed_silicon')
         .itemOutputs('ae2:logic_processor')
         .duration(200)
         .EUt(65);
 
-    event.recipes.gtceu.forming_press('press_calculation')
+    event.recipes.gtceu.forming_press(id('press_calculation'))
         .itemInputs('gtceu:double_star_steel_plate', 'ae2:certus_quartz_crystal')
         .itemOutputs('ae2:calculation_processor_press')
         .duration(600)
         .EUt(65);
 
-    event.recipes.gtceu.forming_press('press_engineering')
+    event.recipes.gtceu.forming_press(id('press_engineering'))
         .itemInputs('gtceu:double_star_steel_plate', 'minecraft:diamond')
         .itemOutputs('ae2:engineering_processor_press')
         .duration(600)
         .EUt(65);
 
-    event.recipes.gtceu.forming_press('press_logic')
+    event.recipes.gtceu.forming_press(id('press_logic'))
         .itemInputs('gtceu:double_star_steel_plate', 'minecraft:gold_ingot')
         .itemOutputs('ae2:logic_processor_press')
         .duration(600)
         .EUt(65);
 
-    event.recipes.gtceu.forming_press('silicon_logic')
+    event.recipes.gtceu.forming_press(id('silicon_logic'))
         .itemInputs('gtceu:double_star_steel_plate', 'gtceu:silicon_dust')
         .itemOutputs('ae2:silicon_press')
         .duration(600)
@@ -155,19 +155,19 @@ ServerEvents.recipes(event => {
         '#gtceu:circuits/uhv'
     );
 
-    event.recipes.gtceu.wiremill('quartz_fiber_cables')
+    event.recipes.gtceu.wiremill(id('quartz_fiber_cables'))
         .itemInputs('minecraft:quartz')
         .itemOutputs('3x ae2:quartz_fiber')
         .duration(80)
         .EUt(16);
 
-    event.recipes.gtceu.wiremill('fluix_glass_cables')
+    event.recipes.gtceu.wiremill(id('fluix_glass_cables'))
         .itemInputs('ae2:fluix_crystal')
         .itemOutputs('4x ae2:fluix_glass_cable')
         .duration(80)
         .EUt(16);
 
-    event.recipes.gtceu.alloy_smelter('star_steel')
+    event.recipes.gtceu.alloy_smelter(id('star_steel'))
         .itemInputs('ae2:sky_dust', '2x gtceu:steel_ingot')
         .itemOutputs('3x gtceu:star_steel_ingot')
         .duration(160)

--- a/kubejs/server_scripts/gregification/ae2/ae2.js
+++ b/kubejs/server_scripts/gregification/ae2/ae2.js
@@ -108,7 +108,7 @@ ServerEvents.recipes(event => {
         C: 'gtceu:star_steel_frame',
         F: 'ae2:fluix_crystal',
         H: 'ae2:engineering_processor'
-    });
+    }).id('start:shaped/me_controller');
 
     event.replaceInput({output: 'ae2:cell_component_4k'}, 
         'ae2:calculation_processor',
@@ -183,7 +183,7 @@ ServerEvents.recipes(event => {
             H: 'gtceu:star_steel_plate',
             J: 'ae2:annihilation_core',
             B: 'ae2:formation_core'
-        });
+        }).id('start:shaped/molecular_assembler');
 
     event.shaped(Item.of('ae2:pattern_provider'), [
             'HFH',
@@ -194,7 +194,7 @@ ServerEvents.recipes(event => {
             H: 'gtceu:star_steel_plate',
             J: 'ae2:annihilation_core',
             B: 'ae2:formation_core'
-        });
+        }).id('start:shaped/pattern_provider');
 
     event.shaped(Item.of('ae2:crafting_unit'), [
             'HFH',
@@ -205,7 +205,7 @@ ServerEvents.recipes(event => {
             F: 'ae2:calculation_processor',
             H: 'gtceu:star_steel_plate',
             B: 'ae2:fluix_glass_cable'
-        });
+        }).id('start:shaped/crafting_unit');
 
     event.shaped(Item.of('ae2:energy_acceptor'), [
             'HFH',
@@ -215,7 +215,7 @@ ServerEvents.recipes(event => {
             C: '#forge:ingots/copper',
             F: 'ae2:quartz_glass',
             H: 'gtceu:star_steel_plate',
-        });
+        }).id('start:shaped/energy_acceptor');
 
     event.shaped(Item.of('ae2:interface'), [
             'HFH',
@@ -226,7 +226,7 @@ ServerEvents.recipes(event => {
             H: 'gtceu:star_steel_plate',
             J: 'ae2:annihilation_core',
             B: 'ae2:formation_core'
-        });
+        }).id('start:shaped/me_interface');
 
     event.shaped(Item.of('ae2:drive'), [
             'HFH',
@@ -236,7 +236,7 @@ ServerEvents.recipes(event => {
             F: 'ae2:engineering_processor',
             H: 'gtceu:star_steel_plate',
             B: 'ae2:fluix_glass_cable'
-        });
+        }).id('start:shaped/me_drive');
 
     event.shaped(Item.of('ae2:condenser'), [
             'HFH',
@@ -246,7 +246,7 @@ ServerEvents.recipes(event => {
             C: 'ae2:fluix_dust',
             F: '#forge:glass',
             H: 'gtceu:star_steel_plate',
-        });
+        }).id('start:shaped/me_condenser');
 
     event.shaped(Item.of('ae2:cell_workbench'), [
             'ABA',
@@ -257,7 +257,7 @@ ServerEvents.recipes(event => {
             B: 'ae2:calculation_processor',
             C: 'gtceu:star_steel_plate',
             E: '#forge:chests/wooden'
-        });
+        }).id('start:shaped/cell_workbench');
 
     event.shaped(Item.of('ae2:spatial_io_port'), [
             'AAA',
@@ -269,7 +269,7 @@ ServerEvents.recipes(event => {
             C: 'ae2:io_port',
             D: 'gtceu:star_steel_plate',
             E: 'ae2:engineering_processor'
-        });
+        }).id('start:shaped/spatial_io_port');
 
     event.shaped(Item.of('ae2:io_port'), [
             'AAA',
@@ -281,7 +281,7 @@ ServerEvents.recipes(event => {
             C: 'ae2:fluix_glass_cable',
             D: 'gtceu:star_steel_plate',
             E: 'ae2:engineering_processor'
-        });
+        }).id('start:shaped/io_port');
 
     event.shaped(Item.of('ae2:chest'), [
             'ABA',
@@ -293,7 +293,7 @@ ServerEvents.recipes(event => {
             C: 'ae2:fluix_glass_cable',
             D: 'gtceu:star_steel_plate',
             E: '#forge:ingots/copper'
-        });
+        }).id('start:shaped/me_chest');
 
     //MEGA cells
     event.replaceInput({input: 'megacells:accumulation_processor'}, 

--- a/kubejs/server_scripts/gregification/ae2/ae2_things.js
+++ b/kubejs/server_scripts/gregification/ae2/ae2_things.js
@@ -1,10 +1,10 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     //AncientSkies idea
     //Uncrafting Crafting Storage/Storage Cells
     function applEn(ae2) {
-        event.recipes.gtceu.packer(`start:crafting_storage_${ae2}k_uncrafting`)
+        event.recipes.gtceu.packer(id(`crafting_storage_${ae2}k_uncrafting`))
             .itemInputs(`ae2:${ae2}k_crafting_storage`)
             .itemOutputs(`ae2:cell_component_${ae2}k`)
             .itemOutputs('ae2:crafting_unit')
@@ -12,7 +12,7 @@ ServerEvents.recipes(event => {
             .duration(100)
             .EUt(7);
 
-        event.recipes.gtceu.packer(`start:storage_cell_${ae2}k_uncrafting`)
+        event.recipes.gtceu.packer(id(`storage_cell_${ae2}k_uncrafting`))
             .itemInputs(`ae2:item_storage_cell_${ae2}k`)
             .itemOutputs(`ae2:cell_component_${ae2}k`)
             .itemOutputs('ae2:item_cell_housing')
@@ -20,7 +20,7 @@ ServerEvents.recipes(event => {
             .duration(100)
             .EUt(7);
 
-        event.recipes.gtceu.packer(`start:fluid_cell${ae2}k_uncrafting`)
+        event.recipes.gtceu.packer(id(`fluid_cell${ae2}k_uncrafting`))
             .itemInputs(`ae2:fluid_storage_cell_${ae2}k`)
             .itemOutputs(`ae2:cell_component_${ae2}k`)
             .itemOutputs('ae2:fluid_cell_housing')
@@ -36,7 +36,7 @@ ServerEvents.recipes(event => {
     
     function ae2mega(ae2a) {
 
-        event.recipes.gtceu.packer(`start:crafting_storage_${ae2a}_uncrafting`)
+        event.recipes.gtceu.packer(id(`crafting_storage_${ae2a}_uncrafting`))
             .itemInputs(`megacells:${ae2a}m_crafting_storage`)
             .itemOutputs(`megacells:cell_component_${ae2a}m`)
             .itemOutputs('ae2:crafting_unit')
@@ -44,7 +44,7 @@ ServerEvents.recipes(event => {
             .duration(100)
             .EUt(7);
 
-        event.recipes.gtceu.packer(`start:storage_cell_${ae2a}_uncrafting`)
+        event.recipes.gtceu.packer(id(`storage_cell_${ae2a}_uncrafting`))
             .itemInputs(`megacells:item_storage_cell_${ae2a}m`)
             .itemOutputs(`megacells:cell_component_${ae2a}m`)
             .itemOutputs('megacells:mega_item_cell_housing')
@@ -52,7 +52,7 @@ ServerEvents.recipes(event => {
             .duration(100)
             .EUt(7);
 
-        event.recipes.gtceu.packer(`start:fluid_cell${ae2a}_uncrafting`)
+        event.recipes.gtceu.packer(id(`fluid_cell${ae2a}_uncrafting`))
             .itemInputs(`megacells:fluid_storage_cell_${ae2a}m`)
             .itemOutputs(`megacells:cell_component_${ae2a}m`)
             .itemOutputs('megacells:mega_fluid_cell_housing')
@@ -74,14 +74,14 @@ ServerEvents.recipes(event => {
         function dyingCable(type) {
 
 
-            event.recipes.gtceu.chemical_bath(`start:${colour}_fluix_${type}`)
+            event.recipes.gtceu.chemical_bath(id(`${colour}_fluix_${type}`))
                 .itemInputs(`8x ae2:fluix_${type}`)
                 .inputFluids(`gtceu:${colour}_dye 36`)
                 .itemOutputs(`8x ae2:${colour}_${type}`)
                 .duration(280)
                 .EUt(100);
 
-            event.recipes.gtceu.chemical_bath(`start:${colour}_uncoloured_${type}`)
+            event.recipes.gtceu.chemical_bath(id(`${colour}_uncoloured_${type}`))
                 .itemInputs(`8x ae2:${colour}_${type}`)
                 .inputFluids('gtceu:chlorine 100')
                 .itemOutputs(`8x ae2:fluix_${type}`)
@@ -118,7 +118,7 @@ ServerEvents.recipes(event => {
     //Coating ae2 cables with rubber for covered cable
     function rubberType(rubber, amount) {
 
-        event.recipes.gtceu.assembler(`start:${rubber.path}_covered_cable`)
+        event.recipes.gtceu.assembler(id(`${rubber.path}_covered_cable`))
             .itemInputs(`ae2:fluix_glass_cable`)
             .inputFluids(`${rubber} ${amount}`)
             .itemOutputs(`ae2:fluix_covered_cable`)
@@ -139,7 +139,7 @@ ServerEvents.recipes(event => {
     function fluidtype(lube, mb) {
         function metaltype(wire, amount) {
 
-            event.recipes.gtceu.cutter(`start:${wire}_${lube.path}_cable_anchor`)
+            event.recipes.gtceu.cutter(id(`${wire}_${lube.path}_cable_anchor`))
                 .itemInputs(`gtceu:${wire}_single_wire`)
                 .inputFluids(`${lube} ${mb}`)
                 .itemOutputs(`${amount}x ae2:cable_anchor`)

--- a/kubejs/server_scripts/gregification/create.js
+++ b/kubejs/server_scripts/gregification/create.js
@@ -1,55 +1,55 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.polarizer('energized_gold')
+    event.recipes.gtceu.polarizer(id('energized_gold'))
         .itemInputs('minecraft:gold_ingot')
         .itemOutputs('create_new_age:overcharged_gold')
         .duration(32)
         .EUt(16)
 
-    event.recipes.gtceu.polarizer('energized_iron')
+    event.recipes.gtceu.polarizer(id('energized_iron'))
         .itemInputs('gtceu:magnetic_iron_ingot')
         .itemOutputs('create_new_age:overcharged_iron')
         .duration(16)
         .EUt(16)
 
-    event.recipes.gtceu.polarizer('energized_diamond')
+    event.recipes.gtceu.polarizer(id('energized_diamond'))
         .itemInputs('minecraft:diamond')
         .itemOutputs('create_new_age:overcharged_diamond')
         .duration(160)
         .EUt(16)
 
-    event.recipes.gtceu.bender('overcharged_iron_plate')
+    event.recipes.gtceu.bender(id('overcharged_iron_plate'))
         .itemInputs('create_new_age:overcharged_iron')
         .itemOutputs('create_new_age:overcharged_iron_sheet')
         .duration(48)
         .EUt(24);
 
-    event.recipes.gtceu.bender('overcharged_gold_plate')
+    event.recipes.gtceu.bender(id('overcharged_gold_plate'))
         .itemInputs('create_new_age:overcharged_gold')
         .itemOutputs('create_new_age:overcharged_golden_sheet')
         .duration(196)
         .EUt(24);
 
-    event.recipes.gtceu.wiremill('copper_wire')
+    event.recipes.gtceu.wiremill(id('copper_wire'))
         .itemInputs('gtceu:copper_plate')
         .itemOutputs('4x create_new_age:copper_wire')
         .duration(189)
         .EUt(7);
 
-    event.recipes.gtceu.wiremill('iron_wire')
+    event.recipes.gtceu.wiremill(id('iron_wire'))
         .itemInputs('create_new_age:overcharged_iron_sheet')
         .itemOutputs('4x create_new_age:overcharged_iron_wire')
         .duration(321)
         .EUt(7);
 
-    event.recipes.gtceu.wiremill('gold_wire')
+    event.recipes.gtceu.wiremill(id('gold_wire'))
         .itemInputs('create_new_age:overcharged_golden_sheet')
         .itemOutputs('4x create_new_age:overcharged_golden_wire')
         .duration(588)
         .EUt(7);
 
-    event.recipes.gtceu.wiremill('diamond_wire')
+    event.recipes.gtceu.wiremill(id('diamond_wire'))
         .itemInputs('create_new_age:overcharged_diamond')
         .itemOutputs('2x create_new_age:overcharged_diamond_wire')
         .duration(764)

--- a/kubejs/server_scripts/gregification/create.js
+++ b/kubejs/server_scripts/gregification/create.js
@@ -56,8 +56,8 @@ ServerEvents.recipes(event => {
         .EUt(7);
 
     event.remove({output: 'create:andesite_alloy'});
-    event.shapeless('2x create:andesite_alloy', ['2x minecraft:iron_nugget', '2x exnihilosequentia:andesite_pebble']);
-    event.shapeless('16x create:andesite_alloy', ['4x minecraft:andesite', '5x minecraft:iron_nugget']);
+    event.shapeless('2x create:andesite_alloy', ['2x minecraft:iron_nugget', '2x exnihilosequentia:andesite_pebble']).id('start:shapeless/andesite_alloy_pebble');
+    event.shapeless('16x create:andesite_alloy', ['4x minecraft:andesite', '5x minecraft:iron_nugget']).id('start:shapeless/andesite_alloy_block');
     
     event.shaped('create:precision_mechanism', [
         'NBN',
@@ -68,6 +68,6 @@ ServerEvents.recipes(event => {
         B: 'create:large_cogwheel',
         S: 'create:cogwheel',
         P: 'gtceu:gold_plate'
-    });
+    }).id('start:shaped/precision_mechanism');
    
 });

--- a/kubejs/server_scripts/gregification/exnihilo.js
+++ b/kubejs/server_scripts/gregification/exnihilo.js
@@ -1,26 +1,26 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.forge_hammer('cobble_to_sand')
+    event.recipes.gtceu.forge_hammer(id('cobble_to_sand'))
         .itemInputs('minecraft:cobblestone')
         .itemOutputs('minecraft:gravel')
         .duration(10)
         .EUt(16);
 
-    event.recipes.gtceu.forge_hammer('gravel_to_sand')
+    event.recipes.gtceu.forge_hammer(id('gravel_to_sand'))
         .itemInputs('minecraft:gravel')
         .itemOutputs('minecraft:sand')
         .duration(10)
         .EUt(16);
 
-    event.recipes.gtceu.forge_hammer('sand_to_dust')
+    event.recipes.gtceu.forge_hammer(id('sand_to_dust'))
         .itemInputs('minecraft:sand')
         .itemOutputs('exnihilosequentia:dust')
         .duration(10)
         .EUt(16);
 
     event.remove({id: 'gtceu:forge_hammer/cobblestone_to_gravel', input: 'minecraft:blackstone'});
-    event.recipes.gtceu.forge_hammer('crushed_blackstone')
+    event.recipes.gtceu.forge_hammer(id('crushed_blackstone'))
         .itemInputs('minecraft:blackstone')
         .itemOutputs('exnihilosequentia:crushed_blackstone')
         .duration(10)

--- a/kubejs/server_scripts/gregification/exnihilo.js
+++ b/kubejs/server_scripts/gregification/exnihilo.js
@@ -26,6 +26,6 @@ ServerEvents.recipes(event => {
         .duration(10)
         .EUt(16);
 
-    event.recipes.create.crushing('exnihilosequentia:crushed_blackstone', 'minecraft:blackstone');
+    event.recipes.create.crushing('exnihilosequentia:crushed_blackstone', 'minecraft:blackstone').id('start:crushing/blackstone');
 
 });

--- a/kubejs/server_scripts/gregification/flux_networks.js
+++ b/kubejs/server_scripts/gregification/flux_networks.js
@@ -1,7 +1,7 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.large_chemical_reactor('flux_dust')
+    event.recipes.gtceu.large_chemical_reactor(id('flux_dust'))
     .itemInputs('32x minecraft:redstone')
     .inputFluids('minecraft:lava 64000')
     .itemOutputs('64x fluxnetworks:flux_dust')

--- a/kubejs/server_scripts/gregification/functional_storage.js
+++ b/kubejs/server_scripts/gregification/functional_storage.js
@@ -24,7 +24,7 @@ ServerEvents.recipes(event => {
     ], {
         C: 'gtceu:double_copper_plate',
         T: 'gtceu:tin_plate'
-    });
+    }).id('start:shaped/copper_upgrade');
 
     event.shaped(Item.of('functionalstorage:iron_downgrade'), [
         ' C ',
@@ -33,7 +33,7 @@ ServerEvents.recipes(event => {
     ], {
         C: 'gtceu:iron_plate',
         T: 'gtceu:tin_plate'
-    });
+    }).id('start:shaped/iron_downgrade');
 
     event.shaped(Item.of('functionalstorage:void_upgrade'), [
         ' O ',
@@ -42,7 +42,7 @@ ServerEvents.recipes(event => {
     ], {
         O: 'minecraft:obsidian',
         S: 'gtceu:soul_infused_plate'
-    });
+    }).id('start:shaped/void_upgrade');
 
     event.shaped(Item.of('functionalstorage:puller_upgrade'), [
         ' C ',
@@ -52,7 +52,7 @@ ServerEvents.recipes(event => {
         C: 'gtceu:lv_conveyor_module',
         T: 'gtceu:tin_plate',
         R: 'minecraft:redstone'
-    });
+    }).id('start:shaped/puller_upgrade');
 
     event.shaped(Item.of('functionalstorage:pusher_upgrade'), [
         ' T ',
@@ -62,7 +62,7 @@ ServerEvents.recipes(event => {
         C: 'gtceu:lv_conveyor_module',
         T: 'gtceu:tin_plate',
         R: 'minecraft:redstone'
-    });
+    }).id('start:shaped/pusher_upgrade');
 
     event.shaped(Item.of('functionalstorage:storage_controller'), [
         'SSS',
@@ -72,7 +72,7 @@ ServerEvents.recipes(event => {
         S: 'minecraft:stone',
         G: '#forge:glass',
         C: '#gtceu:circuits/lv'
-    });
+    }).id('start:shaped/storage_controller');
 
     event.shaped(Item.of('2x functionalstorage:ender_drawer'), [
         'OOO',
@@ -83,7 +83,7 @@ ServerEvents.recipes(event => {
         G: '#forge:glass',
         P: 'minecraft:ender_pearl',
         C: '#gtceu:circuits/lv'
-    });
+    }).id('start:shaped/ender_drawer');
 
     [
         '1',
@@ -91,7 +91,7 @@ ServerEvents.recipes(event => {
         '4'
     ].forEach(size => {
         event.remove({ output: `functionalstorage:framed_${size}` });
-        event.shapeless(`1x functionalstorage:framed_${size}`, [`1x functionalstorage:oak_${size}`, 'framedblocks:framed_hammer']);
+        event.shapeless(`1x functionalstorage:framed_${size}`, [`1x functionalstorage:oak_${size}`, 'framedblocks:framed_hammer']).id(`start:shapeless/framed_drawer_${size}`);
     })
     event.shapeless('1x functionalstorage:framed_storage_controller', ['functionalstorage:storage_controller', 'framedblocks:framed_hammer']);
 
@@ -103,9 +103,9 @@ ServerEvents.recipes(event => {
         R: '#forge:dusts/redstone',
         C: 'minecraft:comparator',
         P: '#forge:plates/iron'
-    });
+    }).id('start:shaped/redstone_upgrade');
 
-    event.shapeless('functionalstorage:pusher_upgrade', [Item.of('functionalstorage:puller_upgrade'), '#forge:tools/screwdrivers']);
-    event.shapeless('functionalstorage:puller_upgrade', [Item.of('functionalstorage:pusher_upgrade'), '#forge:tools/screwdrivers']);
+    event.shapeless('functionalstorage:pusher_upgrade', [Item.of('functionalstorage:puller_upgrade'), '#forge:tools/screwdrivers']).id('start:shapeless/pusher_flip');
+    event.shapeless('functionalstorage:puller_upgrade', [Item.of('functionalstorage:pusher_upgrade'), '#forge:tools/screwdrivers']).id('start:shapeless/puller_flip');
 
 });

--- a/kubejs/server_scripts/gregification/functional_storage.js
+++ b/kubejs/server_scripts/gregification/functional_storage.js
@@ -1,5 +1,5 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     event.remove({output: /functionalstorage:.*grade/});
     event.remove({output: /functionalstorage:fluid.*/});

--- a/kubejs/server_scripts/gregification/item_collectors.js
+++ b/kubejs/server_scripts/gregification/item_collectors.js
@@ -1,4 +1,3 @@
-
 ServerEvents.recipes(event => {
 
     event.shaped(Item.of('itemcollectors:basic_collector'), [

--- a/kubejs/server_scripts/gregification/item_collectors.js
+++ b/kubejs/server_scripts/gregification/item_collectors.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     event.shaped(Item.of('itemcollectors:basic_collector'), [
         ' P ',
@@ -7,7 +8,7 @@ ServerEvents.recipes(event => {
     ], {
         P: 'minecraft:ender_pearl',
         S: 'gtceu:steel_plate'
-    });
+    }).id('start:shaped/basic_collector');
 
     event.shaped(Item.of('itemcollectors:advanced_collector'), [
         ' P ',
@@ -17,6 +18,6 @@ ServerEvents.recipes(event => {
         P: 'minecraft:ender_pearl',
         C: 'itemcollectors:basic_collector',
         B: 'gtceu:black_bronze_plate'
-    });
+    }).id('start:shaped/advanced_collectors');
 
 });

--- a/kubejs/server_scripts/gregification/pipez.js
+++ b/kubejs/server_scripts/gregification/pipez.js
@@ -1,6 +1,6 @@
 ServerEvents.recipes(event => {
     const id = global.id;
-
+    
     event.remove({mod: 'pipez'});
 
     event.shaped(Item.of('8x pipez:energy_pipe'), [
@@ -10,7 +10,7 @@ ServerEvents.recipes(event => {
     ], {
         P: 'gtceu:lead_plate',
         W: 'gtceu:tin_single_cable'
-    });
+    }).id('start:shaped/energy_pipe');
 
     event.shaped(Item.of('8x pipez:fluid_pipe'), [
         'PWP',
@@ -19,7 +19,7 @@ ServerEvents.recipes(event => {
     ], {
         P: 'gtceu:bronze_plate',
         W: 'gtceu:copper_tiny_fluid_pipe'
-    });
+    }).id('start:shaped/fluid_pipe');
 
     event.shaped(Item.of('8x pipez:item_pipe'), [
         'PWP',
@@ -28,7 +28,7 @@ ServerEvents.recipes(event => {
     ], {
         P: 'gtceu:brass_plate',
         W: 'gtceu:tin_small_item_pipe'
-    });
+    }).id('start:shaped/item_pipe');
 
     event.shaped(Item.of('8x pipez:universal_pipe'), [
         'LWL',
@@ -41,7 +41,7 @@ ServerEvents.recipes(event => {
         W: 'gtceu:tin_single_cable',
         C: 'gtceu:copper_tiny_fluid_pipe',
         T: 'gtceu:tin_small_item_pipe'
-    });
+    }).id('start:shaped/universal_pipe');
 
     event.shaped(Item.of('pipez:wrench'), [
         ' P ',
@@ -50,7 +50,7 @@ ServerEvents.recipes(event => {
     ], {
         P: 'gtceu:wrought_iron_plate',
         B: 'gtceu:brass_rod'
-    });
+    }).id('start:shaped/pipe_wrench');
 
     event.shaped(Item.of('pipez:basic_upgrade'), [
         'PPP',
@@ -60,7 +60,7 @@ ServerEvents.recipes(event => {
         P: 'gtceu:invar_plate',
         U: 'gtceu:tin_small_item_pipe',
         C: 'gtceu:lv_conveyor_module'
-    });
+    }).id('start:shaped/basic_upgrade');
 
     event.shaped(Item.of('pipez:improved_upgrade'), [
         'PPP',
@@ -70,7 +70,7 @@ ServerEvents.recipes(event => {
         P: 'gtceu:aluminium_plate',
         U: 'pipez:basic_upgrade',
         C: 'gtceu:mv_conveyor_module'
-    });
+    }).id('start:shaped/improved_upgrade');
 
     event.shaped(Item.of('pipez:advanced_upgrade'), [
         'PPP',
@@ -80,7 +80,7 @@ ServerEvents.recipes(event => {
         P: 'gtceu:stainless_steel_plate',
         U: 'pipez:improved_upgrade',
         C: 'gtceu:hv_conveyor_module'
-    });
+    }).id('start:shaped/advanced_upgrade');
 
     event.shaped(Item.of('pipez:ultimate_upgrade'), [
         'PPP',
@@ -88,9 +88,9 @@ ServerEvents.recipes(event => {
         'PPP'
     ], {
         P: 'gtceu:titanium_plate',
-        U: 'pipez:improved_upgrade',
+        U: 'pipez:advanced_upgrade',
         C: 'gtceu:ev_conveyor_module'
-    });
+    }).id('start:shaped/ultimate_upgrade');
 
     event.shaped(Item.of('pipez:filter_destination_tool'), [
         'PPP',
@@ -101,6 +101,6 @@ ServerEvents.recipes(event => {
         R: 'minecraft:redstone',
         G: '#forge:glass_panes',
         B: '#minecraft:buttons'
-    });
+    }).id('start:shaped/filter_destination_tool');
 
 });

--- a/kubejs/server_scripts/gregification/pipez.js
+++ b/kubejs/server_scripts/gregification/pipez.js
@@ -1,5 +1,5 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     event.remove({mod: 'pipez'});
 

--- a/kubejs/server_scripts/gregification/solar_energy.js
+++ b/kubejs/server_scripts/gregification/solar_energy.js
@@ -1,78 +1,79 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.circuit_assembler('basic_energy_core')
+    event.recipes.gtceu.circuit_assembler(id('basic_energy_core'))
         .itemInputs('gtceu:silicon_wafer', '4x #gtceu:capacitors', '2x #gtceu:diodes', 'gtceu:tin_single_cable', '4x minecraft:glass_pane')
         .inputFluids('gtceu:soldering_alloy 12')
         .itemOutputs('kubejs:basic_energy_core')
         .duration(200)
         .EUt(8);
 
-    event.recipes.gtceu.polarizer('basic_to_regular_energy_core')
+    event.recipes.gtceu.polarizer(id('basic_to_regular_energy_core'))
         .itemInputs('kubejs:basic_energy_core')
         .itemOutputs('kubejs:regular_energy_core')
         .duration(1000)
         .EUt(25);
 
-    event.recipes.gtceu.polarizer('regular_to_intermediate_energy_core')
+    event.recipes.gtceu.polarizer(id('regular_to_intermediate_energy_core'))
         .itemInputs('kubejs:regular_energy_core')
         .itemOutputs('kubejs:intermediate_energy_core')
         .duration(2000)
         .EUt(125);
 
-    event.recipes.gtceu.polarizer('intermediate_to_advanced_energy_core')
+    event.recipes.gtceu.polarizer(id('intermediate_to_advanced_energy_core'))
         .itemInputs('kubejs:intermediate_energy_core')
         .itemOutputs('kubejs:advanced_energy_core')
         .duration(5000)
         .EUt(500);
 
-    event.recipes.gtceu.polarizer('advanced_to_elite_energy_core')
+    event.recipes.gtceu.polarizer(id('advanced_to_elite_energy_core'))
         .itemInputs('kubejs:advanced_energy_core')
         .itemOutputs('kubejs:elite_energy_core')
         .duration(12500)
         .EUt(2000);
 
-    event.recipes.gtceu.polarizer('elite_to_ultimate_energy_core')
+    event.recipes.gtceu.polarizer(id('elite_to_ultimate_energy_core'))
         .itemInputs('kubejs:elite_energy_core')
         .itemOutputs('kubejs:ultimate_energy_core')
         .duration(31250)
         .EUt(8000);
 
-    event.recipes.gtceu.circuit_assembler('basic_solar_cell')
+    event.recipes.gtceu.circuit_assembler(id('basic_solar_cell'))
         .itemInputs('gtceu:silicon_plate', 'kubejs:basic_energy_core', '2x #gtceu:circuits/lv', '2x gtceu:tin_single_cable', '4x minecraft:glass_pane')
         .inputFluids('gtceu:soldering_alloy 12')
         .itemOutputs('solarflux:photovoltaic_cell_1')
         .duration(200)
         .EUt(30);
 
-    event.recipes.gtceu.circuit_assembler('regular_solar_cell')
+    event.recipes.gtceu.circuit_assembler(id('regular_solar_cell'))
         .itemInputs('gtceu:plastic_printed_circuit_board', 'kubejs:regular_energy_core', '2x #gtceu:circuits/mv', '2x gtceu:copper_single_cable', '4x minecraft:glass_pane')
         .inputFluids('gtceu:soldering_alloy 36')
         .itemOutputs('solarflux:photovoltaic_cell_2')
         .duration(200)
         .EUt(80);
 
-    event.recipes.gtceu.circuit_assembler('intermediate_solar_cell')
+    event.recipes.gtceu.circuit_assembler(id('intermediate_solar_cell'))
         .itemInputs('gtceu:plastic_printed_circuit_board', 'kubejs:intermediate_energy_core', '2x #gtceu:circuits/hv', '2x gtceu:gold_single_cable', '4x minecraft:glass_pane')
         .inputFluids('gtceu:soldering_alloy 36')
         .itemOutputs('solarflux:photovoltaic_cell_3')
         .duration(200)
         .EUt(200);
 
-    event.recipes.gtceu.circuit_assembler('advanced_solar_cell')
+    event.recipes.gtceu.circuit_assembler(id('advanced_solar_cell'))
         .itemInputs('gtceu:epoxy_printed_circuit_board', 'kubejs:advanced_energy_core', '2x #gtceu:circuits/ev', '2x gtceu:aluminium_single_cable', '4x minecraft:glass_pane')
         .inputFluids('gtceu:soldering_alloy 72')
         .itemOutputs('solarflux:photovoltaic_cell_4')
         .duration(200)
         .EUt(1000);
 
-    event.recipes.gtceu.circuit_assembler('elite_solar_cell')
+    event.recipes.gtceu.circuit_assembler(id('elite_solar_cell'))
         .itemInputs('gtceu:fiber_reinforced_printed_circuit_board', 'kubejs:elite_energy_core', '2x #gtceu:circuits/iv', '2x gtceu:platinum_single_cable', '4x minecraft:glass_pane')
         .inputFluids('gtceu:soldering_alloy 144')
         .itemOutputs('solarflux:photovoltaic_cell_5')
         .duration(200)
         .EUt(3400);
 
-    event.recipes.gtceu.circuit_assembler('ultimate_solar_cell')
+    event.recipes.gtceu.circuit_assembler(id('ultimate_solar_cell'))
         .itemInputs('gtceu:multilayer_fiber_reinforced_printed_circuit_board', 'kubejs:ultimate_energy_core', '2x #gtceu:circuits/luv', '2x gtceu:niobium_titanium_single_cable', '4x minecraft:glass_pane')
         .inputFluids('gtceu:soldering_alloy 216')
         .itemOutputs('solarflux:photovoltaic_cell_6')

--- a/kubejs/server_scripts/gregification/thermal.js
+++ b/kubejs/server_scripts/gregification/thermal.js
@@ -32,23 +32,23 @@ ServerEvents.recipes(event => {
         G: 'gtceu:iron_gear',
         S: 'gtceu:steel_plate',
         R: 'gtceu:lv_machine_hull'
-    });
+    }).id('start:shaped/stirling_dynamo');
 
-    event.recipes.gtceu.assembler(id('gtceu:stirling_dynamo'))
+    event.recipes.gtceu.assembler(id('stirling_dynamo'))
         .itemInputs('thermal:rf_coil', 'gtceu:iron_gear', 'gtceu:lv_machine_hull')
         .itemOutputs('thermal:dynamo_stirling')
         .inputFluids('gtceu:tin_alloy 144')
         .duration(300)
         .EUt(16);
 
-    event.recipes.gtceu.assembler(id('gtceu:lapidary_dynamo'))
+    event.recipes.gtceu.assembler(id('lapidary_dynamo'))
         .itemInputs('thermal:rf_coil', 'gtceu:cobalt_brass_gear', 'gtceu:lv_machine_hull')
         .itemOutputs('thermal:dynamo_lapidary')
         .inputFluids('gtceu:tin_alloy 288')
         .duration(300)
         .EUt(30);
 
-    event.recipes.gtceu.assembler(id('gtceu:compression_dynamo'))
+    event.recipes.gtceu.assembler(id('compression_dynamo'))
         .itemInputs('thermal:rf_coil', 'gtceu:bronze_gear', 'gtceu:lv_machine_hull')
         .itemOutputs('thermal:dynamo_compression')
         .inputFluids('gtceu:tin_alloy 432')
@@ -117,7 +117,7 @@ ServerEvents.recipes(event => {
         P: 'gtceu:iron_plate',
         I: 'minecraft:iron_ingot'
     }
-    );
+    ).id('start:shaped/redstone_servo');
     event.shaped(Item.of('thermal:rf_coil'), [
         ' RP',
         'RBR',
@@ -126,7 +126,7 @@ ServerEvents.recipes(event => {
         R: 'gtceu:gold_rod',
         P: 'gtceu:gold_plate',
         B: 'minecraft:redstone_block'
-    });
+    }).id('start:shaped/rf_coil');
 
     event.replaceInput({ id: 'thermal:device_fisher' },
         '#forge:gears/copper',
@@ -174,7 +174,7 @@ ServerEvents.recipes(event => {
     ], {
         L: 'gtceu:lead_plate',
         E: 'gtceu:electrum_plate'
-    });
+    }).id('start:shaped/energy_cell_frame');
 
     event.shaped(Item.of('thermal:fluid_cell_frame'), [
         'BTB',
@@ -184,7 +184,7 @@ ServerEvents.recipes(event => {
         B: 'gtceu:bronze_plate',
         T: 'gtceu:tin_plate',
         G: '#forge:glass'
-    });
+    }).id('start:shaped/fluid_cell_frame');
 
     event.shaped(Item.of('thermal:machine_frame'), [
         'SSS',
@@ -193,9 +193,9 @@ ServerEvents.recipes(event => {
     ], {
         S: 'gtceu:double_stainless_steel_plate',
         B: 'gtceu:double_black_steel_plate'
-    });
+    }).id('start:shaped/machine_frame');
 
-    event.recipes.create.item_application('thermal:fluid_cell', ['thermal:fluid_cell_frame', 'create:fluid_tank']);
+    event.recipes.create.item_application('thermal:fluid_cell', ['thermal:fluid_cell_frame', 'create:fluid_tank']).id('start:item_application/fluid_cell');
 
     event.recipes.gtceu.alloy_smelter(id('fluid_cell'))
         .itemInputs('thermal:fluid_cell_frame', 'create:fluid_tank')
@@ -203,7 +203,7 @@ ServerEvents.recipes(event => {
         .duration(80)
         .EUt(28);
 
-    event.recipes.create.item_application('thermal:energy_cell', ['thermal:energy_cell_frame', 'minecraft:redstone_block']);
+    event.recipes.create.item_application('thermal:energy_cell', ['thermal:energy_cell_frame', 'minecraft:redstone_block']).id('start:item_application/energy_cell');
 
     event.recipes.gtceu.alloy_smelter(id('energy_cell'))
         .itemInputs('thermal:energy_cell_frame', 'minecraft:redstone_block')

--- a/kubejs/server_scripts/gregification/thermal.js
+++ b/kubejs/server_scripts/gregification/thermal.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     event.remove({id: /thermal:parts.*gear/});
     event.remove({id: /thermal_extra:parts.*gear/});
@@ -33,21 +34,21 @@ ServerEvents.recipes(event => {
         R: 'gtceu:lv_machine_hull'
     });
 
-    event.recipes.gtceu.assembler('gtceu:stirling_dynamo')
+    event.recipes.gtceu.assembler(id('gtceu:stirling_dynamo'))
         .itemInputs('thermal:rf_coil', 'gtceu:iron_gear', 'gtceu:lv_machine_hull')
         .itemOutputs('thermal:dynamo_stirling')
         .inputFluids('gtceu:tin_alloy 144')
         .duration(300)
         .EUt(16);
 
-    event.recipes.gtceu.assembler('gtceu:lapidary_dynamo')
+    event.recipes.gtceu.assembler(id('gtceu:lapidary_dynamo'))
         .itemInputs('thermal:rf_coil', 'gtceu:cobalt_brass_gear', 'gtceu:lv_machine_hull')
         .itemOutputs('thermal:dynamo_lapidary')
         .inputFluids('gtceu:tin_alloy 288')
         .duration(300)
         .EUt(30);
 
-    event.recipes.gtceu.assembler('gtceu:compression_dynamo')
+    event.recipes.gtceu.assembler(id('gtceu:compression_dynamo'))
         .itemInputs('thermal:rf_coil', 'gtceu:bronze_gear', 'gtceu:lv_machine_hull')
         .itemOutputs('thermal:dynamo_compression')
         .inputFluids('gtceu:tin_alloy 432')
@@ -62,34 +63,34 @@ ServerEvents.recipes(event => {
     event.recipes.thermal.compression_fuel('gtceu:gasoline', 6400000);
     event.recipes.thermal.compression_fuel('gtceu:high_octane_gasoline', 12800000);
     event.recipes.thermal.compression_fuel('gtceu:naphtha', 1280000);
-    event.recipes.gtceu.mixer('refined_fuel')
+    event.recipes.gtceu.mixer(id('refined_fuel'))
         .inputFluids('gtceu:light_fuel 1000', 'gtceu:heavy_fuel 1000')
         .outputFluids('thermal:refined_fuel 2000')
         .duration(20)
         .circuit(0)
         .EUt(30);
 
-    event.recipes.gtceu.brewery('sunflower_oil')
+    event.recipes.gtceu.brewery(id('sunflower_oil'))
         .itemInputs('16x minecraft:sunflower')
         .outputFluids('thermal_extra:sunflower_oil 500')
         .duration(400)
         .EUt(28);
 
-    event.recipes.gtceu.mixer('crystalized_sunflower_oil')
+    event.recipes.gtceu.mixer(id('crystalized_sunflower_oil'))
         .itemInputs('minecraft:amethyst_shard')
         .inputFluids('thermal_extra:sunflower_oil 1000')
         .outputFluids('thermal_extra:crystallized_sunflower_oil 750')
         .duration(600)
         .EUt(28);
 
-    event.recipes.gtceu.distillery('sunflower_oil_refined')
+    event.recipes.gtceu.distillery(id('sunflower_oil_refined'))
         .inputFluids('thermal_extra:crystallized_sunflower_oil 1000')
         .outputFluids('thermal_extra:refined_sunflower_oil 600')
         .circuit(0)
         .duration(600)
         .EUt(325);
 
-    event.recipes.gtceu.distillery('sunflower_oil_seed')
+    event.recipes.gtceu.distillery(id('sunflower_oil_seed'))
         .inputFluids('thermal_extra:crystallized_sunflower_oil 1000')
         .outputFluids('gtceu:seed_oil 400')
         .circuit(1)
@@ -142,7 +143,7 @@ ServerEvents.recipes(event => {
         'gtceu:bronze_gear'
     );
 
-    event.recipes.gtceu.extractor('molten_ender')
+    event.recipes.gtceu.extractor(id('molten_ender'))
         .itemInputs('minecraft:ender_pearl')
         .outputFluids('thermal:ender 250')
         .duration(600)
@@ -196,7 +197,7 @@ ServerEvents.recipes(event => {
 
     event.recipes.create.item_application('thermal:fluid_cell', ['thermal:fluid_cell_frame', 'create:fluid_tank']);
 
-    event.recipes.gtceu.alloy_smelter('fluid_cell')
+    event.recipes.gtceu.alloy_smelter(id('fluid_cell'))
         .itemInputs('thermal:fluid_cell_frame', 'create:fluid_tank')
         .itemOutputs('thermal:fluid_cell')
         .duration(80)
@@ -204,19 +205,19 @@ ServerEvents.recipes(event => {
 
     event.recipes.create.item_application('thermal:energy_cell', ['thermal:energy_cell_frame', 'minecraft:redstone_block']);
 
-    event.recipes.gtceu.alloy_smelter('energy_cell')
+    event.recipes.gtceu.alloy_smelter(id('energy_cell'))
         .itemInputs('thermal:energy_cell_frame', 'minecraft:redstone_block')
         .itemOutputs('thermal:energy_cell')
         .duration(80)
         .EUt(28);
 
-    event.recipes.gtceu.assembler('boiler_pipe')
+    event.recipes.gtceu.assembler(id('boiler_pipe'))
         .itemInputs('gtceu:tempered_glass', '3x gtceu:bronze_ring')
         .itemOutputs('systeams:boiler_pipe')
         .duration(120)
         .EUt(112);
 
-    event.recipes.gtceu.assembler('steam_dynamo')
+    event.recipes.gtceu.assembler(id('steam_dynamo'))
         .itemInputs('gtceu:lv_machine_hull', 'systeams:boiler_pipe', 'gtceu:black_steel_gear', 'gtceu:lead_rotor')
         .itemOutputs('systeams:steam_dynamo')
         .duration(320)

--- a/kubejs/server_scripts/gregification/travel_anchors.js
+++ b/kubejs/server_scripts/gregification/travel_anchors.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     event.remove({output: 'travelanchors:travel_anchor'});
     event.remove({output: 'travelanchors:travel_staff'});
@@ -11,7 +12,7 @@ ServerEvents.recipes(event => {
         D: 'gtceu:double_steel_plate',
         S: 'gtceu:steel_plate',
         P: 'minecraft:ender_pearl'
-    });
+    }).id('start:shaped/travel_anchor');
 
     event.shaped(Item.of('travelanchors:travel_staff'), [
         '  P',
@@ -20,6 +21,6 @@ ServerEvents.recipes(event => {
     ], {
         P: 'minecraft:ender_pearl',
         R: 'gtceu:iron_rod'
-    });
+    }).id('start:shaped/travel_staff');
 
 });

--- a/kubejs/server_scripts/gregification/travel_anchors.js
+++ b/kubejs/server_scripts/gregification/travel_anchors.js
@@ -1,4 +1,3 @@
-
 ServerEvents.recipes(event => {
 
     event.remove({output: 'travelanchors:travel_anchor'});

--- a/kubejs/server_scripts/gregification/xycraft.js
+++ b/kubejs/server_scripts/gregification/xycraft.js
@@ -1,19 +1,20 @@
-
 ServerEvents.recipes(event => {
 
     event.replaceInput({mod: 'xycraft_world'}, 'xycraft:aluminum_ingot', 'gtceu:aluminium_ingot');
     event.replaceInput({mod: 'xycraft_world'}, '#forge:ingots/aluminum', 'gtceu:aluminium_ingot');
+    
     event.remove({input: 'xycraft_world:aluminum_nugget'});
     event.remove({output: 'xycraft_world:aluminum_nugget'});
-    event.remove([{output: 'xycraft_world:aluminum_storage'}, {output: 'xycraft_world:aluminum_bricks'}]);
-    event.remove([{id: 'xycraft_world:shaped/aluminum_bricks_cloud_red'}, {id: 'xycraft_world:shaped/aluminum_bricks_cloud_red_r'},
-    {id: 'xycraft_world:shaped/aluminum_bricks_cloud_blue'}, {id: 'xycraft_world:shaped/aluminum_bricks_cloud_blue_r'},
-    {id: 'xycraft_world:shaped/aluminum_bricks_cloud_green'}, {id: 'xycraft_world:shaped/aluminum_bricks_cloud_green_r'},
-    {id: 'xycraft_world:shaped/aluminum_bricks_cloud_light'}, {id: 'xycraft_world:shaped/aluminum_bricks_cloud_light_r'},
-    {id: 'xycraft_world:shaped/aluminum_bricks_cloud_dark'}, {id: 'xycraft_world:shaped/aluminum_bricks_cloud_dark_r'}]);
+    event.remove({output: ['xycraft_world:aluminum_storage', 'xycraft_world:aluminum_bricks']});
+    event.remove({id: ['xycraft_world:shaped/aluminum_bricks_cloud_red', 'xycraft_world:shaped/aluminum_bricks_cloud_red_r', 'xycraft_world:shaped/aluminum_bricks_cloud_blue', 
+        'xycraft_world:shaped/aluminum_bricks_cloud_blue_r', 'xycraft_world:shaped/aluminum_bricks_cloud_green', 'xycraft_world:shaped/aluminum_bricks_cloud_green_r',
+        'xycraft_world:shaped/aluminum_bricks_cloud_light', 'xycraft_world:shaped/aluminum_bricks_cloud_light_r', 'xycraft_world:shaped/aluminum_bricks_cloud_dark',
+        'xycraft_world:shaped/aluminum_bricks_cloud_dark_r']});
+    
     event.replaceInput({output: 'xycraft_world:glass_viewer_immortal'}, 'gtceu:aluminium_ingot', 'gtceu:aluminium_nugget');
     event.replaceInput({output: /xycraft_world:glass_viewer_phantom.*/}, 'minecraft:phantom_membrane', 'gtceu:carbon_fibers');
     event.replaceInput({output: /xycraft_world:immortal_stone.*/}, 'gtceu:aluminium_ingot', 'gtceu:aluminium_nugget');  
+    
     event.shaped(Item.of('5x xycraft_world:aluminum_storage'), [
         'NCN',
         'CNC',

--- a/kubejs/server_scripts/gregification/xycraft.js
+++ b/kubejs/server_scripts/gregification/xycraft.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     event.replaceInput({mod: 'xycraft_world'}, 'xycraft:aluminum_ingot', 'gtceu:aluminium_ingot');
     event.replaceInput({mod: 'xycraft_world'}, '#forge:ingots/aluminum', 'gtceu:aluminium_ingot');
@@ -6,10 +7,14 @@ ServerEvents.recipes(event => {
     event.remove({input: 'xycraft_world:aluminum_nugget'});
     event.remove({output: 'xycraft_world:aluminum_nugget'});
     event.remove({output: ['xycraft_world:aluminum_storage', 'xycraft_world:aluminum_bricks']});
-    event.remove({id: ['xycraft_world:shaped/aluminum_bricks_cloud_red', 'xycraft_world:shaped/aluminum_bricks_cloud_red_r', 'xycraft_world:shaped/aluminum_bricks_cloud_blue', 
+    [
+        'xycraft_world:shaped/aluminum_bricks_cloud_red', 'xycraft_world:shaped/aluminum_bricks_cloud_red_r', 'xycraft_world:shaped/aluminum_bricks_cloud_blue', 
         'xycraft_world:shaped/aluminum_bricks_cloud_blue_r', 'xycraft_world:shaped/aluminum_bricks_cloud_green', 'xycraft_world:shaped/aluminum_bricks_cloud_green_r',
         'xycraft_world:shaped/aluminum_bricks_cloud_light', 'xycraft_world:shaped/aluminum_bricks_cloud_light_r', 'xycraft_world:shaped/aluminum_bricks_cloud_dark',
-        'xycraft_world:shaped/aluminum_bricks_cloud_dark_r']});
+        'xycraft_world:shaped/aluminum_bricks_cloud_dark_r'
+    ].forEach(item => {
+        event.remove({id: item});
+    })
     
     event.replaceInput({output: 'xycraft_world:glass_viewer_immortal'}, 'gtceu:aluminium_ingot', 'gtceu:aluminium_nugget');
     event.replaceInput({output: /xycraft_world:glass_viewer_phantom.*/}, 'minecraft:phantom_membrane', 'gtceu:carbon_fibers');
@@ -22,7 +27,7 @@ ServerEvents.recipes(event => {
     ], {
         N: 'gtceu:aluminium_nugget',
         C: 'minecraft:calcite'
-    });
+    }).id('start:shaped/aluminum_storage');
 
     event.shaped(Item.of('2x xycraft_world:aluminum_bricks'), [
         'NC',
@@ -30,13 +35,13 @@ ServerEvents.recipes(event => {
     ], {
         N: 'gtceu:aluminium_nugget',
         C: 'minecraft:calcite'
-    });
+    }).id('start:shaped/aluminum_bricks');
     event.shaped(Item.of('4x xycraft_world:kivi'), [
         'BD',
         'DB'
     ], {
         B: 'minecraft:basalt',
         D: 'minecraft:deepslate'
-    });
+    }).id('start:shaped/kivi');
 
 });

--- a/kubejs/server_scripts/lines/PEEK_line.js
+++ b/kubejs/server_scripts/lines/PEEK_line.js
@@ -1,53 +1,54 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     event.remove('gtceu:electrolyzer/decomposition_electrolyzing_sodium_bicarbonate');
     
-    event.recipes.gtceu.large_chemical_reactor('benzotrichloride_process')
+    event.recipes.gtceu.large_chemical_reactor(id('benzotrichloride_process'))
         .inputFluids('gtceu:toluene 1000','gtceu:chlorine 3000')
         .outputFluids('gtceu:benzotrichloride 1000','gtceu:hydrogen 3000')
         .duration(50)
         .EUt(GTValues.VHA[GTValues.ZPM]);
     
-    event.recipes.gtceu.large_chemical_reactor('benzoyl_chloride_process')
+    event.recipes.gtceu.large_chemical_reactor(id('benzoyl_chloride_process'))
         .inputFluids('gtceu:benzotrichloride 1000','minecraft:water 1000')
         .outputFluids('gtceu:benzoyl_chloride 1000','gtceu:hydrochloric_acid 2000')
         .duration(150)
         .EUt(GTValues.VA[GTValues.LuV]);
 
-    event.recipes.gtceu.large_chemical_reactor('4_fluorobenzoyl_chloride_process')
+    event.recipes.gtceu.large_chemical_reactor(id('4_fluorobenzoyl_chloride_process'))
         .inputFluids('gtceu:benzoyl_chloride 1000','gtceu:fluorine 1000')
         .outputFluids('gtceu:4_fluorobenzoyl_chloride 1000','gtceu:hydrogen 1000')
         .duration(250)
         .EUt(GTValues.VA[GTValues.LuV]);
 
-    event.recipes.gtceu.large_chemical_reactor('fluorobenzene_process')
+    event.recipes.gtceu.large_chemical_reactor(id('fluorobenzene_process'))
         .inputFluids('gtceu:benzene 1000','gtceu:fluorine 2000')
         .outputFluids('gtceu:fluorobenzene 1000','gtceu:hydrofluoric_acid 1000')
         .duration(100)
         .EUt(GTValues.VA[GTValues.LuV]);
     
-    event.recipes.gtceu.large_chemical_reactor('44_difluorobenzophenone_process')
+    event.recipes.gtceu.large_chemical_reactor(id('44_difluorobenzophenone_process'))
         .inputFluids('gtceu:fluorobenzene 1000','gtceu:4_fluorobenzoyl_chloride 1000')
         .outputFluids('gtceu:hydrochloric_acid 1000')
         .itemOutputs('gtceu:44_difluorobenzophenone_dust')
         .duration(120)
         .EUt(GTValues.VA[GTValues.LuV]);
 
-    event.recipes.gtceu.large_chemical_reactor('hydroquinone_process')
+    event.recipes.gtceu.large_chemical_reactor(id('hydroquinone_process'))
         .inputFluids('gtceu:benzene 1000','gtceu:propene 1000','gtceu:oxygen 3000')
         .outputFluids('gtceu:acetone 1000')
         .itemOutputs('gtceu:hydroquinone_dust')
         .duration(200)
         .EUt(GTValues.VA[GTValues.ZPM]);
 
-    event.recipes.gtceu.large_chemical_reactor('disodium_salt_of_hydroquinone_process')
+    event.recipes.gtceu.large_chemical_reactor(id('disodium_salt_of_hydroquinone_process'))
         .itemInputs('gtceu:soda_ash_dust','gtceu:hydroquinone_dust')
         .outputFluids('gtceu:carbon_acid 1000')
         .itemOutputs('gtceu:disodium_salt_of_hydroquinone_dust')
         .duration(120)
         .EUt(GTValues.VA[GTValues.IV]);
 
-    event.recipes.gtceu.large_chemical_reactor('carbon_acid_to_sodium_bicarbonate_dust')
+    event.recipes.gtceu.large_chemical_reactor(id('carbon_acid_to_sodium_bicarbonate_dust'))
         .itemInputs('gtceu:sodium_dust')
         .inputFluids('gtceu:carbon_acid 1000')
         .outputFluids('gtceu:hydrogen 1000')
@@ -55,14 +56,14 @@ ServerEvents.recipes(event => {
         .duration(120)
         .EUt(GTValues.VA[GTValues.HV]);
 
-    event.recipes.gtceu.electrolyzer('sodium_bicarbonate_to_soda_ash_dust')
+    event.recipes.gtceu.electrolyzer(id('sodium_bicarbonate_to_soda_ash_dust'))
         .itemInputs('2x gtceu:sodium_bicarbonate_dust')
         .outputFluids('minecraft:water 1000','gtceu:carbon_dioxide 1000')
         .itemOutputs('gtceu:soda_ash_dust')
         .duration(120)
         .EUt(GTValues.VA[GTValues.HV]);
 
-    event.recipes.gtceu.large_chemical_reactor('peek_process')
+    event.recipes.gtceu.large_chemical_reactor(id('peek_process'))
         .itemInputs('gtceu:44_difluorobenzophenone_dust','gtceu:disodium_salt_of_hydroquinone_dust')
         .outputFluids('gtceu:polyether_ether_ketone 1008')
         .itemOutputs('2x gtceu:sodium_fluoride_dust')
@@ -71,7 +72,7 @@ ServerEvents.recipes(event => {
 
     //effortless chemical plant recipe
     
-    event.recipes.gtceu.chemical_plant('effortless_peek_process')
+    event.recipes.gtceu.chemical_plant(id('effortless_peek_process'))
         .inputFluids('gtceu:benzene 3000','gtceu:methanol 1000','gtceu:propene 1000','gtceu:oxygen 8000')
         .itemInputs('gtceu:soda_ash_dust')
         .outputFluids('gtceu:polyether_ether_ketone 1008','gtceu:acetone 1000','gtceu:carbon_acid 1000','minecraft:water 4000')
@@ -80,14 +81,14 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.UHV]);
 
     // PEEK usages 
-    event.recipes.gtceu.chemical_reactor('plastic_boards_peek')
+    event.recipes.gtceu.chemical_reactor(id('plastic_boards_peek'))
         .itemInputs('gtceu:polyether_ether_ketone_plate', '4x gtceu:copper_foil')
         .inputFluids('gtceu:sulfuric_acid 250')
         .itemOutputs('16x gtceu:plastic_circuit_board')
         .duration(500)
         .EUt(10);
 
-    event.recipes.gtceu.large_chemical_reactor('plastic_boards_peek')
+    event.recipes.gtceu.large_chemical_reactor(id('plastic_boards_peek'))
         .itemInputs('gtceu:polyether_ether_ketone_plate', '4x gtceu:copper_foil')
         .inputFluids('gtceu:sulfuric_acid 250')
         .itemOutputs('16x gtceu:plastic_circuit_board')

--- a/kubejs/server_scripts/lines/hexafluorobromic_acid.js
+++ b/kubejs/server_scripts/lines/hexafluorobromic_acid.js
@@ -1,41 +1,42 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-const CRtype = [event.recipes.gtceu.large_chemical_reactor, event.recipes.gtceu.chemical_reactor]
-CRtype.forEach(CR=>{
+    const CRtype = [event.recipes.gtceu.large_chemical_reactor, event.recipes.gtceu.chemical_reactor]
+    CRtype.forEach(CR=>{
 
-    CR('bromine_pentafluoride')
-        .inputFluids('gtceu:bromine 2000', 'gtceu:fluorine 10000')
-        .notConsumable('1x gtceu:nickel_fluoride_dust')
-        .outputFluids('gtceu:bromine_pentafluoride 2000')
-        .duration(640)
-        .EUt(GTValues.V[GTValues.UV]);
+        CR(id('bromine_pentafluoride'))
+            .inputFluids('gtceu:bromine 2000', 'gtceu:fluorine 10000')
+            .notConsumable('1x gtceu:nickel_fluoride_dust')
+            .outputFluids('gtceu:bromine_pentafluoride 2000')
+            .duration(640)
+            .EUt(GTValues.V[GTValues.UV]);
 
-    CR('caesium_hexafluorobromine')
-        .inputFluids('gtceu:bromine_pentafluoride 1000')
-        .itemInputs('1x gtceu:caesium_fluoride_dust')
-        .outputFluids('gtceu:caesium_hexafluorobromine 1000')
-        .duration(960)
-        .EUt(GTValues.VA[GTValues.ZPM]);
+        CR(id('caesium_hexafluorobromine'))
+            .inputFluids('gtceu:bromine_pentafluoride 1000')
+            .itemInputs('1x gtceu:caesium_fluoride_dust')
+            .outputFluids('gtceu:caesium_hexafluorobromine 1000')
+            .duration(960)
+            .EUt(GTValues.VA[GTValues.ZPM]);
 
-    CR('hexafluorobromic_acid')
-        .inputFluids('gtceu:caesium_hexafluorobromine 1000', 'gtceu:hydrofluoric_acid 1000')
-        .outputFluids('gtceu:hexafluorobromic_acid 1000')
-        .itemOutputs('1x gtceu:caesium_fluoride_dust')
-        .duration(160)
-        .EUt(GTValues.VA[GTValues.UHV]);
+        CR(id('hexafluorobromic_acid'))
+            .inputFluids('gtceu:caesium_hexafluorobromine 1000', 'gtceu:hydrofluoric_acid 1000')
+            .outputFluids('gtceu:hexafluorobromic_acid 1000')
+            .itemOutputs('1x gtceu:caesium_fluoride_dust')
+            .duration(160)
+            .EUt(GTValues.VA[GTValues.UHV]);
 
-    CR('nickel_fluoride')
-        .itemInputs('1x gtceu:nickel_dust')
-        .inputFluids('gtceu:fluorine 2000')
-        .itemOutputs('1x gtceu:nickel_fluoride_dust')
-        .duration(400)
-        .EUt(GTValues.VHA[GTValues.HV]);
+        CR(id('nickel_fluoride'))
+            .itemInputs('1x gtceu:nickel_dust')
+            .inputFluids('gtceu:fluorine 2000')
+            .itemOutputs('1x gtceu:nickel_fluoride_dust')
+            .duration(400)
+            .EUt(GTValues.VHA[GTValues.HV]);
 
-    CR('caesium_fluoride')
-        .itemInputs('1x gtceu:caesium_dust')
-        .inputFluids('gtceu:fluorine 1000')
-        .itemOutputs('1x gtceu:caesium_fluoride_dust')
-        .duration(720)
-        .EUt(GTValues.VH[GTValues.LuV]);
+        CR(id('caesium_fluoride'))
+            .itemInputs('1x gtceu:caesium_dust')
+            .inputFluids('gtceu:fluorine 1000')
+            .itemOutputs('1x gtceu:caesium_fluoride_dust')
+            .duration(720)
+            .EUt(GTValues.VH[GTValues.LuV]);
 
 })});

--- a/kubejs/server_scripts/lines/nether_star_line.js
+++ b/kubejs/server_scripts/lines/nether_star_line.js
@@ -1,32 +1,32 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     [
         {powder: 'blizz', item: 'cobalt_dust', fluid: 'fluorine', multiplier: 16, element: 'ice'},
         {powder: 'blitz', item: 'platinum_dust', fluid: 'deuterium', multiplier: 4, element: 'lightning'},
         {powder: 'basalz', item: 'small_rhodium_dust', fluid: 'helium', multiplier: 1, element: 'earth'}
     ].forEach(type=>{
-        event.recipes.gtceu.chemical_reactor(`${type.powder}_dust`)
+        event.recipes.gtceu.chemical_reactor(id(`${type.powder}_dust`))
             .itemInputs(`gtceu:${type.item}`)
             .inputFluids(`gtceu:${type.fluid} 1000`)
             .itemOutputs(`${type.multiplier}x thermal:${type.powder}_powder`)
             .duration(200)
             .EUt(480*type.multiplier);
 
-        event.recipes.gtceu.large_chemical_reactor(`${type.powder}_dust`)
+        event.recipes.gtceu.large_chemical_reactor(id(`${type.powder}_dust`))
             .itemInputs(`gtceu:${type.item}`)
             .inputFluids(`gtceu:${type.fluid} 1000`)
             .itemOutputs(`${type.multiplier}x thermal:${type.powder}_powder`)
             .duration(200)
             .EUt(480*type.multiplier);
 
-        event.recipes.gtceu.macerator(`${type.powder}_powder`)
+        event.recipes.gtceu.macerator(id(`${type.powder}_powder`))
             .itemInputs(`thermal:${type.powder}_rod`)
             .itemOutputs(`4x thermal:${type.powder}_powder`)
             .duration(88)
             .EUt(2);
 
-        event.recipes.gtceu.mixer(`${type.element}_charge`)
+        event.recipes.gtceu.mixer(id(`${type.element}_charge`))
             .itemInputs('#forge:dusts/coal', 'minecraft:gunpowder', `thermal:${type.powder}_powder`)
             .itemOutputs(`3x thermal:${type.element}_charge`)
             .duration(100)
@@ -45,20 +45,20 @@ ServerEvents.recipes(event => {
         {element: 'lightning', mod: 'thermal', powder: 'blitz'},
         {element: 'earth', mod: 'thermal', powder: 'basalz'}
       ].forEach(shard => {
-        event.recipes.gtceu.extractor(`liquid_${shard.powder}`)
+        event.recipes.gtceu.extractor(id(`liquid_${shard.powder}`))
           .itemInputs(`${shard.mod}:${shard.powder}_powder`)
           .outputFluids(`gtceu:${shard.powder} 144`)
           .duration(22)
           .EUt(30);
 
-        event.recipes.gtceu.autoclave(`${shard.element}_infused_shard_shard`)
+        event.recipes.gtceu.autoclave(id(`${shard.element}_infused_shard_shard`))
           .itemInputs('kubejs:energized_nether_star_shard')
           .inputFluids(`gtceu:${shard.powder} 720`)
           .chancedOutput(`kubejs:${shard.element}_infused_shard`, 8000, 500)
           .duration(480)
           .EUt(2048);
       
-        event.recipes.gtceu.autoclave(`${shard.element}_infused_shard_charge`)
+        event.recipes.gtceu.autoclave(id(`${shard.element}_infused_shard_charge`))
           .itemInputs(`4x ${shard.mod}:${shard.element}_charge`)
           .inputFluids(`gtceu:${shard.powder} 720`)
           .chancedOutput(`kubejs:${shard.element}_infused_shard`, 5000, -1000)
@@ -76,7 +76,7 @@ ServerEvents.recipes(event => {
         F: '#forge:tools/files'
     });
 
-    event.recipes.gtceu.forming_press('impure_nether_star')
+    event.recipes.gtceu.forming_press(id('impure_nether_star'))
         .itemInputs('kubejs:fire_infused_shard', 'kubejs:ice_infused_shard', 'kubejs:lightning_infused_shard', 'kubejs:earth_infused_shard')
         .notConsumable('kubejs:star_casting_mold')
         .itemOutputs('kubejs:impure_nether_star')
@@ -87,7 +87,7 @@ ServerEvents.recipes(event => {
         {name: 'itnt', explosive: 'gtceu:industrial_tnt'},{name: 'powderbarrel', explosive: '8x gtceu:powderbarrel'}]
 
     implosion.forEach(shard=>{
-        event.recipes.gtceu.implosion_compressor(`nether_star_${shard.name}`)
+        event.recipes.gtceu.implosion_compressor(id(`nether_star_${shard.name}`))
             .itemInputs('kubejs:impure_nether_star', shard.explosive)
             .itemOutputs('minecraft:nether_star')
             .chancedOutput('gtceu:dark_ash_dust', 2500, 0)
@@ -95,13 +95,13 @@ ServerEvents.recipes(event => {
             .EUt(30);
     });
     
-    event.recipes.gtceu.forge_hammer('nether_star_shard')
+    event.recipes.gtceu.forge_hammer(id('nether_star_shard'))
         .itemInputs('minecraft:nether_star')
         .itemOutputs('5x mysticalagradditions:nether_star_shard')
         .duration(300)
         .EUt(512);
 
-    event.recipes.gtceu.polarizer('energized_nether_star_shard')
+    event.recipes.gtceu.polarizer(id('energized_nether_star_shard'))
         .itemInputs('mysticalagradditions:nether_star_shard')
         .itemOutputs('kubejs:energized_nether_star_shard')
         .duration(400)

--- a/kubejs/server_scripts/lines/nether_star_line.js
+++ b/kubejs/server_scripts/lines/nether_star_line.js
@@ -74,7 +74,7 @@ ServerEvents.recipes(event => {
     ], {
         M: 'gtceu:ball_casting_mold',
         F: '#forge:tools/files'
-    });
+    }).id('start:shaped/star_casting_mold');
 
     event.recipes.gtceu.forming_press(id('impure_nether_star'))
         .itemInputs('kubejs:fire_infused_shard', 'kubejs:ice_infused_shard', 'kubejs:lightning_infused_shard', 'kubejs:earth_infused_shard')

--- a/kubejs/server_scripts/lines/netherite_line.js
+++ b/kubejs/server_scripts/lines/netherite_line.js
@@ -1,7 +1,7 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.electric_blast_furnace('netherite')
+    event.recipes.gtceu.electric_blast_furnace(id('netherite'))
         .itemInputs('gtceu:debris_dust', 'minecraft:gold_ingot')
         .inputFluids('gtceu:argon 100')
         .itemOutputs('minecraft:netherite_ingot')
@@ -9,14 +9,14 @@ ServerEvents.recipes(event => {
         .duration(6000)
         .EUt(1890);
 
-    event.recipes.gtceu.centrifuge('debris_dust')
+    event.recipes.gtceu.centrifuge(id('debris_dust'))
         .itemInputs('mysticalagriculture:nether_agglomeratio')
         .chancedOutput('gtceu:tiny_debris_dust', 200, 500)
         .duration(20)
         .EUt(6500)
         .circuit(1);
 
-    event.recipes.gtceu.large_chemical_reactor('purified_debris_dust')
+    event.recipes.gtceu.large_chemical_reactor(id('purified_debris_dust'))
         .itemInputs('2x gtceu:debris_dust')
         .inputFluids('gtceu:chlorine_trifluoride 250')
         .itemOutputs('2x gtceu:purified_debris_dust', '4x gtceu:small_titanium_trifluoride_dust')
@@ -25,45 +25,45 @@ ServerEvents.recipes(event => {
         .duration(400)
         .EUt(6500);
 
-    event.recipes.gtceu.chemical_bath('pure_netherite')
+    event.recipes.gtceu.chemical_bath(id('pure_netherite'))
         .itemInputs('gtceu:purified_debris_dust')
         .inputFluids('gtceu:tetrachloroethylene 100')
         .itemOutputs('gtceu:pure_netherite_dust')
         .duration(300)
         .EUt(20450);
 
-    event.recipes.gtceu.chemical_reactor('chlorine_trifluoride')
+    event.recipes.gtceu.chemical_reactor(id('chlorine_trifluoride'))
         .inputFluids('gtceu:chlorine 1000', 'gtceu:fluorine 3000')
         .outputFluids('gtceu:chlorine_trifluoride 1000')
         .duration(800)
         .EUt(22);
 
-    event.recipes.gtceu.large_chemical_reactor('chlorine_trifluoride')
+    event.recipes.gtceu.large_chemical_reactor(id('chlorine_trifluoride'))
         .inputFluids('gtceu:chlorine 1000', 'gtceu:fluorine 3000')
         .outputFluids('gtceu:chlorine_trifluoride 1000')
         .duration(800)
         .EUt(22);
 
-    event.recipes.gtceu.chemical_reactor('dichloroethylene')
+    event.recipes.gtceu.chemical_reactor(id('dichloroethylene'))
         .inputFluids('gtceu:ethane 1000', 'gtceu:chlorine 2000')
         .outputFluids('gtceu:dichloroethane 1000', 'gtceu:hydrochloric_acid 2000')
         .duration(200)
         .EUt(120)
         .circuit(1);
 
-    event.recipes.gtceu.large_chemical_reactor('dichloroethylene')
+    event.recipes.gtceu.large_chemical_reactor(id('dichloroethylene'))
         .inputFluids('gtceu:ethane 1000', 'gtceu:chlorine 2000')
         .outputFluids('gtceu:dichloroethane 1000', 'gtceu:hydrochloric_acid 2000')
         .duration(200)
         .EUt(120);
 
-    event.recipes.gtceu.chemical_reactor('tetrachloroetylene')
+    event.recipes.gtceu.chemical_reactor(id('tetrachloroetylene'))
         .inputFluids('gtceu:dichloroethane', 'gtceu:chlorine 6000')
         .outputFluids('gtceu:tetrachloroethylene 1000', 'gtceu:hydrochloric_acid 4000')
         .duration(600)
         .EUt(200);
 
-    event.recipes.gtceu.large_chemical_reactor('tetrachloroetylene')
+    event.recipes.gtceu.large_chemical_reactor(id('tetrachloroetylene'))
         .inputFluids('gtceu:dichloroethane', 'gtceu:chlorine 6000')
         .outputFluids('gtceu:tetrachloroethylene 1000', 'gtceu:hydrochloric_acid 4000')
         .duration(600)

--- a/kubejs/server_scripts/lines/sicbite_line.js
+++ b/kubejs/server_scripts/lines/sicbite_line.js
@@ -1,6 +1,7 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.electric_blast_furnace('silicon_carbide')
+    event.recipes.gtceu.electric_blast_furnace(id('silicon_carbide'))
         .itemInputs('gtceu:silicon_dioxide_dust','2x gtceu:activated_carbon_dust')
         .itemOutputs('gtceu:silicon_carbide_dust')
         .outputFluids('gtceu:carbon_dioxide')
@@ -8,7 +9,7 @@ ServerEvents.recipes(event => {
         .duration(500)
         .EUt(GTValues.VHA[GTValues.HV]);
 
-    event.recipes.gtceu.large_chemical_reactor('sicbite_1')
+    event.recipes.gtceu.large_chemical_reactor(id('sicbite_1'))
         .itemInputs('gtceu:borax_dust', '16x gtceu:sodium_dust')
         .inputFluids('gtceu:hydrogen 16000')
         .itemOutputs('4x gtceu:sodium_borohydride_dust', '7x gtceu:sodium_oxide_dust')
@@ -16,7 +17,7 @@ ServerEvents.recipes(event => {
         .duration(600)
         .EUt(GTValues.VHA[GTValues.IV]);
 
-    event.recipes.gtceu.large_chemical_reactor('sicbite_2')
+    event.recipes.gtceu.large_chemical_reactor(id('sicbite_2'))
         .itemInputs('gtceu:bismuth_dust')
         .inputFluids('gtceu:nitric_acid 4000')
         .itemOutputs('gtceu:bismuth_3_nitrate_dust')
@@ -24,7 +25,7 @@ ServerEvents.recipes(event => {
         .duration(400)
         .EUt(GTValues.VHA[GTValues.IV]);
 
-    event.recipes.gtceu.chemical_plant('sicbite_3')
+    event.recipes.gtceu.chemical_plant(id('sicbite_3'))
         .itemInputs('gtceu:silicon_carbide_dust', '2x gtceu:bismuth_3_nitrate_dust', '3x gtceu:tellurium_dust', '6x gtceu:sodium_borohydride_dust')
         .itemOutputs('gtceu:silicon_carbide_over_bismuth_tritelluride_dust', '6x gtceu:sodium_nitrate_dust')
         .outputFluids('gtceu:diborane 6000')

--- a/kubejs/server_scripts/lines/sicbite_line.js
+++ b/kubejs/server_scripts/lines/sicbite_line.js
@@ -1,5 +1,5 @@
 ServerEvents.recipes(event => {
-    const id = global.id;
+    const id = global.id;    
 
     event.recipes.gtceu.electric_blast_furnace(id('silicon_carbide'))
         .itemInputs('gtceu:silicon_dioxide_dust','2x gtceu:activated_carbon_dust')

--- a/kubejs/server_scripts/multiblock recipes/bacterial_multiblocks.js
+++ b/kubejs/server_scripts/multiblock recipes/bacterial_multiblocks.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     event.recipes.gtceu.assembly_line(id('bacterial_runic_mutator'))
         .itemInputs('gtceu:uhv_machine_hull', '4x gtceu:uhv_electric_motor', 'gtceu:zircalloy_4_gear', '2x gtceu:uhv_emitter', '4x #gtceu:circuits/uhv')

--- a/kubejs/server_scripts/multiblock recipes/bacterial_multiblocks.js
+++ b/kubejs/server_scripts/multiblock recipes/bacterial_multiblocks.js
@@ -1,6 +1,6 @@
 ServerEvents.recipes(event => {
 
-    event.recipes.gtceu.assembly_line('bacterial_runic_mutator')
+    event.recipes.gtceu.assembly_line(id('bacterial_runic_mutator'))
         .itemInputs('gtceu:uhv_machine_hull', '4x gtceu:uhv_electric_motor', 'gtceu:zircalloy_4_gear', '2x gtceu:uhv_emitter', '4x #gtceu:circuits/uhv')
         .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 1872', 'gtceu:naquadria 576')
         .itemOutputs('start_core:bacterial_runic_mutator')
@@ -13,7 +13,7 @@ ServerEvents.recipes(event => {
         //     )
         .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.assembly_line('bacterial_breeding_vat')
+    event.recipes.gtceu.assembly_line(id('bacterial_breeding_vat'))
         .itemInputs('gtceu:uhv_machine_hull', '4x gtceu:uhv_electric_pump', '4x gtceu:zircalloy_4_rotor', '2x gtceu:uhv_fluid_regulator', '4x #gtceu:circuits/uhv')
         .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 1872', 'gtceu:naquadria 576')
         .itemOutputs('start_core:bacterial_breeding_vat')
@@ -26,7 +26,7 @@ ServerEvents.recipes(event => {
         //     )
         .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.assembly_line('bacterial_hydrocarbon_harvester')
+    event.recipes.gtceu.assembly_line(id('bacterial_hydrocarbon_harvester'))
         .itemInputs('gtceu:uhv_machine_hull', '4x gtceu:uhv_electric_pump', 'gtceu:zircalloy_4_rotor', '2x gtceu:uhv_field_generator', '8x #gtceu:circuits/uhv')
         .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 1872', 'gtceu:naquadria 1158')
         .itemOutputs('start_core:bacterial_hydrocarbon_harvester')

--- a/kubejs/server_scripts/multiblock recipes/chemical_builder.js
+++ b/kubejs/server_scripts/multiblock recipes/chemical_builder.js
@@ -1,4 +1,5 @@
 // ServerEvents.recipes(event => {
+//     const id = global.id;
 
 //     event.recipes.gtceu.assembly_line(id('chemical_builder'))
 //         .itemInputs('gtceu:zpm_machine_hull', '4x gtceu:zpm_electric_motor', 'gtceu:weapon_grade_naquadah_rotor', '2x gtceu:duranium_large_fluid_pipe', '4x #gtceu:circuits/zpm')

--- a/kubejs/server_scripts/multiblock recipes/chemical_builder.js
+++ b/kubejs/server_scripts/multiblock recipes/chemical_builder.js
@@ -1,13 +1,13 @@
 // ServerEvents.recipes(event => {
 
-//     event.recipes.gtceu.assembly_line('chemical_builder')
+//     event.recipes.gtceu.assembly_line(id('chemical_builder'))
 //         .itemInputs('gtceu:zpm_machine_hull', '4x gtceu:zpm_electric_motor', 'gtceu:weapon_grade_naquadah_rotor', '2x gtceu:duranium_large_fluid_pipe', '4x #gtceu:circuits/zpm')
 //         .inputFluids('gtceu:soldering_alloy 1872', 'gtceu:naquadria 288', 'gtceu:polyether_ether_ketone 1008')
 //         .itemOutputs('gtceu:chemical_builder')
 //         .duration(950)
 //         .EUt(GTValues.VA[GTValues.UV]);
     
-//     event.recipes.gtceu.chemical_builder('propene')
+//     event.recipes.gtceu.chemical_builder(id('propene'))
 //         .itemInputs('3x gtceu:carbon_dust')
 //         .inputFluids('gtceu:hydrogen 6000')
 //         .outputFluids('gtceu:propene 1000')
@@ -15,7 +15,7 @@
 //         .EUt(GTValues.VHA[GTValues.IV])
 //         .circuit(0);
     
-//     event.recipes.gtceu.chemical_builder('ethane')
+//     event.recipes.gtceu.chemical_builder(id('ethane'))
 //         .itemInputs('2x gtceu:carbon_dust')
 //         .inputFluids('gtceu:hydrogen 6000')
 //         .outputFluids('gtceu:ethane 1000')
@@ -23,7 +23,7 @@
 //         .EUt(GTValues.VHA[GTValues.IV])
 //         .circuit(1);
     
-//     event.recipes.gtceu.chemical_builder('butene')
+//     event.recipes.gtceu.chemical_builder(id('butene'))
 //         .itemInputs('4x gtceu:carbon_dust')
 //         .inputFluids('gtceu:hydrogen 8000')
 //         .outputFluids('gtceu:butene 1000')
@@ -31,7 +31,7 @@
 //         .EUt(GTValues.VHA[GTValues.IV])
 //         .circuit(2);
 
-//     event.recipes.gtceu.chemical_builder('styrene')
+//     event.recipes.gtceu.chemical_builder(id('styrene'))
 //         .itemInputs('8x gtceu:carbon_dust')
 //         .inputFluids('gtceu:hydrogen 8000')
 //         .outputFluids('gtceu:styrene 1000')
@@ -39,7 +39,7 @@
 //         .EUt(GTValues.VHA[GTValues.IV])
 //         .circuit(3);
     
-//     event.recipes.gtceu.chemical_builder('phenol')
+//     event.recipes.gtceu.chemical_builder(id('phenol'))
 //         .itemInputs('6x gtceu:carbon_dust')
 //         .inputFluids('gtceu:hydrogen 6000', 'gtceu:oxygen 1000')
 //         .outputFluids('gtceu:phenol 1000')
@@ -47,7 +47,7 @@
 //         .EUt(GTValues.VHA[GTValues.IV])
 //         .circuit(4);
     
-//     event.recipes.gtceu.chemical_builder('acetone')
+//     event.recipes.gtceu.chemical_builder(id('acetone'))
 //         .itemInputs('3x gtceu:carbon_dust')
 //         .inputFluids('gtceu:hydrogen 6000', 'gtceu:oxygen 1000')
 //         .outputFluids('gtceu:acetone 1000')
@@ -55,7 +55,7 @@
 //         .EUt(GTValues.VHA[GTValues.IV])
 //         .circuit(5);
 
-//     event.recipes.gtceu.chemical_builder('toluene')
+//     event.recipes.gtceu.chemical_builder(id('toluene'))
 //         .itemInputs('7x gtceu:carbon_dust')
 //         .inputFluids('gtceu:hydrogen 8000')
 //         .outputFluids('gtceu:toluene 1000')
@@ -63,7 +63,7 @@
 //         .EUt(GTValues.VHA[GTValues.IV])
 //         .circuit(6);
 
-//     event.recipes.gtceu.chemical_builder('benzene')
+//     event.recipes.gtceu.chemical_builder(id('benzene'))
 //         .itemInputs('6x gtceu:carbon_dust')
 //         .inputFluids('gtceu:hydrogen 6000')
 //         .outputFluids('gtceu:benzene 1000')
@@ -71,7 +71,7 @@
 //         .EUt(GTValues.VHA[GTValues.IV])
 //         .circuit(15);
 
-//     event.recipes.gtceu.chemical_builder('butadiene')
+//     event.recipes.gtceu.chemical_builder(id('butadiene'))
 //         .itemInputs('4x gtceu:carbon_dust')
 //         .inputFluids('gtceu:hydrogen 6000')
 //         .outputFluids('gtceu:butadiene 1000')
@@ -79,7 +79,7 @@
 //         .EUt(GTValues.VHA[GTValues.IV])
 //         .circuit(8);
 
-//     event.recipes.gtceu.chemical_builder('ethylene')
+//     event.recipes.gtceu.chemical_builder(id('ethylene'))
 //         .itemInputs('2x gtceu:carbon_dust')
 //         .inputFluids('gtceu:hydrogen 4000')
 //         .outputFluids('gtceu:ethylene 1000')
@@ -87,7 +87,7 @@
 //         .EUt(GTValues.VHA[GTValues.IV])
 //         .circuit(9);
     
-//     event.recipes.gtceu.chemical_builder('octane')
+//     event.recipes.gtceu.chemical_builder(id('octane'))
 //         .itemInputs('8x gtceu:carbon_dust')
 //         .inputFluids('gtceu:hydrogen 18000')
 //         .outputFluids('gtceu:octane 1000')
@@ -95,7 +95,7 @@
 //         .EUt(GTValues.VHA[GTValues.IV])
 //         .circuit(10);
     
-//     event.recipes.gtceu.chemical_builder('acetic_acid')
+//     event.recipes.gtceu.chemical_builder(id('acetic_acid'))
 //         .itemInputs('2x gtceu:carbon_dust')
 //         .inputFluids('gtceu:hydrogen 4000', 'gtceu:oxygen 2000')
 //         .outputFluids('gtceu:acetic_acid 1000')
@@ -103,7 +103,7 @@
 //         .EUt(GTValues.VHA[GTValues.IV])
 //         .circuit(11);
 
-//     event.recipes.gtceu.chemical_builder('methanol')
+//     event.recipes.gtceu.chemical_builder(id('methanol'))
 //         .itemInputs('gtceu:carbon_dust')
 //         .inputFluids('gtceu:hydrogen 4000', 'gtceu:oxygen 1000')
 //         .outputFluids('gtceu:methanol 1000')
@@ -111,7 +111,7 @@
 //         .EUt(GTValues.VHA[GTValues.IV])
 //         .circuit(12);
 
-//     event.recipes.gtceu.chemical_builder('ethanol')
+//     event.recipes.gtceu.chemical_builder(id('ethanol'))
 //         .itemInputs('2x gtceu:carbon_dust')
 //         .inputFluids('gtceu:hydrogen 6000', 'gtceu:oxygen 1000')
 //         .outputFluids('gtceu:ethanol 1000')
@@ -119,7 +119,7 @@
 //         .EUt(GTValues.VHA[GTValues.IV])
 //         .circuit(13);
 
-//     event.recipes.gtceu.chemical_builder('methyl_acetate')
+//     event.recipes.gtceu.chemical_builder(id('methyl_acetate'))
 //         .itemInputs('3x gtceu:carbon_dust')
 //         .inputFluids('gtceu:hydrogen 6000', 'gtceu:oxygen 2000')
 //         .outputFluids('gtceu:methyl_acetate 1000')

--- a/kubejs/server_scripts/multiblock recipes/chemical_plant.js
+++ b/kubejs/server_scripts/multiblock recipes/chemical_plant.js
@@ -1,5 +1,6 @@
 
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     event.recipes.gtceu.assembly_line(id('chemical_plant_controller'))
         .itemInputs('gtceu:zpm_machine_hull', '4x gtceu:zpm_electric_motor', 'gtceu:naquadah_alloy_rotor', '2x gtceu:niobium_titanium_large_fluid_pipe', '4x #gtceu:circuits/uv')

--- a/kubejs/server_scripts/multiblock recipes/chemical_plant.js
+++ b/kubejs/server_scripts/multiblock recipes/chemical_plant.js
@@ -1,7 +1,7 @@
 
 ServerEvents.recipes(event => {
 
-    event.recipes.gtceu.assembly_line('chemical_plant_controller')
+    event.recipes.gtceu.assembly_line(id('chemical_plant_controller'))
         .itemInputs('gtceu:zpm_machine_hull', '4x gtceu:zpm_electric_motor', 'gtceu:naquadah_alloy_rotor', '2x gtceu:niobium_titanium_large_fluid_pipe', '4x #gtceu:circuits/uv')
         .inputFluids('gtceu:soldering_alloy 1872', 'gtceu:naquadria 288')
         .itemOutputs('gtceu:chemical_plant')
@@ -14,35 +14,35 @@ ServerEvents.recipes(event => {
             )
         .EUt(GTValues.VHA[GTValues.UV]);
 
-    event.recipes.gtceu.assembler('peek_casing')
+    event.recipes.gtceu.assembler(id('peek_casing'))
         .itemInputs('gtceu:robust_machine_casing')
         .inputFluids('gtceu:polyether_ether_ketone 216')
         .itemOutputs('kubejs:peek_casing')
         .duration(600)
         .EUt(GTValues.VA[GTValues.LuV]);
 
-    event.recipes.gtceu.chemical_plant('fluoroantimonic_acid')
+    event.recipes.gtceu.chemical_plant(id('fluoroantimonic_acid'))
         .itemInputs('gtceu:antimony_dust')
         .inputFluids('gtceu:hydrogen 2000', 'gtceu:fluorine 7000')
         .outputFluids('gtceu:fluoroantimonic_acid 1000')
         .duration(200)
         .EUt(GTValues.VHA[GTValues.LuV]);
 
-    event.recipes.gtceu.chemical_plant('polybenzimidazole_with_phenol')
+    event.recipes.gtceu.chemical_plant(id('polybenzimidazole_with_phenol'))
         .inputFluids('gtceu:benzene 2000', 'gtceu:phenol 1000', 'gtceu:carbon_dioxide 2000', 'gtceu:ammonia 4000', 'gtceu:oxygen 4000')
         .outputFluids('gtceu:polybenzimidazole 1000', 'minecraft:water 9000')
         .circuit(24)
         .duration(400)
         .EUt(GTValues.VHA[GTValues.ZPM]);
 
-    event.recipes.gtceu.chemical_plant('polybenzimidazole_without_phenol')
+    event.recipes.gtceu.chemical_plant(id('polybenzimidazole_without_phenol'))
         .inputFluids('gtceu:benzene 3000', 'gtceu:carbon_dioxide 2000', 'gtceu:ammonia 4000', 'gtceu:oxygen 5000')
         .outputFluids('gtceu:polybenzimidazole 1000', 'minecraft:water 9000')
         .circuit(25)
         .duration(400)
         .EUt(GTValues.VHA[GTValues.ZPM]);
 
-        event.recipes.gtceu.chemical_plant('plat_line')
+        event.recipes.gtceu.chemical_plant(id('plat_line'))
         .itemInputs('6x gtceu:platinum_group_sludge_dust')
         .inputFluids('gtceu:aqua_regia 1500')
         .itemOutputs('gtceu:platinum_dust', 'gtceu:palladium_dust', 'gtceu:ruthenium_dust', 'gtceu:rhodium_dust', 'gtceu:osmium_dust', 'gtceu:iridium_dust')
@@ -50,7 +50,7 @@ ServerEvents.recipes(event => {
         .duration(600)
         .EUt(GTValues.VHA[GTValues.ZPM]);
 
-    event.recipes.gtceu.chemical_plant('sulfuric_acid')
+    event.recipes.gtceu.chemical_plant(id('sulfuric_acid'))
         .itemInputs('gtceu:sulfur_dust')
         .inputFluids('minecraft:water 4000')
         .outputFluids('gtceu:sulfuric_acid 1000')
@@ -58,20 +58,20 @@ ServerEvents.recipes(event => {
         .EUt(480)
         .circuit(24);
 
-    event.recipes.gtceu.chemical_plant('ptfe')
+    event.recipes.gtceu.chemical_plant(id('ptfe'))
         .itemInputs('2x gtceu:carbon_dust')
         .inputFluids('gtceu:fluorine 4000')
         .outputFluids('gtceu:tetrafluoroethylene 1000')
         .duration(480)
         .EUt(GTValues.VHA[GTValues.LuV]);
 
-    event.recipes.gtceu.chemical_plant('epoxy')
+    event.recipes.gtceu.chemical_plant(id('epoxy'))
         .inputFluids('gtceu:benzene 2000', 'gtceu:propene 2000', 'gtceu:chlorine 2000', 'gtceu:oxygen 4000')
         .outputFluids('gtceu:epoxy 1000', 'gtceu:hydrochloric_acid 1000')
         .duration(500)
         .EUt(GTValues.VHA[GTValues.ZPM]);
 
-    event.recipes.gtceu.chemical_plant('naquadah_line')
+    event.recipes.gtceu.chemical_plant(id('naquadah_line'))
         .itemInputs('2x gtceu:naquadah_dust')
         .inputFluids('gtceu:fluoroantimonic_acid 1000')
         .itemOutputs('gtceu:enriched_naquadah_dust', 'gtceu:naquadria_dust', 'gtceu:trinium_dust', 'gtceu:antimony_dust', 'gtceu:indium_phosphide_dust')

--- a/kubejs/server_scripts/multiblock recipes/cobbleworks.js
+++ b/kubejs/server_scripts/multiblock recipes/cobbleworks.js
@@ -1,7 +1,7 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.assembler('cobbleworks')
+    event.recipes.gtceu.assembler(id('cobbleworks'))
         .itemInputs('gtceu:iv_machine_hull', '2x #gtceu:circuits/iv', '2x gtceu:double_maraging_steel_300_plate' ,'4x gtceu:pure_netherite_gear')
         .itemOutputs('gtceu:cobbleworks')
         .duration(1200)
@@ -10,7 +10,7 @@ ServerEvents.recipes(event => {
     const overclock = [256, 512, 1024, 2048];
 
     for (let i = 0; i < 4; i++) {
-        event.recipes.gtceu.cobbleworks(`cobble_to_gravel_${i}`)
+        event.recipes.gtceu.cobbleworks(id(`cobble_to_gravel_${i}`))
             .chancedFluidInput('minecraft:water 1', 1, 0)
             .chancedFluidInput('minecraft:lava 1', 1, 0)
             .itemOutputs(`${overclock[i]}x minecraft:gravel`)
@@ -18,7 +18,7 @@ ServerEvents.recipes(event => {
             .EUt(320)
             .circuit(i);
 
-        event.recipes.gtceu.cobbleworks(`cobble_to_sand_${i + 4}`)
+        event.recipes.gtceu.cobbleworks(id(`cobble_to_sand_${i + 4}`))
             .chancedFluidInput('minecraft:water 1', 1, 0)
             .chancedFluidInput('minecraft:lava 1', 1, 0)
             .itemOutputs(`${overclock[i]}x minecraft:sand`)
@@ -26,7 +26,7 @@ ServerEvents.recipes(event => {
             .EUt(320)
             .circuit(i + 4);
 
-        event.recipes.gtceu.cobbleworks(`cobble_to_dust_${i + 8}`)
+        event.recipes.gtceu.cobbleworks(id(`cobble_to_dust_${i + 8}`))
             .chancedFluidInput('minecraft:water 1', 1, 0)
             .chancedFluidInput('minecraft:lava 1', 1, 0)
             .itemOutputs(`${overclock[i]}x exnihilosequentia:dust`)
@@ -34,7 +34,7 @@ ServerEvents.recipes(event => {
             .EUt(320)
             .circuit(i + 8);
 
-        event.recipes.gtceu.cobbleworks(`blackstone_to_crushed_blackstone_${i}`)
+        event.recipes.gtceu.cobbleworks(id(`blackstone_to_crushed_blackstone_${i}`))
             .chancedFluidInput('exnihilosequentia:witch_water 1', 1, 0)
             .chancedFluidInput('minecraft:lava 1', 1, 0)
             .itemOutputs(`${overclock[i]}x exnihilosequentia:crushed_blackstone`)

--- a/kubejs/server_scripts/multiblock recipes/greenhouse and large farm/large_farm_and_crop_greenhouse.js
+++ b/kubejs/server_scripts/multiblock recipes/greenhouse and large farm/large_farm_and_crop_greenhouse.js
@@ -1,5 +1,5 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     event.shaped(Item.of('gtceu:large_farm'), [
         'SPS',
@@ -68,14 +68,14 @@ ServerEvents.recipes(event => {
         { name: 'minecraft:rose_bush' },
         { name: 'minecraft:peony' }
     ].forEach(crop => {
-        event.recipes.gtceu.large_farm(`${crop.name.split(':')[1]}${(!crop.name.startsWith('minecraft')) ? '_' + crop.name.split(':')[0] : ''}_harvest`)
+        event.recipes.gtceu.large_farm(id(`${crop.name.split(':')[1]}${(!crop.name.startsWith('minecraft')) ? '_' + crop.name.split(':')[0] : ''}_harvest`))
             .itemInputs(`8x ${(crop.seed) ? crop.seed : crop.name}`)
             .itemOutputs(`16x ${crop.name}`)
             .chancedOutput(`8x ${(crop.seed) ? crop.seed : crop.name}`, 5000, 0)
             .daytime()
             .duration(800);
 
-        event.recipes.gtceu.crop_greenhouse(`${crop.name.split(':')[1]}${(!crop.name.startsWith('minecraft')) ? '_' + crop.name.split(':')[0] : ''}_harvest_no_fertilizer`)
+        event.recipes.gtceu.crop_greenhouse(id(`${crop.name.split(':')[1]}${(!crop.name.startsWith('minecraft')) ? '_' + crop.name.split(':')[0] : ''}_harvest_no_fertilizer`))
             .itemInputs(`8x ${(crop.seed) ? crop.seed : crop.name}`)
             .inputFluids('minecraft:water 100')
             .itemOutputs(`16x ${crop.name}`)
@@ -84,7 +84,7 @@ ServerEvents.recipes(event => {
             .EUt(global.vha['lv'])
             .circuit(0);
 
-        event.recipes.gtceu.crop_greenhouse(`${crop.name.split(':')[1]}${(!crop.name.startsWith('minecraft')) ? '_' + crop.name.split(':')[0] : ''}_harvest_bone_meal`)
+        event.recipes.gtceu.crop_greenhouse(id(`${crop.name.split(':')[1]}${(!crop.name.startsWith('minecraft')) ? '_' + crop.name.split(':')[0] : ''}_harvest_bone_meal`))
             .itemInputs(`8x ${(crop.seed) ? crop.seed : crop.name}`)
             .chancedInput('minecraft:bone_meal', 7500, -500)
             .inputFluids('minecraft:water 100')
@@ -94,7 +94,7 @@ ServerEvents.recipes(event => {
             .EUt(global.vha['lv'])
             .circuit(1);
 
-        event.recipes.gtceu.crop_greenhouse(`${crop.name.split(':')[1]}${(!crop.name.startsWith('minecraft')) ? '_' + crop.name.split(':')[0] : ''}_harvest_compost`)
+        event.recipes.gtceu.crop_greenhouse(id(`${crop.name.split(':')[1]}${(!crop.name.startsWith('minecraft')) ? '_' + crop.name.split(':')[0] : ''}_harvest_compost`))
             .itemInputs(`8x ${(crop.seed) ? crop.seed : crop.name}`)
             .chancedInput('thermal:compost', 7500, -500)
             .inputFluids('minecraft:water 100')
@@ -104,7 +104,7 @@ ServerEvents.recipes(event => {
             .EUt(global.vha['lv'])
             .circuit(2);
 
-        event.recipes.gtceu.crop_greenhouse(`${crop.name.split(':')[1]}${(!crop.name.startsWith('minecraft')) ? '_' + crop.name.split(':')[0] : ''}_harvest_fertilizer`)
+        event.recipes.gtceu.crop_greenhouse(id(`${crop.name.split(':')[1]}${(!crop.name.startsWith('minecraft')) ? '_' + crop.name.split(':')[0] : ''}_harvest_fertilizer`))
             .itemInputs(`8x ${(crop.seed) ? crop.seed : crop.name}`)
             .chancedInput('gtceu:fertilizer', 7500, -500)
             .inputFluids('minecraft:water 100')

--- a/kubejs/server_scripts/multiblock recipes/greenhouse and large farm/large_farm_and_crop_greenhouse.js
+++ b/kubejs/server_scripts/multiblock recipes/greenhouse and large farm/large_farm_and_crop_greenhouse.js
@@ -9,7 +9,7 @@ ServerEvents.recipes(event => {
         S: 'gtceu:treated_wood_rod',
         P: 'gtceu:treated_wood_planks',
         B: 'minecraft:bone_meal'
-    });
+    }).id('start:shaped/large_farm');
 
     [
         { name: 'minecraft:wheat', seed: 'minecraft:wheat_seeds' },

--- a/kubejs/server_scripts/multiblock recipes/greenhouse and large farm/tree_greenhouse.js
+++ b/kubejs/server_scripts/multiblock recipes/greenhouse and large farm/tree_greenhouse.js
@@ -50,6 +50,6 @@ ServerEvents.recipes(event => {
         H: 'gtceu:lv_machine_hull',
         S: 'gtceu:steel_plate',
         C: '#gtceu:circuits/mv'
-    });
+    }).id('start:shaped/greenhouse');
 
 });

--- a/kubejs/server_scripts/multiblock recipes/greenhouse and large farm/tree_greenhouse.js
+++ b/kubejs/server_scripts/multiblock recipes/greenhouse and large farm/tree_greenhouse.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     [
         { name: 'oak', sapling: 'oak_sapling', namespace: 'minecraft'},
@@ -11,7 +12,7 @@ ServerEvents.recipes(event => {
         { name: 'mangrove', sapling: 'mangrove_propagule', namespace: 'minecraft'},
         { name: 'twisted', sapling: 'twisted_sapling', namespace: 'architects_palette'},
     ].forEach(type => {
-        event.recipes.gtceu.tree_greenhouse(`${type.name}_growing`)
+        event.recipes.gtceu.tree_greenhouse(id(`${type.name}_growing`))
             .notConsumable(`${type.namespace}:${type.sapling}`)
             .itemOutputs(`16x ${type.namespace}:${type.name}_log`)
             .inputFluids('minecraft:water 100')
@@ -19,7 +20,7 @@ ServerEvents.recipes(event => {
             .circuit(0)
             .EUt(global.va['lv']);
 
-        event.recipes.gtceu.tree_greenhouse(`${type.name}_co2_growing`)
+        event.recipes.gtceu.tree_greenhouse(id(`${type.name}_co2_growing`))
             .notConsumable(`${type.namespace}:${type.sapling}`)
             .itemOutputs(`64x ${type.namespace}:${type.name}_log`)
             .outputFluids('gtceu:oxygen 1000')
@@ -28,7 +29,7 @@ ServerEvents.recipes(event => {
             .circuit(1)
             .EUt(global.va['lv']);
 
-        event.recipes.gtceu.tree_greenhouse(`${type.name}_npkco2_growing`)
+        event.recipes.gtceu.tree_greenhouse(id(`${type.name}_npkco2_growing`))
             .notConsumable(`${type.namespace}:${type.sapling}`)
             .itemOutputs(`64x ${type.namespace}:${type.name}_log`, `64x ${type.namespace}:${type.name}_log`)
             .outputFluids('gtceu:oxygen 2500')

--- a/kubejs/server_scripts/multiblock recipes/greenhouse and large farm/wild_garden.js
+++ b/kubejs/server_scripts/multiblock recipes/greenhouse and large farm/wild_garden.js
@@ -1,7 +1,7 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.wild_garden('flowers')
+    event.recipes.gtceu.wild_garden(id('flowers'))
         .itemInputs('minecraft:bone_meal')
         .chancedOutput('minecraft:dandelion', 800, 200)
         .chancedOutput('minecraft:poppy', 800, 200)
@@ -19,7 +19,7 @@ ServerEvents.recipes(event => {
         .EUt(global.vha['lv'])
         .circuit(0);
 
-    event.recipes.gtceu.wild_garden('tall_flowers_and_wither_rose')
+    event.recipes.gtceu.wild_garden(id('tall_flowers_and_wither_rose'))
         .itemInputs('minecraft:bone_meal')
         .chancedOutput('minecraft:torchflower_seeds', 200, 200)
         .chancedOutput('minecraft:pitcher_pod', 200, 200)
@@ -32,7 +32,7 @@ ServerEvents.recipes(event => {
         .EUt(global.vha['lv'])
         .circuit(1);
 
-    event.recipes.gtceu.wild_garden('wild_crops')
+    event.recipes.gtceu.wild_garden(id('wild_crops'))
         .itemInputs('minecraft:bone_meal')
         .chancedOutput('minecraft:glow_berries', 500, 200)
         .chancedOutput('farmersdelight:wild_cabbages', 800, 200)
@@ -43,7 +43,7 @@ ServerEvents.recipes(event => {
         .EUt(global.vha['lv'])
         .circuit(2);
 
-    event.recipes.gtceu.wild_garden('thermal_crops_1')
+    event.recipes.gtceu.wild_garden(id('thermal_crops_1'))
         .itemInputs('minecraft:bone_meal')
         .chancedOutput('thermal:barley_seeds', 800, 200)
         .chancedOutput('thermal:corn_seeds', 800, 200)
@@ -60,7 +60,7 @@ ServerEvents.recipes(event => {
         .EUt(global.vha['lv'])
         .circuit(3);
 
-    event.recipes.gtceu.wild_garden('thermal_crops_2')
+    event.recipes.gtceu.wild_garden(id('thermal_crops_2'))
         .itemInputs('minecraft:bone_meal')
         .chancedOutput('thermal:amaranth_seeds', 800, 200)
         .chancedOutput('thermal:sadiroot_seeds', 800, 200)

--- a/kubejs/server_scripts/multiblock recipes/kinetic_box.js
+++ b/kubejs/server_scripts/multiblock recipes/kinetic_box.js
@@ -1,5 +1,6 @@
 
 // ServerEvents.recipes(event => {
+//      const id = global.id;
 
 //     event.shaped(Item.of('gtceu:kinetic_box'), [
 //         ' V ',
@@ -9,7 +10,7 @@
 //         G: 'gtceu:iron_gear',
 //         V: 'gtceu:lv_voltage_coil',
 //         C: 'gtceu:steel_machine_casing'
-//     });
+//     }).id('start:shaped/kinetic_box');
 
 //     event.recipes.gtceu.kinetic_box(id('lv_stress'))
 //         .outputStress(1024)

--- a/kubejs/server_scripts/multiblock recipes/kinetic_box.js
+++ b/kubejs/server_scripts/multiblock recipes/kinetic_box.js
@@ -11,7 +11,7 @@
 //         C: 'gtceu:steel_machine_casing'
 //     });
 
-//     event.recipes.gtceu.kinetic_box('lv_stress')
+//     event.recipes.gtceu.kinetic_box(id('lv_stress'))
 //         .outputStress(1024)
 //         .EUt(32)
 //         .rpm(32);

--- a/kubejs/server_scripts/multiblock recipes/large_barrel.js
+++ b/kubejs/server_scripts/multiblock recipes/large_barrel.js
@@ -10,7 +10,7 @@ ServerEvents.recipes(event => {
         S: 'gtceu:treated_wood_rod',
         B: 'gtceu:ulv_barrel',
         I: 'gtceu:wrought_iron_plate'
-    });
+    }).id('start:shaped/large_barrel');
 
     event.recipes.gtceu.large_barrel(id('witch_water'))
         .notConsumable('exnihilosequentia:mycelium_spores')
@@ -54,7 +54,7 @@ ServerEvents.recipes(event => {
         .chancedOutput('thermal:slime_mushroom_spores', 9500, 0)
         .duration(20);
 
-    event.shapeless(Item.of('3x minecraft:brown_mushroom'), ['minecraft:brown_mushroom_block', '#forge:tools/mortars']);
+    event.shapeless(Item.of('3x minecraft:brown_mushroom'), ['minecraft:brown_mushroom_block', '#forge:tools/mortars']).id('start:shapeless/brown_mushroom');
     event.recipes.gtceu.macerator(id('brown_mushrooms'))
         .itemInputs('minecraft:brown_mushroom_block')
         .itemOutputs('3x minecraft:brown_mushroom')
@@ -62,7 +62,7 @@ ServerEvents.recipes(event => {
         .duration(45)
         .EUt(8);
 
-    event.shapeless(Item.of('3x minecraft:red_mushroom'), ['minecraft:red_mushroom_block', '#forge:tools/mortars']);
+    event.shapeless(Item.of('3x minecraft:red_mushroom'), ['minecraft:red_mushroom_block', '#forge:tools/mortars']).id('start:shapeless/red_mushroom');
     event.recipes.gtceu.macerator(id('red_mushrooms'))
         .itemInputs('minecraft:red_mushroom_block')
         .itemOutputs('3x minecraft:red_mushroom')

--- a/kubejs/server_scripts/multiblock recipes/large_barrel.js
+++ b/kubejs/server_scripts/multiblock recipes/large_barrel.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     event.shaped(Item.of('gtceu:large_barrel'), [
         'PSP',
@@ -11,50 +12,50 @@ ServerEvents.recipes(event => {
         I: 'gtceu:wrought_iron_plate'
     });
 
-    event.recipes.gtceu.large_barrel('witch_water')
+    event.recipes.gtceu.large_barrel(id('witch_water'))
         .notConsumable('exnihilosequentia:mycelium_spores')
         .inputFluids('minecraft:water 1000')
         .outputFluids('exnihilosequentia:witch_water 1000')
         .duration(80);
 
-    event.recipes.gtceu.large_barrel('to_clay')
+    event.recipes.gtceu.large_barrel(id('to_clay'))
         .itemInputs('exnihilosequentia:dust')
         .inputFluids('minecraft:water 1000')
         .itemOutputs('minecraft:clay')
         .duration(1);
 
-    event.recipes.gtceu.large_barrel('to_ssand')
+    event.recipes.gtceu.large_barrel(id('to_ssand'))
         .itemInputs('minecraft:sand')
         .inputFluids('exnihilosequentia:witch_water 100')
         .itemOutputs('minecraft:soul_sand')
         .duration(1);
 
-    event.recipes.gtceu.large_barrel('to_slime')
+    event.recipes.gtceu.large_barrel(id('to_slime'))
         .itemInputs('#forge:mushrooms')
         .inputFluids('exnihilosequentia:witch_water 1000')
         .itemOutputs('minecraft:slime_block')
         .duration(1);
 
-    event.recipes.gtceu.large_barrel('to_bshroom')
+    event.recipes.gtceu.large_barrel(id('to_bshroom'))
         .itemInputs('exnihilosequentia:mycelium_spores')
         .inputFluids('exnihilosequentia:witch_water 1000')
         .itemOutputs('minecraft:brown_mushroom_block')
         .duration(1);
 
-    event.recipes.gtceu.large_barrel('to_rshroom')
+    event.recipes.gtceu.large_barrel(id('to_rshroom'))
         .itemInputs('minecraft:brown_mushroom_block')
         .inputFluids('exnihilosequentia:witch_water 1000')
         .itemOutputs('minecraft:red_mushroom_block')
         .duration(1);
 
-    event.recipes.gtceu.large_barrel('slimeshroom_dupe')
+    event.recipes.gtceu.large_barrel(id('slimeshroom_dupe'))
         .notConsumable('thermal:slime_mushroom_spores')
         .inputFluids('exnihilosequentia:witch_water 100')
         .chancedOutput('thermal:slime_mushroom_spores', 9500, 0)
         .duration(20);
 
     event.shapeless(Item.of('3x minecraft:brown_mushroom'), ['minecraft:brown_mushroom_block', '#forge:tools/mortars']);
-    event.recipes.gtceu.macerator('brown_mushrooms')
+    event.recipes.gtceu.macerator(id('brown_mushrooms'))
         .itemInputs('minecraft:brown_mushroom_block')
         .itemOutputs('3x minecraft:brown_mushroom')
         .chancedOutput('minecraft:brown_mushroom', 5000, 0)
@@ -62,7 +63,7 @@ ServerEvents.recipes(event => {
         .EUt(8);
 
     event.shapeless(Item.of('3x minecraft:red_mushroom'), ['minecraft:red_mushroom_block', '#forge:tools/mortars']);
-    event.recipes.gtceu.macerator('red_mushrooms')
+    event.recipes.gtceu.macerator(id('red_mushrooms'))
         .itemInputs('minecraft:red_mushroom_block')
         .itemOutputs('3x minecraft:red_mushroom')
         .chancedOutput('minecraft:red_mushroom', 5000, 0)
@@ -71,14 +72,14 @@ ServerEvents.recipes(event => {
 
     // Credit: Schrubbls
     function concreteRecipe(event, color) {
-        event.recipes.gtceu.large_barrel(`start:vanilla_concrete_and_dye_${color}`)
+        event.recipes.gtceu.large_barrel(id(`vanilla_concrete_and_dye_${color}`))
             .itemInputs(`minecraft:${color}_concrete_powder`)
             .inputFluids('gtceu:distilled_water 500')
             .itemOutputs(`minecraft:${color}_concrete`)
             .outputFluids(`gtceu:${color}_dye 9`)
             .duration(10)
     
-        event.recipes.gtceu.large_barrel(`start:vanilla_concrete_${color}`)
+        event.recipes.gtceu.large_barrel(id(`vanilla_concrete_${color}`))
             .itemInputs(`minecraft:${color}_concrete_powder`)
             .inputFluids('minecraft:water 1000')
             .itemOutputs(`minecraft:${color}_concrete`)
@@ -104,21 +105,21 @@ ServerEvents.recipes(event => {
 
     // Mycelium Growths
 
-    event.recipes.gtceu.large_barrel('mycelium_growth_compost')
+    event.recipes.gtceu.large_barrel(id('mycelium_growth_compost'))
         .duration(400)
         .itemInputs('thermal:compost', 'exnihilosequentia:mycelium_spores')
         .itemOutputs('kubejs:mycelium_growth')
-    event.recipes.gtceu.large_barrel('mycelium_growth_bonemeal')
+    event.recipes.gtceu.large_barrel(id('mycelium_growth_bonemeal'))
         .duration(600)
         .itemInputs('minecraft:bone_meal', 'exnihilosequentia:mycelium_spores')
         .itemOutputs('kubejs:mycelium_growth')
-    event.recipes.gtceu.large_barrel('mycelium_growth_sawdust')
+    event.recipes.gtceu.large_barrel(id('mycelium_growth_sawdust'))
         .duration(400)
         .itemInputs('gtceu:wood_dust', 'exnihilosequentia:mycelium_spores')
         .itemOutputs('kubejs:mycelium_growth')
 
     // Mycelium Spores
-    event.recipes.gtceu.large_barrel('mycelium_spores')
+    event.recipes.gtceu.large_barrel(id('mycelium_spores'))
         .duration(300)
         .notConsumable('minecraft:red_mushroom_block')
         .itemInputs('4x minecraft:dirt')

--- a/kubejs/server_scripts/multiblock recipes/large_rock_crusher.js
+++ b/kubejs/server_scripts/multiblock recipes/large_rock_crusher.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     [
         {stone: 'andesite', energy: 60},
@@ -14,7 +15,7 @@ ServerEvents.recipes(event => {
         {stone: 'stone', energy: 60},
         {stone: 'tuff', energy: 7}
     ].forEach(type=> {
-        event.recipes.gtceu.large_rock_crusher(type.stone)
+        event.recipes.gtceu.large_rock_crusher(id(type.stone))
             .notConsumable(`minecraft:${type.stone}`)
             .notConsumableFluid('minecraft:water 1000')
             .notConsumableFluid('minecraft:lava 1000')
@@ -27,7 +28,7 @@ ServerEvents.recipes(event => {
         {stone: 'red_granite', energy: 960},
         {stone: 'marble', energy: 240}
     ].forEach(type=> {
-        event.recipes.gtceu.large_rock_crusher(type.stone)
+        event.recipes.gtceu.large_rock_crusher(id(type.stone))
             .notConsumable(`gtceu:${type.stone}`)
             .notConsumableFluid('minecraft:water 1000')
             .notConsumableFluid('minecraft:lava 1000')

--- a/kubejs/server_scripts/multiblock recipes/large_sieve.js
+++ b/kubejs/server_scripts/multiblock recipes/large_sieve.js
@@ -1,5 +1,6 @@
 
 // ServerEvents.recipes(event => {
+//     const id = global.id;
 
 //     event.recipes.gtceu.assembler(id('large_sieve'))
 //         .itemInputs('gtceu:iv_machine_hull', '2x #gtceu:circuits/iv', '2x gtceu:double_tungsten_steel_plate' ,'4x gtceu:pure_netherite_gear')

--- a/kubejs/server_scripts/multiblock recipes/large_sieve.js
+++ b/kubejs/server_scripts/multiblock recipes/large_sieve.js
@@ -1,13 +1,13 @@
 
 // ServerEvents.recipes(event => {
 
-//     event.recipes.gtceu.assembler('large_sieve')
+//     event.recipes.gtceu.assembler(id('large_sieve'))
 //         .itemInputs('gtceu:iv_machine_hull', '2x #gtceu:circuits/iv', '2x gtceu:double_tungsten_steel_plate' ,'4x gtceu:pure_netherite_gear')
 //         .itemOutputs('gtceu:large_sieve')
 //         .duration(1200)
 //         .EUt(1240);
 
-//     event.recipes.gtceu.large_sieve('gravel_sieving')
+//     event.recipes.gtceu.large_sieve(id('gravel_sieving'))
 //         .itemInputs('64x minecraft:gravel')
 //         .itemOutputs('64x gtceu:crushed_tin_ore', '64x gtceu:crushed_copper_ore', '64x gtceu:crushed_iron_ore', '64x gtceu:crushed_sphalerite_ore', '64x gtceu:crushed_magnetite_ore',)
 //             // '64x gtceu:crushed_chalcopyrite_ore', '64x gtceu:crushed_gold_ore', '64x gtceu:crushed_cassiterite_ore', '64x gtceu:crushed_silver_ore',
@@ -17,7 +17,7 @@
 //         .duration(400)
 //         .EUt(6400);
 
-//     event.recipes.gtceu.large_sieve('sand_sieving')
+//     event.recipes.gtceu.large_sieve(id('sand_sieving'))
 //         .itemInputs('64x minecraft:sand')
 //         .itemOutputs('64x minecraft:diamond', '64x minecraft:emerald', '64x minecraft:amethyst_shard', '64x minecraft:quartz', '64x minecraft:lapis_lazuli',)
 //             // '64x minecraft:coal', '64x gtceu:crushed_diamond_ore', '64x gtceu:crushed_quartzite_ore', '64x gtceu:crushed_green_sapphire_ore', 
@@ -28,13 +28,13 @@
 //         .duration(400)
 //         .EUt(6400);
 
-//     event.recipes.gtceu.large_sieve('dust_sieving')
+//     event.recipes.gtceu.large_sieve(id('dust_sieving'))
 //         .itemInputs('64x exnihilosequentia:dust')
 //         .itemOutputs('64x minecraft:ender_pearl', '64x minecraft:glowstone_dust', '64x minecraft:redstone', '64x gtceu:sulfur_dust',)// '64x ae2:sky_dust', '64x minecraft:echo_shard')
 //         .duration(400)
 //         .EUt(6400);
 
-//     event.recipes.gtceu.large_sieve('blackstone_sieving')
+//     event.recipes.gtceu.large_sieve(id('blackstone_sieving'))
 //         .itemInputs('64x exnihilosequentia:crushed_blackstone')
 //         .itemOutputs('64x gtceu:crushed_stibnite_ore', '64x gtceu:crushed_galena_ore',)// '64x gtceu:crushed_pentlandite_ore', '64x gtceu:crushed_bornite_ore', 
 //             // '64x gtceu:crushed_cobaltite_ore', '64x gtceu:crushed_chromite_ore', '64x gtceu:crushed_beryllium_ore', '64x gtceu:crushed_pitchblende_ore', 

--- a/kubejs/server_scripts/multiblock recipes/large_stone_barrel.js
+++ b/kubejs/server_scripts/multiblock recipes/large_stone_barrel.js
@@ -10,7 +10,7 @@ ServerEvents.recipes(event => {
         S: 'gtceu:treated_wood_rod',
         B: 'gtceu:ulv_stone_barrel',
         I: 'gtceu:wrought_iron_plate'
-    });
+    }).id('start:shaped/large_stone_barrel');
 
     event.recipes.gtceu.large_stone_barrel(id('lava_from_stones'))
         .itemInputs('#forge:stone')

--- a/kubejs/server_scripts/multiblock recipes/large_stone_barrel.js
+++ b/kubejs/server_scripts/multiblock recipes/large_stone_barrel.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     event.shaped(Item.of('gtceu:large_stone_barrel'), [
         'PSP',
@@ -11,79 +12,79 @@ ServerEvents.recipes(event => {
         I: 'gtceu:wrought_iron_plate'
     });
 
-    event.recipes.gtceu.large_stone_barrel('lava_from_stones')
+    event.recipes.gtceu.large_stone_barrel(id('lava_from_stones'))
         .itemInputs('#forge:stone')
         .notConsumable('minecraft:soul_campfire')
         .outputFluids('minecraft:lava 500')
         .duration(200);
 
-    event.recipes.gtceu.large_stone_barrel('lava_from_cobblestones')
+    event.recipes.gtceu.large_stone_barrel(id('lava_from_cobblestones'))
         .itemInputs('#forge:cobblestone')
         .notConsumable('minecraft:soul_campfire')
         .outputFluids('minecraft:lava 500')
         .duration(200);
 
-    event.recipes.gtceu.large_stone_barrel('obsidian')
+    event.recipes.gtceu.large_stone_barrel(id('obsidian'))
         .inputFluids('minecraft:water 1000', 'minecraft:lava 1000')
         .itemOutputs('minecraft:obsidian')
         .circuit(10)
         .duration(1);
 
-    event.recipes.gtceu.large_stone_barrel('cobble_pebbles')
+    event.recipes.gtceu.large_stone_barrel(id('cobble_pebbles'))
         .inputFluids('minecraft:lava 1', 'minecraft:water 1')
         .chancedOutput('exnihilosequentia:stone_pebble', 7500, 0)
         .circuit(0)
         .duration(1);
 
-    event.recipes.gtceu.large_stone_barrel('andesite_pebbles')
+    event.recipes.gtceu.large_stone_barrel(id('andesite_pebbles'))
         .inputFluids('minecraft:lava 1', 'minecraft:water 1')
         .chancedOutput('exnihilosequentia:andesite_pebble', 7500, 0)
         .circuit(1)
         .duration(1);
 
-    event.recipes.gtceu.large_stone_barrel('diorite_pebbles')
+    event.recipes.gtceu.large_stone_barrel(id('diorite_pebbles'))
         .inputFluids('minecraft:lava 1', 'minecraft:water 1')
         .chancedOutput('exnihilosequentia:diorite_pebble', 7500, 0)
         .circuit(2)
         .duration(1);
     
-    event.recipes.gtceu.large_stone_barrel('granite_pebbles')
+    event.recipes.gtceu.large_stone_barrel(id('granite_pebbles'))
         .inputFluids('minecraft:lava 1', 'minecraft:water 1')
         .chancedOutput('exnihilosequentia:granite_pebble', 7500, 0)
         .circuit(3)
         .duration(1);
 
-    event.recipes.gtceu.large_stone_barrel('tuff_pebbles')
+    event.recipes.gtceu.large_stone_barrel(id('tuff_pebbles'))
         .inputFluids('minecraft:lava 1', 'minecraft:water 1')
         .chancedOutput('exnihilosequentia:tuff_pebble', 7500, 0)
         .circuit(7)
         .duration(1);
 
-    event.recipes.gtceu.large_stone_barrel('dripstone_pebbles')
+    event.recipes.gtceu.large_stone_barrel(id('dripstone_pebbles'))
         .inputFluids('minecraft:lava 1', 'minecraft:water 1')
         .chancedOutput('exnihilosequentia:dripstone_pebble', 7500, 0)
         .circuit(4)
         .duration(1);
 
-    event.recipes.gtceu.large_stone_barrel('deepslate_pebbles')
+    event.recipes.gtceu.large_stone_barrel(id('deepslate_pebbles'))
         .inputFluids('minecraft:lava 2', 'minecraft:water 2')
         .chancedOutput('exnihilosequentia:deepslate_pebble', 7500, 0)
         .circuit(5)
         .duration(1);
 
-    event.recipes.gtceu.large_stone_barrel('calcite_pebbles')
+    event.recipes.gtceu.large_stone_barrel(id('calcite_pebbles'))
         .inputFluids('minecraft:lava 1', 'minecraft:water 1')
         .chancedOutput('exnihilosequentia:calcite_pebble', 7500, 0)
         .circuit(6)
         .duration(1);
 
-    event.recipes.gtceu.large_stone_barrel('blackstone_pebbles')
+    event.recipes.gtceu.large_stone_barrel(id('blackstone_pebbles'))
         .inputFluids('minecraft:lava 1', 'exnihilosequentia:witch_water 1')
         .chancedOutput('exnihilosequentia:blackstone_pebble', 7500, 0)
         .circuit(0)
         .duration(1);
 
-    event.recipes.gtceu.large_stone_barrel('basalt_pebbles')
+    event.recipes.gtceu.large_stone_barrel(id('basalt_pebbles'))
         .inputFluids('minecraft:lava 1', 'exnihilosequentia:witch_water 1')
         .chancedOutput('exnihilosequentia:basalt_pebble', 7500, 0)
         .circuit(1)

--- a/kubejs/server_scripts/multipart_bus_hatch.js
+++ b/kubejs/server_scripts/multipart_bus_hatch.js
@@ -1,6 +1,7 @@
 // Readds Multipart bus/hatch recipes removed in 1.20.1 GT 
 // for ULV and LV tiers with parity to the GTceuM assembler recipes.
 ServerEvents.recipes(event => {
+    const id = global.id;
     [
         {tier: 'ulv', item: '#forge:chests/wooden', fluid: '#forge:glass'},
         {tier: 'lv', item: 'gtceu:wood_crate', fluid: 'gtceu:wood_drum'}
@@ -15,14 +16,14 @@ ServerEvents.recipes(event => {
             {
                 C: tier.item,
                 M: `gtceu:${tier.tier}_machine_hull`
-            });
+            }).id(`start:shaped/${tier.tier}_${type.type}_bus`);
             // Hatches
             event.shaped(Item.of(`gtceu:${tier.tier}_${type.type}_hatch`),
             type.shape,
             {
                 C: tier.fluid,
                 M: `gtceu:${tier.tier}_machine_hull`
-            });
+            }).id(`start:shaped/${tier.tier}_${type.type}_hatch`);
         });
     });
 

--- a/kubejs/server_scripts/mystical agriculture/cryptands.js
+++ b/kubejs/server_scripts/mystical agriculture/cryptands.js
@@ -1,5 +1,5 @@
 ServerEvents.recipes(event => {
-    const id = global.id;
+    const id = global.id;    
 
     event.recipes.gtceu.chemical_reactor(id('ethylene_oxide'))
         .inputFluids('gtceu:ethylene 1000', 'gtceu:oxygen 1000')

--- a/kubejs/server_scripts/mystical agriculture/cryptands.js
+++ b/kubejs/server_scripts/mystical agriculture/cryptands.js
@@ -1,7 +1,7 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.chemical_reactor('ethylene_oxide')
+    event.recipes.gtceu.chemical_reactor(id('ethylene_oxide'))
         .inputFluids('gtceu:ethylene 1000', 'gtceu:oxygen 1000')
         .notConsumable('gtceu:silver_oxide_dust')
         .outputFluids('gtceu:ethylene_oxide 1000')
@@ -9,42 +9,42 @@ ServerEvents.recipes(event => {
         .EUt(120)
         .circuit(5);
 
-    event.recipes.gtceu.chemical_reactor('ethylene_glycol')
+    event.recipes.gtceu.chemical_reactor(id('ethylene_glycol'))
         .inputFluids('gtceu:ethylene_oxide 1000', 'minecraft:water 1000')
         .outputFluids('gtceu:ethylene_glycol 1000')
         .duration(680)
         .EUt(120)
         .circuit(0);
 
-    event.recipes.gtceu.chemical_reactor('diethylene_glycol')
+    event.recipes.gtceu.chemical_reactor(id('diethylene_glycol'))
         .inputFluids('gtceu:ethylene_oxide 2000', 'minecraft:water 1000')
         .outputFluids('gtceu:diethylene_glycol 1000')
         .duration(740)
         .EUt(120)
         .circuit(1);
 
-    event.recipes.gtceu.chemical_reactor('triethylene_glycol')
+    event.recipes.gtceu.chemical_reactor(id('triethylene_glycol'))
         .inputFluids('gtceu:ethylene_oxide 3000', 'gtceu:oxygen 1000')
         .outputFluids('gtceu:triethylene_glycol 1000')
         .duration(880)
         .EUt(120)
         .circuit(2);
 
-    event.recipes.gtceu.chemical_reactor('sodium_chlorate')
+    event.recipes.gtceu.chemical_reactor(id('sodium_chlorate'))
         .inputFluids('gtceu:salt_water 1000', 'gtceu:oxygen 3000')
         .itemOutputs('gtceu:sodium_chlorate_dust')
         .outputFluids('minecraft:water 1000')
         .duration(320)
         .EUt(120);
     
-    event.recipes.gtceu.chemical_reactor('sodium_perchlorate')
+    event.recipes.gtceu.chemical_reactor(id('sodium_perchlorate'))
         .itemInputs('gtceu:sodium_chlorate_dust')
         .inputFluids('gtceu:oxygen 1000')
         .itemOutputs('gtceu:sodium_perchlorate_dust')
         .duration(440)
         .EUt(120);
 
-    event.recipes.gtceu.chemical_reactor('lithium_perchlorate')
+    event.recipes.gtceu.chemical_reactor(id('lithium_perchlorate'))
         .itemInputs('gtceu:sodium_perchlorate_dust', 'gtceu:lithium_chloride_dust')
         .inputFluids('minecraft:water 1000')
         .itemOutputs('gtceu:lithium_perchlorate_dust')
@@ -52,7 +52,7 @@ ServerEvents.recipes(event => {
         .duration(560)
         .EUt(120);
 
-    event.recipes.gtceu.chemical_reactor('potassium_hydroxide')
+    event.recipes.gtceu.chemical_reactor(id('potassium_hydroxide'))
         .itemInputs('gtceu:potassium_dust')
         .inputFluids('minecraft:water 1000')
         .itemOutputs('gtceu:potassium_hydroxide_dust')
@@ -60,7 +60,7 @@ ServerEvents.recipes(event => {
         .duration(100)
         .EUt(120);
 
-    event.recipes.gtceu.chemical_reactor('sodium_hydroxide')
+    event.recipes.gtceu.chemical_reactor(id('sodium_hydroxide'))
         .itemInputs('gtceu:sodium_dust')
         .inputFluids('minecraft:water 1000')
         .itemOutputs('gtceu:sodium_hydroxide_dust')
@@ -68,39 +68,39 @@ ServerEvents.recipes(event => {
         .duration(100)
         .EUt(120);
 
-    event.recipes.gtceu.chemical_reactor('silver_oxide')
+    event.recipes.gtceu.chemical_reactor(id('silver_oxide'))
         .itemInputs('2x gtceu:silver_dust')
         .inputFluids('gtceu:oxygen 1000')
         .itemOutputs('3x gtceu:silver_oxide_dust')
         .duration(120)
         .EUt(32);
 
-    event.recipes.gtceu.chemical_reactor('sulfur_dichloride')
+    event.recipes.gtceu.chemical_reactor(id('sulfur_dichloride'))
         .itemInputs('#forge:dusts/sulfur')
         .inputFluids('gtceu:chlorine 2000')
         .outputFluids('gtceu:sulfur_dichloride 1000')
         .duration(120)
         .EUt(120);
 
-    event.recipes.gtceu.chemical_reactor('thionyl_chloride')
+    event.recipes.gtceu.chemical_reactor(id('thionyl_chloride'))
         .inputFluids('gtceu:sulfur_dioxide 1000', 'gtceu:chlorine 2000')
         .outputFluids('gtceu:thionyl_chloride 1000')
         .duration(120)
         .EUt(120);
 
-    event.recipes.gtceu.chemical_reactor('sulfonyl_chloride')
+    event.recipes.gtceu.chemical_reactor(id('sulfonyl_chloride'))
         .inputFluids('gtceu:sulfur_trioxide 1000', 'gtceu:sulfur_dichloride 1000')
         .outputFluids('gtceu:sulfuryl_chloride 1000', 'gtceu:sulfur_dioxide 1000')
         .duration(180)
         .EUt(120);
 
-    event.recipes.gtceu.chemical_reactor('triglycol_dichloride')
+    event.recipes.gtceu.chemical_reactor(id('triglycol_dichloride'))
         .inputFluids('gtceu:sulfuryl_chloride 1000', 'gtceu:triethylene_glycol 1000', 'gtceu:oxygen 1000')
         .outputFluids('gtceu:triglycol_dichloride 1000', 'gtceu:sulfuric_acid 1000')
         .duration(220)
         .EUt(120); 
 
-    event.recipes.gtceu.chemical_reactor('12-crown-4')
+    event.recipes.gtceu.chemical_reactor(id('12-crown-4'))
         .itemInputs('2x gtceu:sodium_hydroxide_dust')
         .inputFluids('gtceu:triglycol_dichloride 1000', 'gtceu:ethylene_glycol 1000')
         .itemOutputs('2x gtceu:salt_dust')
@@ -109,7 +109,7 @@ ServerEvents.recipes(event => {
         .EUt(120)
         .circuit(0);
 
-    event.recipes.gtceu.large_chemical_reactor('ethylene_oxide')
+    event.recipes.gtceu.large_chemical_reactor(id('ethylene_oxide'))
         .inputFluids('gtceu:ethylene 1000', 'gtceu:oxygen 1000')
         .notConsumable('gtceu:silver_oxide_dust')
         .outputFluids('gtceu:ethylene_oxide 1000')
@@ -117,42 +117,42 @@ ServerEvents.recipes(event => {
         .EUt(120)
         .circuit(5);
 
-    event.recipes.gtceu.large_chemical_reactor('ethylene_glycol')
+    event.recipes.gtceu.large_chemical_reactor(id('ethylene_glycol'))
         .inputFluids('gtceu:ethylene_oxide 1000', 'minecraft:water 1000')
         .outputFluids('gtceu:ethylene_glycol 1000')
         .duration(680)
         .EUt(120)
         .circuit(0);
 
-    event.recipes.gtceu.large_chemical_reactor('diethylene_glycol')
+    event.recipes.gtceu.large_chemical_reactor(id('diethylene_glycol'))
         .inputFluids('gtceu:ethylene_oxide 2000', 'minecraft:water 1000')
         .outputFluids('gtceu:diethylene_glycol 1000')
         .duration(740)
         .EUt(120)
         .circuit(1);
 
-    event.recipes.gtceu.large_chemical_reactor('triethylene_glycol')
+    event.recipes.gtceu.large_chemical_reactor(id('triethylene_glycol'))
         .inputFluids('gtceu:ethylene_oxide 3000', 'gtceu:oxygen 1000')
         .outputFluids('gtceu:triethylene_glycol 1000')
         .duration(880)
         .EUt(120)
         .circuit(2);
 
-    event.recipes.gtceu.large_chemical_reactor('sodium_chlorate')
+    event.recipes.gtceu.large_chemical_reactor(id('sodium_chlorate'))
         .inputFluids('gtceu:salt_water 1000', 'gtceu:oxygen 3000')
         .itemOutputs('gtceu:sodium_chlorate_dust')
         .outputFluids('minecraft:water 1000')
         .duration(320)
         .EUt(120);
     
-    event.recipes.gtceu.large_chemical_reactor('sodium_perchlorate')
+    event.recipes.gtceu.large_chemical_reactor(id('sodium_perchlorate'))
         .itemInputs('gtceu:sodium_chlorate_dust')
         .inputFluids('gtceu:oxygen 1000')
         .itemOutputs('gtceu:sodium_perchlorate_dust')
         .duration(440)
         .EUt(120);
 
-    event.recipes.gtceu.large_chemical_reactor('lithium_perchlorate')
+    event.recipes.gtceu.large_chemical_reactor(id('lithium_perchlorate'))
         .itemInputs('gtceu:sodium_perchlorate_dust', 'gtceu:lithium_chloride_dust')
         .inputFluids('minecraft:water 1000')
         .itemOutputs('gtceu:lithium_perchlorate_dust')
@@ -160,7 +160,7 @@ ServerEvents.recipes(event => {
         .duration(560)
         .EUt(120);
 
-    event.recipes.gtceu.large_chemical_reactor('potassium_hydroxide')
+    event.recipes.gtceu.large_chemical_reactor(id('potassium_hydroxide'))
         .itemInputs('gtceu:potassium_dust')
         .inputFluids('minecraft:water 1000')
         .itemOutputs('gtceu:potassium_hydroxide_dust')
@@ -168,7 +168,7 @@ ServerEvents.recipes(event => {
         .duration(100)
         .EUt(120);
 
-    event.recipes.gtceu.large_chemical_reactor('sodium_hydroxide')
+    event.recipes.gtceu.large_chemical_reactor(id('sodium_hydroxide'))
         .itemInputs('gtceu:sodium_dust')
         .inputFluids('minecraft:water 1000')
         .itemOutputs('gtceu:sodium_hydroxide_dust')
@@ -176,39 +176,39 @@ ServerEvents.recipes(event => {
         .duration(100)
         .EUt(120);
 
-    event.recipes.gtceu.large_chemical_reactor('silver_oxide')
+    event.recipes.gtceu.large_chemical_reactor(id('silver_oxide'))
         .itemInputs('2x gtceu:silver_dust')
         .inputFluids('gtceu:oxygen 1000')
         .itemOutputs('3x gtceu:silver_oxide_dust')
         .duration(120)
         .EUt(32);
 
-    event.recipes.gtceu.large_chemical_reactor('sulfur_dichloride')
+    event.recipes.gtceu.large_chemical_reactor(id('sulfur_dichloride'))
         .itemInputs('#forge:dusts/sulfur')
         .inputFluids('gtceu:chlorine 2000')
         .outputFluids('gtceu:sulfur_dichloride 1000')
         .duration(120)
         .EUt(120);
 
-    event.recipes.gtceu.large_chemical_reactor('thionyl_chloride')
+    event.recipes.gtceu.large_chemical_reactor(id('thionyl_chloride'))
         .inputFluids('gtceu:sulfur_dioxide 1000', 'gtceu:chlorine 2000')
         .outputFluids('gtceu:thionyl_chloride 1000')
         .duration(120)
         .EUt(120);
 
-    event.recipes.gtceu.large_chemical_reactor('sulfonyl_chloride')
+    event.recipes.gtceu.large_chemical_reactor(id('sulfonyl_chloride'))
         .inputFluids('gtceu:sulfur_trioxide 1000', 'gtceu:sulfur_dichloride 1000')
         .outputFluids('gtceu:sulfuryl_chloride 1000', 'gtceu:sulfur_dioxide 1000')
         .duration(180)
         .EUt(120);
 
-    event.recipes.gtceu.large_chemical_reactor('triglycol_dichloride')
+    event.recipes.gtceu.large_chemical_reactor(id('triglycol_dichloride'))
         .inputFluids('gtceu:sulfuryl_chloride 1000', 'gtceu:triethylene_glycol 1000', 'gtceu:oxygen 1000')
         .outputFluids('gtceu:triglycol_dichloride 1000', 'gtceu:sulfuric_acid 1000')
         .duration(220)
         .EUt(120); 
 
-    event.recipes.gtceu.large_chemical_reactor('12-crown-4')
+    event.recipes.gtceu.large_chemical_reactor(id('12-crown-4'))
         .itemInputs('2x gtceu:sodium_hydroxide_dust')
         .inputFluids('gtceu:triglycol_dichloride 1000', 'gtceu:ethylene_glycol 1000')
         .itemOutputs('2x gtceu:salt_dust')
@@ -217,7 +217,7 @@ ServerEvents.recipes(event => {
         .EUt(120)
         .circuit(0);
 
-    event.recipes.gtceu.mixer('12-crown-4-li')
+    event.recipes.gtceu.mixer(id('12-crown-4-li'))
         .itemInputs('gtceu:lithium_perchlorate_dust', 'gtceu:sodium_dust')
         .inputFluids('gtceu:12_crown_4 1000')
         .itemOutputs('gtceu:sodium_perchlorate_dust')
@@ -225,7 +225,7 @@ ServerEvents.recipes(event => {
         .duration(120)
         .EUt(120);
 
-    event.recipes.gtceu.chemical_reactor('15-crown-5')
+    event.recipes.gtceu.chemical_reactor(id('15-crown-5'))
         .itemInputs('2x gtceu:sodium_hydroxide_dust')
         .inputFluids('gtceu:triglycol_dichloride 1000', 'gtceu:diethylene_glycol 1000')
         .itemOutputs('2x gtceu:salt_dust')
@@ -234,7 +234,7 @@ ServerEvents.recipes(event => {
         .EUt(120)
         .circuit(1);
 
-    event.recipes.gtceu.large_chemical_reactor('15-crown-5')
+    event.recipes.gtceu.large_chemical_reactor(id('15-crown-5'))
         .itemInputs('2x gtceu:sodium_hydroxide_dust')
         .inputFluids('gtceu:triglycol_dichloride 1000', 'gtceu:diethylene_glycol 1000')
         .itemOutputs('2x gtceu:salt_dust')
@@ -243,7 +243,7 @@ ServerEvents.recipes(event => {
         .EUt(120)
         .circuit(1);
 
-    event.recipes.gtceu.mixer('15-crown-5-na')
+    event.recipes.gtceu.mixer(id('15-crown-5-na'))
         .itemInputs('gtceu:sodium_perchlorate_dust', 'gtceu:lithium_dust')
         .inputFluids('gtceu:15_crown_5 1000')
         .itemOutputs('gtceu:lithium_perchlorate_dust')
@@ -251,7 +251,7 @@ ServerEvents.recipes(event => {
         .duration(120)
         .EUt(120);
 
-    event.recipes.gtceu.chemical_reactor('18-crown-6')
+    event.recipes.gtceu.chemical_reactor(id('18-crown-6'))
         .itemInputs('2x gtceu:potassium_hydroxide_dust')
         .inputFluids('gtceu:triglycol_dichloride 1000', 'gtceu:triethylene_glycol 1000')
         .itemOutputs('2x gtceu:rock_salt_dust')
@@ -260,7 +260,7 @@ ServerEvents.recipes(event => {
         .EUt(120)
         .circuit(2);
 
-    event.recipes.gtceu.large_chemical_reactor('18-crown-6')
+    event.recipes.gtceu.large_chemical_reactor(id('18-crown-6'))
         .itemInputs('2x gtceu:potassium_hydroxide_dust')
         .inputFluids('gtceu:triglycol_dichloride 1000', 'gtceu:triethylene_glycol 1000')
         .itemOutputs('2x gtceu:rock_salt_dust')
@@ -269,7 +269,7 @@ ServerEvents.recipes(event => {
         .EUt(120)
         .circuit(2);
 
-    event.recipes.gtceu.mixer('18-crown-6-k')
+    event.recipes.gtceu.mixer(id('18-crown-6-k'))
         .itemInputs('gtceu:rock_salt_dust', 'gtceu:sodium_dust')
         .inputFluids('gtceu:18_crown_6 1000')
         .itemOutputs('gtceu:salt_dust')
@@ -277,35 +277,35 @@ ServerEvents.recipes(event => {
         .duration(120)
         .EUt(120);
 
-    event.recipes.gtceu.large_chemical_reactor('ethylene_glycol_lcr')
+    event.recipes.gtceu.large_chemical_reactor(id('ethylene_glycol_lcr'))
         .inputFluids('gtceu:ethylene 1000', 'gtceu:oxygen 1000', 'minecraft:water 1000')
         .outputFluids('gtceu:ethylene_glycol 1000')
         .duration(200)
         .EUt(346)
         .circuit(8);
 
-    event.recipes.gtceu.large_chemical_reactor('diethylene_glycol_lcr')
+    event.recipes.gtceu.large_chemical_reactor(id('diethylene_glycol_lcr'))
         .inputFluids('gtceu:ethylene 2000', 'gtceu:oxygen 2000', 'minecraft:water 1000')
         .outputFluids('gtceu:diethylene_glycol 1000')
         .duration(200)
         .EUt(346)
         .circuit(9);
 
-    event.recipes.gtceu.large_chemical_reactor('triethylene_glycol_lcr')
+    event.recipes.gtceu.large_chemical_reactor(id('triethylene_glycol_lcr'))
         .inputFluids('gtceu:ethylene 3000', 'gtceu:oxygen 3000', 'minecraft:water 1000')
         .outputFluids('gtceu:triethylene_glycol 1000')
         .duration(200)
         .EUt(346)
         .circuit(10);
 
-    event.recipes.gtceu.large_chemical_reactor('toluenesulfonyl')
+    event.recipes.gtceu.large_chemical_reactor(id('toluenesulfonyl'))
         .inputFluids('gtceu:toluene 1000', 'gtceu:thionyl_chloride 1000')
         .itemOutputs('gtceu:4_toluenesulfonyl_chloride_dust')
         .outputFluids('gtceu:hydrochloric_acid 1000')
         .duration(300)
         .EUt(346);
 
-    event.recipes.gtceu.large_chemical_reactor('ditosylate')
+    event.recipes.gtceu.large_chemical_reactor(id('ditosylate'))
         .itemInputs('2x gtceu:potassium_hydroxide_dust', '2x gtceu:4_toluenesulfonyl_chloride_dust')
         .inputFluids('gtceu:triethylene_glycol 1000')
         .itemOutputs('gtceu:triethylene_glycol_ditosylate_dust', '2x gtceu:rock_salt_dust')
@@ -313,27 +313,27 @@ ServerEvents.recipes(event => {
         .duration(300)
         .EUt(1024);
 
-    event.recipes.gtceu.chemical_reactor('sodium_azide')
+    event.recipes.gtceu.chemical_reactor(id('sodium_azide'))
         .itemInputs('gtceu:sodium_dust')
         .inputFluids('gtceu:nitrogen 3000')
         .itemOutputs('4x gtceu:sodium_azide_dust')
         .duration(220)
         .EUt(396);
 
-    event.recipes.gtceu.large_chemical_reactor('sodium_azide')
+    event.recipes.gtceu.large_chemical_reactor(id('sodium_azide'))
         .itemInputs('gtceu:sodium_dust')
         .inputFluids('gtceu:nitrogen 3000')
         .itemOutputs('4x gtceu:sodium_azide_dust')
         .duration(220)
         .EUt(396);
 
-    event.recipes.gtceu.large_chemical_reactor('diazide')
+    event.recipes.gtceu.large_chemical_reactor(id('diazide'))
         .itemInputs('gtceu:triethylene_glycol_ditosylate_dust', '2x gtceu:sodium_azide_dust')
         .itemOutputs('gtceu:triethylene_glycol_diazide_dust', '2x gtceu:sodium_p_toluenesulfonate_dust')
         .duration(300)
         .EUt(1024);
 
-    event.recipes.gtceu.large_chemical_reactor('bisulfate_from_ts')
+    event.recipes.gtceu.large_chemical_reactor(id('bisulfate_from_ts'))
         .itemInputs('gtceu:sodium_p_toluenesulfonate_dust')
         .inputFluids('minecraft:water 1000')
         .itemOutputs('gtceu:sodium_bisulfate_dust')
@@ -341,13 +341,13 @@ ServerEvents.recipes(event => {
         .duration(600)
         .EUt(396);
 
-    event.recipes.gtceu.mixer('palladium_on_carbon')
+    event.recipes.gtceu.mixer(id('palladium_on_carbon'))
         .itemInputs('gtceu:palladium_dust', 'gtceu:carbon_dust')
         .itemOutputs('2x gtceu:palladium_on_carbon_dust')
         .duration(1200)
         .EUt(396);
 
-    event.recipes.gtceu.large_chemical_reactor('diamine')
+    event.recipes.gtceu.large_chemical_reactor(id('diamine'))
         .itemInputs('gtceu:triethylene_glycol_diazide_dust')
         .notConsumable('gtceu:palladium_on_carbon_dust')
         .inputFluids('gtceu:hydrogen 4000')
@@ -356,14 +356,14 @@ ServerEvents.recipes(event => {
         .duration(4800)
         .EUt(1024);
 
-    event.recipes.gtceu.large_chemical_reactor('cryptand')
+    event.recipes.gtceu.large_chemical_reactor(id('cryptand'))
         .itemInputs('gtceu:triethylene_glycol_diamine_dust', '2x gtceu:triethylene_glycol_ditosylate_dust', '2x gtceu:soda_ash_dust')
         .itemOutputs('4x gtceu:sodium_p_toluenesulfonate_dust')
         .outputFluids('gtceu:cryptand 1000', 'gtceu:carbon_dioxide 2000', 'minecraft:water 2000')
         .duration(9600)
         .EUt(1024);
 
-    event.recipes.gtceu.mixer('cryptand_k')
+    event.recipes.gtceu.mixer(id('cryptand_k'))
         .itemInputs('gtceu:rock_salt_dust', 'gtceu:sodium_dust')
         .inputFluids('gtceu:cryptand 1000')
         .itemOutputs('gtceu:salt_dust')
@@ -371,7 +371,7 @@ ServerEvents.recipes(event => {
         .duration(4800)
         .EUt(1024);
 
-    event.recipes.gtceu.mixer('cryptand_na')
+    event.recipes.gtceu.mixer(id('cryptand_na'))
         .itemInputs('gtceu:sodium_perchlorate_dust', 'gtceu:lithium_dust')
         .inputFluids('gtceu:cryptand 1000')
         .itemOutputs('gtceu:lithium_perchlorate_dust')
@@ -379,7 +379,7 @@ ServerEvents.recipes(event => {
         .duration(4800)
         .EUt(1024);
 
-    event.recipes.gtceu.mixer('cryptand_li')
+    event.recipes.gtceu.mixer(id('cryptand_li'))
         .itemInputs('gtceu:lithium_perchlorate_dust', 'gtceu:sodium_dust')
         .inputFluids('gtceu:cryptand 1000')
         .itemOutputs('gtceu:sodium_perchlorate_dust')

--- a/kubejs/server_scripts/mystical agriculture/essence_burning.js
+++ b/kubejs/server_scripts/mystical agriculture/essence_burning.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     const cryptand = 'gtceu:cryptand 1';
     const gem = 'gtceu:12_crown_4_li 100';
@@ -32,7 +33,7 @@ ServerEvents.recipes(event => {
     ].forEach(essence=> {
         const fluidcheck = essence.output.length
         if(essence.output.slice(fluidcheck) == 0){
-            event.recipes.gtceu.essence_burning(`${essence.essence}_essence_burning_${essence.circuit}`)
+            event.recipes.gtceu.essence_burning(id(`${essence.essence}_essence_burning_${essence.circuit}`))
                 .itemInputs(`mysticalagriculture:${essence.essence}_essence`)
                 .outputFluids(essence.output)
                 .duration(100)
@@ -40,7 +41,7 @@ ServerEvents.recipes(event => {
                 .circuit(essence.circuit);
         }
         else{
-            event.recipes.gtceu.essence_burning(`${essence.essence}_essence_burning_${essence.circuit}`)
+            event.recipes.gtceu.essence_burning(id(`${essence.essence}_essence_burning_${essence.circuit}`))
                 .itemInputs(`mysticalagriculture:${essence.essence}_essence`)
                 .itemOutput(essence.output)
                 .duration(100)
@@ -50,63 +51,63 @@ ServerEvents.recipes(event => {
     
     });
 
-    event.recipes.gtceu.essence_burning('dirt_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('dirt_essence_burning_0'))
         .itemInputs('mysticalagriculture:dirt_essence')
         .itemOutputs('32x minecraft:dirt')
         .duration(100)
         .EUt(80)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('dirt_essence_burning_1')
+    event.recipes.gtceu.essence_burning(id('dirt_essence_burning_1'))
         .itemInputs('mysticalagriculture:dirt_essence')
         .itemOutputs('32x minecraft:coarse_dirt')
         .duration(100)
         .EUt(80)
         .circuit(1);
 
-    event.recipes.gtceu.essence_burning('dirt_essence_burning_2')
+    event.recipes.gtceu.essence_burning(id('dirt_essence_burning_2'))
         .itemInputs('mysticalagriculture:dirt_essence')
         .itemOutputs('32x minecraft:rooted_dirt')
         .duration(100)
         .EUt(80)
         .circuit(2);
 
-    event.recipes.gtceu.essence_burning('dirt_essence_burning_3')
+    event.recipes.gtceu.essence_burning(id('dirt_essence_burning_3'))
         .itemInputs('mysticalagriculture:dirt_essence')
         .itemOutputs('32x minecraft:mud')
         .duration(100)
         .EUt(80)
         .circuit(3);
 
-    event.recipes.gtceu.essence_burning('ice_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('ice_essence_burning_0'))
         .itemInputs('mysticalagriculture:ice_essence')
         .itemOutputs('32x minecraft:ice')
         .duration(100)
         .EUt(80)
         .circuit(0);
 
-     event.recipes.gtceu.essence_burning('ice_essence_burning_1')
+     event.recipes.gtceu.essence_burning(id('ice_essence_burning_1'))
         .itemInputs('mysticalagriculture:ice_essence')
         .itemOutputs('32x minecraft:packed_ice')
         .duration(100)
         .EUt(80)
         .circuit(1);
 
-    event.recipes.gtceu.essence_burning('ice_essence_burning_2')
+    event.recipes.gtceu.essence_burning(id('ice_essence_burning_2'))
         .itemInputs('mysticalagriculture:ice_essence')
         .itemOutputs('32x minecraft:blue_ice')
         .duration(100)
         .EUt(80)
         .circuit(2);
 
-    event.recipes.gtceu.essence_burning('coal_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('coal_essence_burning_0'))
         .itemInputs('mysticalagriculture:coal_essence')
         .itemOutputs('32x minecraft:coal')
         .duration(100)
         .EUt(400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('coal_essence_burning_1')
+    event.recipes.gtceu.essence_burning(id('coal_essence_burning_1'))
         .itemInputs('mysticalagriculture:coal_essence')
         .itemOutputs('16x gtceu:coke_gem')
         .duration(100)
@@ -118,7 +119,7 @@ ServerEvents.recipes(event => {
     'minecraft:blue_dye', 'minecraft:brown_dye', 'minecraft:green_dye', 'minecraft:red_dye', 'minecraft:black_dye'];
 
     for (let i = 0; i < dyes.length; i++) {
-        event.recipes.gtceu.essence_burning('dye_essence_burning_' + i)
+        event.recipes.gtceu.essence_burning(id('dye_essence_burning_' + i))
             .itemInputs('mysticalagriculture:dye_essence')
             .itemOutputs('16x ' + dyes[i])
             .duration(100)
@@ -132,7 +133,7 @@ ServerEvents.recipes(event => {
     ];
 
     for (let i = 0; i < crops.length; i++) {
-        event.recipes.gtceu.essence_burning('nature_essence_burning_' + i)
+        event.recipes.gtceu.essence_burning(id('nature_essence_burning_' + i))
             .itemInputs('mysticalagriculture:nature_essence')
             .itemOutputs('16x ' + crops[i])
             .duration(100)
@@ -143,7 +144,7 @@ ServerEvents.recipes(event => {
     const stone = ['minecraft:stone', 'minecraft:cobblestone', 'minecraft:diorite', 'minecraft:granite', 'minecraft:andesite', 'minecraft:deepslate', 'minecraft:tuff', 'minecraft:calcite'];
 
     for (let i = 0; i < stone.length; i++) {
-        event.recipes.gtceu.essence_burning('stone_essence_burning_' + i)
+        event.recipes.gtceu.essence_burning(id('stone_essence_burning_' + i))
             .itemInputs('mysticalagriculture:stone_essence')
             .itemOutputs('16x ' + stone[i])
             .duration(100)
@@ -152,105 +153,105 @@ ServerEvents.recipes(event => {
     }
 
     // tier 2
-    event.recipes.gtceu.essence_burning('iron_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('iron_essence_burning_0'))
         .itemInputs('mysticalagriculture:iron_essence')
         .itemOutputs('16x minecraft:raw_iron')
         .duration(100)
         .EUt(80)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('copper_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('copper_essence_burning_0'))
         .itemInputs('mysticalagriculture:copper_essence')
         .itemOutputs('16x minecraft:raw_copper')
         .duration(100)
         .EUt(80)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('gold_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('gold_essence_burning_0'))
         .itemInputs('mysticalagriculture:gold_essence')
         .itemOutputs('16x minecraft:raw_gold')
         .duration(100)
         .EUt(80)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('nickel_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('nickel_essence_burning_0'))
         .itemInputs('mysticalagriculture:nickel_essence')
         .itemOutputs('16x gtceu:raw_pentlandite')
         .duration(100)
         .EUt(80)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('tin_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('tin_essence_burning_0'))
         .itemInputs('mysticalagriculture:tin_essence')
         .itemOutputs('16x gtceu:raw_cassiterite')
         .duration(100)
         .EUt(80)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('lead_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('lead_essence_burning_0'))
         .itemInputs('mysticalagriculture:lead_essence')
         .itemOutputs('16x gtceu:raw_galena')
         .duration(100)
         .EUt(80)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('zinc_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('zinc_essence_burning_0'))
         .itemInputs('mysticalagriculture:zinc_essence')
         .itemOutputs('16x gtceu:raw_sphalerite')
         .duration(100)
         .EUt(80)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('silver_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('silver_essence_burning_0'))
         .itemInputs('mysticalagriculture:silver_essence')
         .itemOutputs('16x gtceu:raw_silver')
         .duration(100)
         .EUt(80)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('diamond_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('diamond_essence_burning_0'))
         .itemInputs('mysticalagriculture:diamond_essence')
         .itemOutputs('16x gtceu:raw_diamond')
         .duration(100)
         .EUt(80)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('redstone_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('redstone_essence_burning_0'))
         .itemInputs('mysticalagriculture:redstone_essence')
         .itemOutputs('16x gtceu:raw_redstone')
         .duration(100)
         .EUt(80)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('glowstone_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('glowstone_essence_burning_0'))
         .itemInputs('mysticalagriculture:glowstone_essence')
         .itemOutputs('16x minecraft:glowstone_dust')
         .duration(100)
         .EUt(80)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('nether_quartz_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('nether_quartz_essence_burning_0'))
         .itemInputs('mysticalagriculture:nether_quartz_essence')
         .itemOutputs('16x gtceu:raw_nether_quartz')
         .duration(100)
         .EUt(80)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('lapis_lazuli_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('lapis_lazuli_essence_burning_0'))
         .itemInputs('mysticalagriculture:lapis_lazuli_essence')
         .itemOutputs('16x gtceu:raw_lapis')
         .duration(100)
         .EUt(80)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('sulfur_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('sulfur_essence_burning_0'))
         .itemInputs('mysticalagriculture:sulfur_essence')
         .itemOutputs('16x gtceu:raw_sulfur')
         .duration(100)
         .EUt(80)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('amethyst_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('amethyst_essence_burning_0'))
         .itemInputs('mysticalagriculture:amethyst_essence')
         .itemOutputs('16x gtceu:raw_amethyst')
         .duration(100)
@@ -258,7 +259,7 @@ ServerEvents.recipes(event => {
         .circuit(0);
 
     // Tier 3 (crown ethers)
-    event.recipes.gtceu.essence_burning('enderman_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('enderman_essence_burning_0'))
         .itemInputs('mysticalagriculture:enderman_essence')
         .inputFluids(gem)
         .itemOutputs('16x minecraft:ender_pearl')
@@ -267,7 +268,7 @@ ServerEvents.recipes(event => {
         .EUt(400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('enderman_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('enderman_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:enderman_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x minecraft:ender_pearl')
@@ -276,7 +277,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('slime_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('slime_essence_burning_0'))
         .itemInputs('mysticalagriculture:slime_essence')
         .inputFluids(gem)
         .itemOutputs('16x minecraft:slime_ball')
@@ -285,7 +286,7 @@ ServerEvents.recipes(event => {
         .EUt(400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('slime_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('slime_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:slime_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x minecraft:slime_ball')
@@ -294,7 +295,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('slime_essence_burning_1')
+    event.recipes.gtceu.essence_burning(id('slime_essence_burning_1'))
         .itemInputs('mysticalagriculture:slime_essence')
         .inputFluids(gem)
         .itemOutputs('16x gtceu:plant_ball')
@@ -303,7 +304,7 @@ ServerEvents.recipes(event => {
         .EUt(400)
         .circuit(1);
 
-    event.recipes.gtceu.essence_burning('slime_essence_burning_1_cryptand')
+    event.recipes.gtceu.essence_burning(id('slime_essence_burning_1_cryptand'))
         .itemInputs('mysticalagriculture:slime_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x gtceu:plant_ball')
@@ -312,7 +313,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(1);
 
-    event.recipes.gtceu.essence_burning('prismarine_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('prismarine_essence_burning_0'))
         .itemInputs('mysticalagriculture:prismarine_essence')
         .inputFluids(gem)
         .itemOutputs('16x minecraft:prismarine_shard')
@@ -321,7 +322,7 @@ ServerEvents.recipes(event => {
         .EUt(400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('prismarine_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('prismarine_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:prismarine_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x minecraft:prismarine_shard')
@@ -330,7 +331,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('prismarine_essence_burning_1')
+    event.recipes.gtceu.essence_burning(id('prismarine_essence_burning_1'))
         .itemInputs('mysticalagriculture:prismarine_essence')
         .inputFluids(gem)
         .itemOutputs('16x minecraft:prismarine_crystals')
@@ -339,7 +340,7 @@ ServerEvents.recipes(event => {
         .EUt(400)
         .circuit(1);
 
-    event.recipes.gtceu.essence_burning('prismarine_essence_burning_1_cryptand')
+    event.recipes.gtceu.essence_burning(id('prismarine_essence_burning_1_cryptand'))
         .itemInputs('mysticalagriculture:prismarine_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x minecraft:prismarine_crystals')
@@ -348,7 +349,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(1);
 
-    event.recipes.gtceu.essence_burning('emerald_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('emerald_essence_burning_0'))
         .itemInputs('mysticalagriculture:emerald_essence')
         .inputFluids(gem)
         .itemOutputs('16x gtceu:raw_emerald')
@@ -357,7 +358,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('emerald_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('emerald_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:emerald_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x gtceu:raw_emerald')
@@ -366,7 +367,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('certus_quartz_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('certus_quartz_essence_burning_0'))
         .itemInputs('mysticalagriculture:certus_quartz_essence')
         .inputFluids(gem)
         .itemOutputs('16x gtceu:raw_certus_quartz')
@@ -375,7 +376,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('certus_quartz_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('certus_quartz_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:certus_quartz_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x gtceu:raw_certus_quartz')
@@ -384,7 +385,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('ruby_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('ruby_essence_burning_0'))
         .itemInputs('mysticalagriculture:ruby_essence')
         .inputFluids(gem)
         .itemOutputs('16x gtceu:raw_ruby')
@@ -393,7 +394,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('ruby_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('ruby_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:ruby_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x gtceu:raw_ruby')
@@ -402,7 +403,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('garnet_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('garnet_essence_burning_0'))
         .itemInputs('mysticalagriculture:garnet_essence')
         .inputFluids(gem)
         .itemOutputs('16x gtceu:raw_red_garnet')
@@ -411,7 +412,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('garnet_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('garnet_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:garnet_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x gtceu:raw_red_garnet')
@@ -420,7 +421,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('garnet_essence_burning_1')
+    event.recipes.gtceu.essence_burning(id('garnet_essence_burning_1'))
         .itemInputs('mysticalagriculture:garnet_essence')
         .inputFluids(gem)
         .itemOutputs('16x gtceu:raw_yellow_garnet')
@@ -429,7 +430,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(1);
 
-    event.recipes.gtceu.essence_burning('garnet_essence_burning_1_cryptand')
+    event.recipes.gtceu.essence_burning(id('garnet_essence_burning_1_cryptand'))
         .itemInputs('mysticalagriculture:garnet_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x gtceu:raw_yellow_garnet')
@@ -438,7 +439,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(1);
 
-    event.recipes.gtceu.essence_burning('garnet_essence_burning_2')
+    event.recipes.gtceu.essence_burning(id('garnet_essence_burning_2'))
         .itemInputs('mysticalagriculture:garnet_essence')
         .inputFluids(gem)
         .itemOutputs('16x gtceu:raw_garnet_sand')
@@ -447,7 +448,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(2);
 
-    event.recipes.gtceu.essence_burning('garnet_essence_burning_2_cryptand')
+    event.recipes.gtceu.essence_burning(id('garnet_essence_burning_2_cryptand'))
         .itemInputs('mysticalagriculture:garnet_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x gtceu:raw_garnet_sand')
@@ -456,7 +457,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(2);
 
-    event.recipes.gtceu.essence_burning('apatite_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('apatite_essence_burning_0'))
         .itemInputs('mysticalagriculture:apatite_essence')
         .inputFluids(gem)
         .itemOutputs('16x gtceu:raw_apatite')
@@ -465,7 +466,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('apatite_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('apatite_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:apatite_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x gtceu:raw_apatite')
@@ -474,7 +475,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('sapphire_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('sapphire_essence_burning_0'))
         .itemInputs('mysticalagriculture:sapphire_essence')
         .inputFluids(gem)
         .itemOutputs('16x gtceu:raw_sapphire')
@@ -483,7 +484,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('sapphire_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('sapphire_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:sapphire_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x gtceu:raw_sapphire')
@@ -492,7 +493,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('sapphire_essence_burning_1')
+    event.recipes.gtceu.essence_burning(id('sapphire_essence_burning_1'))
         .itemInputs('mysticalagriculture:sapphire_essence')
         .inputFluids(gem)
         .itemOutputs('16x gtceu:raw_green_sapphire')
@@ -501,7 +502,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(1);
 
-    event.recipes.gtceu.essence_burning('sapphire_essence_burning_1_cryptand')
+    event.recipes.gtceu.essence_burning(id('sapphire_essence_burning_1_cryptand'))
         .itemInputs('mysticalagriculture:sapphire_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x gtceu:raw_green_sapphire')
@@ -510,7 +511,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(1);
 
-    event.recipes.gtceu.essence_burning('topaz_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('topaz_essence_burning_0'))
         .itemInputs('mysticalagriculture:topaz_essence')
         .inputFluids(gem)
         .itemOutputs('16x gtceu:raw_topaz')
@@ -519,7 +520,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('topaz_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('topaz_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:topaz_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x gtceu:raw_topaz')
@@ -528,7 +529,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('topaz_essence_burning_1')
+    event.recipes.gtceu.essence_burning(id('topaz_essence_burning_1'))
         .itemInputs('mysticalagriculture:topaz_essence')
         .inputFluids(gem)
         .itemOutputs('16x gtceu:raw_blue_topaz')
@@ -537,7 +538,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(1);
 
-    event.recipes.gtceu.essence_burning('topaz_essence_burning_1_cryptand')
+    event.recipes.gtceu.essence_burning(id('topaz_essence_burning_1_cryptand'))
         .itemInputs('mysticalagriculture:topaz_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x gtceu:raw_blue_topaz')
@@ -546,7 +547,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(1);
 
-    event.recipes.gtceu.essence_burning('realgar_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('realgar_essence_burning_0'))
         .itemInputs('mysticalagriculture:realgar_essence')
         .inputFluids(gem)
         .itemOutputs('16x gtceu:raw_realgar')
@@ -555,7 +556,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('realgar_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('realgar_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:realgar_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x gtceu:raw_realgar')
@@ -564,7 +565,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('saltpeter_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('saltpeter_essence_burning_0'))
         .itemInputs('mysticalagriculture:saltpeter_essence')
         .inputFluids(dust)
         .itemOutputs('16x gtceu:raw_saltpeter')
@@ -573,7 +574,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('saltpeter_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('saltpeter_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:saltpeter_essence')
         .inputFluids(dustCryptand)
         .itemOutputs('64x gtceu:raw_saltpeter')
@@ -582,7 +583,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('salts_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('salts_essence_burning_0'))
         .itemInputs('mysticalagriculture:salts_essence')
         .inputFluids(dust)
         .itemOutputs('16x gtceu:raw_salt')
@@ -591,7 +592,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('salts_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('salts_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:salts_essence')
         .inputFluids(dustCryptand)
         .itemOutputs('64x gtceu:raw_salt')
@@ -600,7 +601,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('salts_essence_burning_1')
+    event.recipes.gtceu.essence_burning(id('salts_essence_burning_1'))
         .itemInputs('mysticalagriculture:salts_essence')
         .inputFluids(dust)
         .itemOutputs('16x gtceu:raw_rock_salt')
@@ -609,7 +610,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(1);
 
-    event.recipes.gtceu.essence_burning('salts_essence_burning_1_cryptand')
+    event.recipes.gtceu.essence_burning(id('salts_essence_burning_1_cryptand'))
         .itemInputs('mysticalagriculture:salts_essence')
         .inputFluids(dustCryptand)
         .itemOutputs('64x gtceu:raw_rock_salt')
@@ -618,7 +619,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(1);
 
-    event.recipes.gtceu.essence_burning('lepidolite_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('lepidolite_essence_burning_0'))
         .itemInputs('mysticalagriculture:lepidolite_essence')
         .inputFluids(dust)
         .itemOutputs('16x gtceu:raw_lepidolite')
@@ -627,7 +628,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('lepidolite_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('lepidolite_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:lepidolite_essence')
         .inputFluids(dustCryptand)
         .itemOutputs('64x gtceu:raw_lepidolite')
@@ -636,7 +637,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('antimony_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('antimony_essence_burning_0'))
         .itemInputs('mysticalagriculture:antimony_essence')
         .inputFluids(metal)
         .itemOutputs('16x gtceu:raw_stibnite')
@@ -645,7 +646,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('antimony_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('antimony_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:antimony_essence')
         .inputFluids(metalCryptand)
         .itemOutputs('64x gtceu:raw_stibnite')
@@ -654,7 +655,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('cobaltite_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('cobaltite_essence_burning_0'))
         .itemInputs('mysticalagriculture:cobaltite_essence')
         .inputFluids(metal)
         .itemOutputs('16x gtceu:raw_cobaltite')
@@ -663,7 +664,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('cobaltite_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('cobaltite_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:cobaltite_essence')
         .inputFluids(metalCryptand)
         .itemOutputs('64x gtceu:raw_cobaltite')
@@ -672,7 +673,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('aluminum_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('aluminum_essence_burning_0'))
         .itemInputs('mysticalagriculture:aluminum_essence')
         .inputFluids(metal)
         .itemOutputs('16x gtceu:raw_bauxite')
@@ -681,7 +682,7 @@ ServerEvents.recipes(event => {
         .EUt(1024)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('aluminum_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('aluminum_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:aluminum_essence')
         .inputFluids(metalCryptand)
         .itemOutputs('64x gtceu:raw_bauxite')
@@ -690,7 +691,7 @@ ServerEvents.recipes(event => {
         .EUt(16000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('monazite_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('monazite_essence_burning_0'))
         .itemInputs('mysticalagriculture:monazite_essence')
         .inputFluids(gem)
         .itemOutputs('16x gtceu:raw_monazite')
@@ -699,7 +700,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('monazite_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('monazite_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:monazite_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x gtceu:raw_monazite')
@@ -708,7 +709,7 @@ ServerEvents.recipes(event => {
         .EUt(100000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('uranium_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('uranium_essence_burning_0'))
         .itemInputs('mysticalagriculture:uranium_essence')
         .inputFluids(metal)
         .itemOutputs('16x gtceu:raw_pitchblende')
@@ -717,7 +718,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('uranium_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('uranium_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:uranium_essence')
         .inputFluids(metalCryptand)
         .itemOutputs('64x gtceu:raw_pitchblende')
@@ -726,7 +727,7 @@ ServerEvents.recipes(event => {
         .EUt(100000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('chrome_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('chrome_essence_burning_0'))
         .itemInputs('mysticalagriculture:chrome_essence')
         .inputFluids(metal)
         .itemOutputs('16x gtceu:raw_chromite')
@@ -735,7 +736,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('chrome_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('chrome_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:chrome_essence')
         .inputFluids(metalCryptand)
         .itemOutputs('64x gtceu:raw_chromite')
@@ -744,7 +745,7 @@ ServerEvents.recipes(event => {
         .EUt(100000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('molybdenum_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('molybdenum_essence_burning_0'))
         .itemInputs('mysticalagriculture:molybdenum_essence')
         .inputFluids(metal)
         .itemOutputs('16x gtceu:raw_molybdenite')
@@ -753,7 +754,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('molybdenum_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('molybdenum_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:molybdenum_essence')
         .inputFluids(metalCryptand)
         .itemOutputs('64x gtceu:raw_molybdenite')
@@ -762,7 +763,7 @@ ServerEvents.recipes(event => {
         .EUt(100000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('tantalum_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('tantalum_essence_burning_0'))
         .itemInputs('mysticalagriculture:tantalum_essence')
         .inputFluids(metal)
         .itemOutputs('16x gtceu:raw_tantalite')
@@ -771,7 +772,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('tantalum_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('tantalum_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:tantalum_essence')
         .inputFluids(metalCryptand)
         .itemOutputs('64x gtceu:raw_tantalite')
@@ -780,7 +781,7 @@ ServerEvents.recipes(event => {
         .EUt(100000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('manganese_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('manganese_essence_burning_0'))
         .itemInputs('mysticalagriculture:manganese_essence')
         .inputFluids(metal)
         .itemOutputs('16x gtceu:raw_pyrolusite')
@@ -789,7 +790,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('manganese_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('manganese_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:manganese_essence')
         .inputFluids(metalCryptand)
         .itemOutputs('64x gtceu:raw_pyrolusite')
@@ -798,7 +799,7 @@ ServerEvents.recipes(event => {
         .EUt(100000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('platinum_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('platinum_essence_burning_0'))
         .itemInputs('mysticalagriculture:platinum_essence')
         .inputFluids(metal)
         .itemOutputs('16x gtceu:raw_cooperite')
@@ -807,7 +808,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('platinum_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('platinum_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:platinum_essence')
         .inputFluids(metalCryptand)
         .itemOutputs('64x gtceu:raw_cooperite')
@@ -816,7 +817,7 @@ ServerEvents.recipes(event => {
         .EUt(100000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('titanium_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('titanium_essence_burning_0'))
         .itemInputs('mysticalagriculture:titanium_essence')
         .inputFluids(metal)
         .itemOutputs('16x gtceu:raw_ilmenite')
@@ -825,7 +826,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('titanium_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('titanium_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:titanium_essence')
         .inputFluids(metalCryptand)
         .itemOutputs('64x gtceu:raw_ilmenite')
@@ -834,7 +835,7 @@ ServerEvents.recipes(event => {
         .EUt(100000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('niobium_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('niobium_essence_burning_0'))
         .itemInputs('mysticalagriculture:niobium_essence')
         .inputFluids(metal)
         .itemOutputs('16x gtceu:raw_pyrochlore')
@@ -843,7 +844,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('niobium_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('niobium_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:niobium_essence')
         .inputFluids(metalCryptand)
         .itemOutputs('64x gtceu:raw_pyrochlore')
@@ -852,7 +853,7 @@ ServerEvents.recipes(event => {
         .EUt(100000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('caesium_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('caesium_essence_burning_0'))
         .itemInputs('mysticalagriculture:caesium_essence')
         .inputFluids(dust)
         .itemOutputs('16x gtceu:raw_pollucite')
@@ -861,7 +862,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('caesium_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('caesium_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:caesium_essence')
         .inputFluids(dustCryptand)
         .itemOutputs('64x gtceu:raw_pollucite')
@@ -870,7 +871,7 @@ ServerEvents.recipes(event => {
         .EUt(100000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('cerium_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('cerium_essence_burning_0'))
         .itemInputs('mysticalagriculture:cerium_essence')
         .inputFluids(dust)
         .itemOutputs('16x gtceu:raw_bastnasite')
@@ -879,7 +880,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('cerium_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('cerium_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:cerium_essence')
         .inputFluids(dustCryptand)
         .itemOutputs('64x gtceu:raw_bastnasite')
@@ -888,7 +889,7 @@ ServerEvents.recipes(event => {
         .EUt(100000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('chalcopyrite_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('chalcopyrite_essence_burning_0'))
         .itemInputs('mysticalagriculture:chalcopyrite_essence')
         .inputFluids(dust)
         .itemOutputs('16x gtceu:raw_chalcopyrite')
@@ -897,7 +898,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('chalcopyrite_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('chalcopyrite_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:chalcopyrite_essence')
         .inputFluids(dustCryptand)
         .itemOutputs('64x gtceu:raw_chalcopyrite')
@@ -906,7 +907,7 @@ ServerEvents.recipes(event => {
         .EUt(100000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('blaze_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('blaze_essence_burning_0'))
         .itemInputs('mysticalagriculture:blaze_essence')
         .inputFluids(gem)
         .itemOutputs('16x minecraft:blaze_rod')
@@ -915,7 +916,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('blaze_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('blaze_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:blaze_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x minecraft:blaze_rod')
@@ -924,7 +925,7 @@ ServerEvents.recipes(event => {
         .EUt(100000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('blizz_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('blizz_essence_burning_0'))
         .itemInputs('mysticalagriculture:blizz_essence')
         .inputFluids(gem)
         .itemOutputs('16x thermal:blizz_rod')
@@ -933,7 +934,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('blizz_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('blizz_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:blizz_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x thermal:blizz_rod')
@@ -942,7 +943,7 @@ ServerEvents.recipes(event => {
         .EUt(100000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('blitz_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('blitz_essence_burning_0'))
         .itemInputs('mysticalagriculture:blitz_essence')
         .inputFluids(gem)
         .itemOutputs('16x thermal:blitz_rod')
@@ -951,7 +952,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('blitz_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('blitz_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:blitz_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x thermal:blitz_rod')
@@ -960,7 +961,7 @@ ServerEvents.recipes(event => {
         .EUt(100000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('basalz_essence_burning_0')
+    event.recipes.gtceu.essence_burning(id('basalz_essence_burning_0'))
         .itemInputs('mysticalagriculture:basalz_essence')
         .inputFluids(gem)
         .itemOutputs('16x thermal:basalz_rod')
@@ -969,7 +970,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('basalz_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('basalz_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:basalz_essence')
         .inputFluids(gemCryptand)
         .itemOutputs('64x thermal:basalz_rod')
@@ -978,7 +979,7 @@ ServerEvents.recipes(event => {
         .EUt(100000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('tungsten_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('tungsten_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:tungsten_essence')
         .inputFluids(metalCryptand)
         .itemOutputs('24x gtceu:raw_tungstate')
@@ -987,7 +988,7 @@ ServerEvents.recipes(event => {
         .EUt(6400)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('tungsten_essence_burning_1_cryptand')
+    event.recipes.gtceu.essence_burning(id('tungsten_essence_burning_1_cryptand'))
         .itemInputs('mysticalagriculture:tungsten_essence')
         .inputFluids(metalCryptand)
         .itemOutputs('24x gtceu:raw_scheelite')
@@ -996,7 +997,7 @@ ServerEvents.recipes(event => {
         .EUt(100000)
         .circuit(1);
 
-    event.recipes.gtceu.essence_burning('barium_essence_burning_0_cryptand')
+    event.recipes.gtceu.essence_burning(id('barium_essence_burning_0_cryptand'))
         .itemInputs('mysticalagriculture:barium_essence')
         .inputFluids(dustCryptand)
         .itemOutputs('32x gtceu:raw_barite')
@@ -1005,7 +1006,7 @@ ServerEvents.recipes(event => {
         .EUt(100000)
         .circuit(0);
 
-    event.recipes.gtceu.essence_burning('naquadah_essence_burning_1_cryptand')
+    event.recipes.gtceu.essence_burning(id('naquadah_essence_burning_1_cryptand'))
         .itemInputs('mysticalagriculture:naquadah_essence')
         .inputFluids(metalCryptand)
         .itemOutputs('12x gtceu:raw_naquadah')

--- a/kubejs/server_scripts/mystical agriculture/essence_enchancer.js
+++ b/kubejs/server_scripts/mystical agriculture/essence_enchancer.js
@@ -1,5 +1,5 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     const dust1 = 'mysticalagriculture:inferium_essence';
     const dust2 = 'mysticalagriculture:prudentium_essence';
@@ -9,37 +9,37 @@ ServerEvents.recipes(event => {
     const dust6 = 'mysticalagriculture:awakened_supremium_essence';
     const dust7 = 'mysticalagradditions:insanium_essence';
 
-    event.recipes.gtceu.essence_enchancing('inferium_ench')
+    event.recipes.gtceu.essence_enchancing(id('inferium_ench'))
         .itemInputs(dust1)
         .itemOutputs(dust2)
         .duration(1000)
         .EUt(400);
 
-    event.recipes.gtceu.essence_enchancing('prudentium_ench')
+    event.recipes.gtceu.essence_enchancing(id('prudentium_ench'))
         .itemInputs(dust2)
         .itemOutputs(dust3)
         .duration(1000)
         .EUt(1024);
 
-    event.recipes.gtceu.essence_enchancing('tertium_ench')
+    event.recipes.gtceu.essence_enchancing(id('tertium_ench'))
         .itemInputs(dust3)
         .itemOutputs(dust4)
         .duration(1000)
         .EUt(6400);
 
-    event.recipes.gtceu.essence_enchancing('imperium_ench')
+    event.recipes.gtceu.essence_enchancing(id('imperium_ench'))
         .itemInputs(dust4)
         .itemOutputs(dust5)
         .duration(1000)
         .EUt(15000);
 
-    event.recipes.gtceu.essence_enchancing('supremium_ench')
+    event.recipes.gtceu.essence_enchancing(id('supremium_ench'))
         .itemInputs(dust5)
         .itemOutputs(dust6)
         .duration(1000)
         .EUt(100000);
 
-    event.recipes.gtceu.essence_enchancing('awakened_supremium_ench')
+    event.recipes.gtceu.essence_enchancing(id('awakened_supremium_ench'))
         .itemInputs(dust6)
         .itemOutputs(dust7)
         .duration(1000)

--- a/kubejs/server_scripts/mystical agriculture/essence_replication.js
+++ b/kubejs/server_scripts/mystical agriculture/essence_replication.js
@@ -1,4 +1,3 @@
-
 ServerEvents.recipes(event => {
 
     const dust1 = 'mysticalagriculture:inferium_essence';
@@ -9,13 +8,13 @@ ServerEvents.recipes(event => {
     const dust6 = 'mysticalagriculture:awakened_supremium_essence';
     const dust7 = 'mysticalagradditions:insanium_essence';
 
-    event.recipes.gtceu.essence_replication('inferium')
+    event.recipes.gtceu.essence_replication(id('inferium'))
         .notConsumable(dust1)
         .chancedOutput(dust1, 7500, 400)
         .duration(2500)
         .EUt(20);
 
-    event.recipes.gtceu.essence_replication('prudentium_a')
+    event.recipes.gtceu.essence_replication(id('prudentium_a'))
         .notConsumable(dust2)
         .inputFluids('gtceu:12_crown_4_li 10')
         .chancedOutput(dust2, 6000, 500)
@@ -23,7 +22,7 @@ ServerEvents.recipes(event => {
         .duration(2500)
         .EUt(80);
 
-    event.recipes.gtceu.essence_replication('prudentium_b')
+    event.recipes.gtceu.essence_replication(id('prudentium_b'))
         .notConsumable(dust2)
         .inputFluids('gtceu:cryptand_na 1')
         .chancedOutput(dust2, 7500, 1000)
@@ -31,7 +30,7 @@ ServerEvents.recipes(event => {
         .duration(2500)
         .EUt(80);
 
-    event.recipes.gtceu.essence_replication('tertium_a')
+    event.recipes.gtceu.essence_replication(id('tertium_a'))
         .notConsumable(dust3)
         .inputFluids('gtceu:12_crown_4_li 10')
         .chancedOutput(dust3, 4000, 400)
@@ -39,7 +38,7 @@ ServerEvents.recipes(event => {
         .duration(2500)
         .EUt(400);
 
-    event.recipes.gtceu.essence_replication('tertium_b')
+    event.recipes.gtceu.essence_replication(id('tertium_b'))
         .notConsumable(dust3)
         .inputFluids('gtceu:cryptand_li 1')
         .chancedOutput(dust3, 5500, 1000)
@@ -47,7 +46,7 @@ ServerEvents.recipes(event => {
         .duration(2500)
         .EUt(400);
 
-    event.recipes.gtceu.essence_replication('imperium_a')
+    event.recipes.gtceu.essence_replication(id('imperium_a'))
         .notConsumable(dust4)
         .inputFluids('gtceu:15_crown_5_na 10')
         .chancedOutput(dust4, 3000, 400)
@@ -55,7 +54,7 @@ ServerEvents.recipes(event => {
         .duration(2500)
         .EUt(1024);
 
-    event.recipes.gtceu.essence_replication('imperium_b')
+    event.recipes.gtceu.essence_replication(id('imperium_b'))
         .notConsumable(dust4)
         .inputFluids('gtceu:cryptand_na 1')
         .chancedOutput(dust4, 4500, 1000)
@@ -63,7 +62,7 @@ ServerEvents.recipes(event => {
         .duration(2500)
         .EUt(1024);
 
-    event.recipes.gtceu.essence_replication('supremium_a')
+    event.recipes.gtceu.essence_replication(id('supremium_a'))
         .notConsumable(dust5)
         .inputFluids('gtceu:15_crown_5_na 10')
         .chancedOutput(dust5, 2000, 400)
@@ -71,7 +70,7 @@ ServerEvents.recipes(event => {
         .duration(2500)
         .EUt(6400);
 
-    event.recipes.gtceu.essence_replication('supremium_b')
+    event.recipes.gtceu.essence_replication(id('supremium_b'))
         .notConsumable(dust5)
         .inputFluids('gtceu:cryptand_na 1')
         .chancedOutput(dust5, 3500, 1000)
@@ -79,7 +78,7 @@ ServerEvents.recipes(event => {
         .duration(2500)
         .EUt(6400);
 
-    event.recipes.gtceu.essence_replication('awakened_supremium_a')
+    event.recipes.gtceu.essence_replication(id('awakened_supremium_a'))
         .notConsumable(dust6)
         .inputFluids('gtceu:18_crown_6_k 10')
         .chancedOutput(dust6, 1000, 400)
@@ -87,7 +86,7 @@ ServerEvents.recipes(event => {
         .duration(2500)
         .EUt(15000);
 
-    event.recipes.gtceu.essence_replication('awakened_supremium_b')
+    event.recipes.gtceu.essence_replication(id('awakened_supremium_b'))
         .notConsumable(dust6)
         .inputFluids('gtceu:cryptand_k 1')
         .chancedOutput(dust6, 2500, 1000)

--- a/kubejs/server_scripts/mystical agriculture/essence_replication.js
+++ b/kubejs/server_scripts/mystical agriculture/essence_replication.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     const dust1 = 'mysticalagriculture:inferium_essence';
     const dust2 = 'mysticalagriculture:prudentium_essence';

--- a/kubejs/server_scripts/mystical agriculture/greenhouse_growing.js
+++ b/kubejs/server_scripts/mystical agriculture/greenhouse_growing.js
@@ -1,5 +1,5 @@
-
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     const dust1 = 'mysticalagriculture:inferium_essence';
     const dust2 = 'mysticalagriculture:prudentium_essence';
@@ -42,7 +42,7 @@ ServerEvents.recipes(event => {
             }
         }
 
-        event.recipes.gtceu.greenhouse_growing(`${type}_essence_growing`)
+        event.recipes.gtceu.greenhouse_growing(id(`${type}_essence_growing`))
             .notConsumable(`mysticalagriculture:${type}_seeds`)
             .chancedInput(dust, 1000, 0)
             .chancedOutput(`mysticalagriculture:${type}_essence`, 7500, 500)

--- a/kubejs/server_scripts/mystical agriculture/mysticalagriculture.js
+++ b/kubejs/server_scripts/mystical agriculture/mysticalagriculture.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     const dust1 = 'mysticalagriculture:inferium_essence';
     const dust2 = 'mysticalagriculture:prudentium_essence';
@@ -9,7 +10,7 @@ ServerEvents.recipes(event => {
     const dust7 = 'mysticalagradditions:insanium_essence';
 
     // essence recipes (SUBJECT OF CHANGE)
-    event.recipes.gtceu.mixer('inferium_essence')
+    event.recipes.gtceu.mixer(id('inferium_essence'))
         .itemInputs('gtceu:phosphorus_dust', 'gtceu:beryllium_dust')
         .inputFluids('gtceu:glowstone 144')
         .itemOutputs(dust1)
@@ -62,7 +63,7 @@ ServerEvents.recipes(event => {
         {essence: 'cerium', inputs: ['33x mysticalagriculture:topaz_essence', '48x mysticalagriculture:coal_essence', '59x mysticalagriculture:earth_essence'], energy: 6400, circuit: 31},
         {essence: 'barium', inputs: ['59x mysticalagriculture:stone_essence', '64x mysticalagriculture:sulfur_essence', '59x mysticalagriculture:nether_quartz_essence'], energy: 6400, circuit: 32}
     ].forEach(essence=> {
-        event.recipes.gtceu.mixer(`${essence.essence}_essence_mix`)
+        event.recipes.gtceu.mixer(id(`${essence.essence}_essence_mix`))
             .itemInputs(essence.inputs)
             .itemOutputs(`mysticalagriculture:${essence.essence}_essence`)
             .duration(200)
@@ -80,7 +81,7 @@ ServerEvents.recipes(event => {
         {essence: 'tungsten', base: 'barium', odds: 4000, energy: 16000},
         {essence: 'naquadah', base: 'tungsten', odds: 950, energy: 100000}
     ].forEach(essence=> {
-        event.recipes.gtceu.extractor(`${essence.essence}_essence_extraction`)
+        event.recipes.gtceu.extractor(id(`${essence.essence}_essence_extraction`))
             .itemInputs(`mysticalagriculture:${essence.base}_essence`)
             .chancedOutput(`mysticalagriculture:${essence.essence}_essence`, essence.odds, 0)
             .duration(200)
@@ -97,7 +98,7 @@ ServerEvents.recipes(event => {
         'molybdenum', 'tantalum', 'manganese', 'platinum', 'titanium', 'caesium', 'blaze', 'blizz', 'blitz',
         'basalz', 'cerium', 'chalcopyrite', 'niobium', 'tungsten', 'barium', 'naquadah'
     ].forEach(element=> {
-        event.recipes.gtceu.compressor(`${element}_seeds_recipe`)
+        event.recipes.gtceu.compressor(id(`${element}_seeds_recipe`))
             .itemInputs(`16x mysticalagriculture:${element}_essence`)
             .itemOutputs(`mysticalagriculture:${element}_seeds`)
             .duration(800)
@@ -105,7 +106,7 @@ ServerEvents.recipes(event => {
     });
 
     // Centrifuging recipes
-    event.recipes.gtceu.centrifuge('elements_from_essence')
+    event.recipes.gtceu.centrifuge(id('elements_from_essence'))
         .itemInputs(dust1)
         .chancedOutput('mysticalagriculture:air_essence', 2500, 0)
         .chancedOutput('mysticalagriculture:earth_essence', 2500, 0)
@@ -114,7 +115,7 @@ ServerEvents.recipes(event => {
         .duration(600)
         .EUt(80);
 
-    event.recipes.gtceu.centrifuge('life_essence_centrifuging_0')
+    event.recipes.gtceu.centrifuge(id('life_essence_centrifuging_0'))
         .itemInputs('6x mysticalagriculture:life_essence')
         .chancedOutput('mysticalagriculture:enderman_essence', 1500, 500)
         .chancedOutput('mysticalagriculture:slime_essence', 4500, 500)
@@ -123,7 +124,7 @@ ServerEvents.recipes(event => {
         .EUt(400)
         .circuit(0);
 
-    event.recipes.gtceu.centrifuge('life_essence_centrifuging_1')
+    event.recipes.gtceu.centrifuge(id('life_essence_centrifuging_1'))
         .itemInputs('32x mysticalagriculture:life_essence')
         .chancedOutput('mysticalagriculture:blaze_essence', 6500, 500)
         .chancedOutput('mysticalagriculture:blitz_essence', 1500, 500)
@@ -209,13 +210,13 @@ ServerEvents.recipes(event => {
         C: 'gtceu:aluminium_single_cable'
     });
 
-    event.recipes.gtceu.chemical_reactor('inferium_coal')
+    event.recipes.gtceu.chemical_reactor(id('inferium_coal'))
         .itemInputs('minecraft:coal', 'mysticalagriculture:inferium_essence')
         .itemOutputs('mysticalagradditions:inferium_coal')
         .duration(200)
         .EUt(20);
 
-    event.recipes.gtceu.large_chemical_reactor('inferium_coal')
+    event.recipes.gtceu.large_chemical_reactor(id('inferium_coal'))
         .itemInputs('minecraft:coal', 'mysticalagriculture:inferium_essence')
         .itemOutputs('mysticalagradditions:inferium_coal')
         .duration(200)
@@ -227,26 +228,26 @@ ServerEvents.recipes(event => {
         {tier: 'imperium', lower_tier: 'tertium', energy: 80},
         {tier: 'supremium', lower_tier: 'imperium', energy: 80}
     ].forEach(tier=> {
-        event.recipes.gtceu.chemical_reactor(`${tier.tier}_coal`)
+        event.recipes.gtceu.chemical_reactor(id(`${tier.tier}_coal`))
             .itemInputs(`mysticalagradditions:${tier.lower_tier}_coal`, `mysticalagriculture:${tier.tier}_essence`)
             .itemOutputs(`mysticalagradditions:${tier.tier}_coal`)
             .duration(200)
             .EUt(tier.energy);
             
-        event.recipes.gtceu.large_chemical_reactor(`${tier.tier}_coal`)
+        event.recipes.gtceu.large_chemical_reactor(id(`${tier.tier}_coal`))
             .itemInputs(`mysticalagradditions:${tier.lower_tier}_coal`, `mysticalagriculture:${tier.tier}_essence`)
             .itemOutputs(`mysticalagradditions:${tier.tier}_coal`)
             .duration(200)
             .EUt(tier.energy);
     });
 
-    event.recipes.gtceu.chemical_reactor('insanium_coal')
+    event.recipes.gtceu.chemical_reactor(id('insanium_coal'))
         .itemInputs('mysticalagradditions:supremium_coal', 'mysticalagradditions:insanium_essence')
         .itemOutputs('mysticalagradditions:insanium_coal')
         .duration(200)
         .EUt(400);
 
-    event.recipes.gtceu.large_chemical_reactor('insanium_coal')
+    event.recipes.gtceu.large_chemical_reactor(id('insanium_coal'))
         .itemInputs('mysticalagradditions:supremium_coal', 'mysticalagradditions:insanium_essence')
         .itemOutputs('mysticalagradditions:insanium_coal')
         .duration(200)

--- a/kubejs/server_scripts/mystical agriculture/mysticalagriculture.js
+++ b/kubejs/server_scripts/mystical agriculture/mysticalagriculture.js
@@ -1,6 +1,6 @@
 ServerEvents.recipes(event => {
     const id = global.id;
-
+    
     const dust1 = 'mysticalagriculture:inferium_essence';
     const dust2 = 'mysticalagriculture:prudentium_essence';
     const dust3 = 'mysticalagriculture:tertium_essence';
@@ -157,7 +157,7 @@ ServerEvents.recipes(event => {
             H: `gtceu:${tier.voltage}_machine_hull`,
             M: `gtceu:${tier.voltage}_electric_pump`,
             C: `gtceu:${tier.cable}_single_cable`
-        });
+        }).id(`start:shaped/${tier.voltage}_mystical_greenhouse`);
     });
 
     [
@@ -182,7 +182,7 @@ ServerEvents.recipes(event => {
             H: `gtceu:${tier.voltage}_machine_hull`,
             P: `gtceu:${tier.voltage}_electric_pump`,
             C: `gtceu:${tier.cable}_single_cable`
-        });
+        }).id(`start:shaped/${tier.voltage}_essence_burner`);
     });
 
     event.shaped(Item.of('gtceu:essence_replicator'), [
@@ -195,7 +195,7 @@ ServerEvents.recipes(event => {
         E: 'gtceu:mv_emitter',
         H: 'gtceu:heatproof_machine_casing',
         C: 'gtceu:gold_single_cable'
-    });
+    }).id('start:shaped/essence_replicator');
 
     event.shaped(Item.of('gtceu:essence_enchancer'), [
         'SAP',
@@ -208,7 +208,7 @@ ServerEvents.recipes(event => {
         E: 'gtceu:hv_emitter',
         H: 'gtceu:clean_machine_casing',
         C: 'gtceu:aluminium_single_cable'
-    });
+    }).id('start:shaped/essence_enhancer');
 
     event.recipes.gtceu.chemical_reactor(id('inferium_coal'))
         .itemInputs('minecraft:coal', 'mysticalagriculture:inferium_essence')

--- a/kubejs/server_scripts/nuclear_reactors/fission/nuclear_fission.js
+++ b/kubejs/server_scripts/nuclear_reactors/fission/nuclear_fission.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     [
         {id: 'thorium_232', rod: 'thorium', input: ['4x gtceu:thorium_dust'], output: ['4x gtceu:uranium_235_dust'], duration: 200, energy: 1024, harvest: -8192},
@@ -7,14 +8,14 @@ ServerEvents.recipes(event => {
     ].forEach(rod=> {
         //compressing fuels into fuel rods
         rod.input.push('gtceu:aluminium_fluid_cell');
-        event.recipes.gtceu.canner(`${rod.rod}_rod`)
+        event.recipes.gtceu.canner(id(`${rod.rod}_rod`))
             .itemInputs(rod.input)
             .itemOutputs(`kubejs:${rod.rod}_fuel_rod`)
             .duration(rod.duration)
             .EUt(rod.energy);  
 
         //fission reactions (depleting rods)
-        event.recipes.gtceu.nuclear_fission(`${rod.id}_rod`)
+        event.recipes.gtceu.nuclear_fission(id(`${rod.id}_rod`))
             .itemInputs(`kubejs:${rod.rod}_fuel_rod`)
             .inputFluids('gtceu:distilled_water 1000')
             .itemOutputs(`kubejs:depleted_${rod.rod}_fuel_rod`)
@@ -23,7 +24,7 @@ ServerEvents.recipes(event => {
 
         //depleted rod separation
         rod.output.push('gtceu:aluminium_fluid_cell');
-        event.recipes.gtceu.centrifuge(`depleted_${rod.id}_rod`)
+        event.recipes.gtceu.centrifuge(id(`depleted_${rod.id}_rod`))
             .itemInputs(`kubejs:depleted_${rod.rod}_fuel_rod`)
             .itemOutputs(rod.output)
             .duration(rod.duration)

--- a/kubejs/server_scripts/nuclear_reactors/fission/nuclear_reactor.js
+++ b/kubejs/server_scripts/nuclear_reactors/fission/nuclear_reactor.js
@@ -1,7 +1,8 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     //controller
-    event.recipes.gtceu.assembler('nuclear_reactor')
+    event.recipes.gtceu.assembler(id('nuclear_reactor'))
         .itemInputs('3x #gtceu:circuits/ev', 'gtceu:high_temperature_smelting_casing','gtceu:hv_emitter',
             '2x gtceu:hv_electric_pump','gtceu:hv_robot_arm')
         .itemOutputs('gtceu:nuclear_reactor')

--- a/kubejs/server_scripts/nuclear_reactors/not_ready.js
+++ b/kubejs/server_scripts/nuclear_reactors/not_ready.js
@@ -1,3 +1,4 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
     
 });

--- a/kubejs/server_scripts/ore_factory_processing.js
+++ b/kubejs/server_scripts/ore_factory_processing.js
@@ -249,7 +249,7 @@ ServerEvents.recipes(event => {
         P: 'gtceu:brass_plate',
         B: 'gtceu:firebricks',
         F: '#forge:tools/screwdrivers'
-    });
+    }).id('start:shaped/primitive_ore_factory');
 
     event.shaped(Item.of('gtceu:steam_ore_factory'), [
         'HRS',
@@ -262,7 +262,7 @@ ServerEvents.recipes(event => {
         P: 'gtceu:invar_plate',
         B: 'gtceu:steam_machine_casing',
         F: '#forge:tools/screwdrivers'
-    });
+    }).id('start:shaped/steam_ore_factory');
 
     event.shaped(Item.of('gtceu:electric_ore_factory'), [
         'GCG', 
@@ -274,7 +274,7 @@ ServerEvents.recipes(event => {
         P: 'gtceu:steel_plate',
         L: 'gtceu:lv_machine_hull',
         W: 'gtceu:tin_single_cable'
-    });
+    }).id('start:shaped/electric_ore_factory');
 
     event.shaped(Item.of('gtceu:ore_processing_plant'), [
         'GCG',
@@ -286,7 +286,7 @@ ServerEvents.recipes(event => {
         P: 'gtceu:tungsten_carbide_plate',
         L: 'gtceu:iv_machine_hull',
         W: 'gtceu:platinum_single_cable'
-    });
+    }).id('start:shaped/ore_processing_plant');
 
     // Iterate over each tier and processable item and register the recipes
     Object.keys(oreProcessableTiers).forEach((tier) => {

--- a/kubejs/server_scripts/ore_factory_processing.js
+++ b/kubejs/server_scripts/ore_factory_processing.js
@@ -1,3 +1,4 @@
+const id = global.id;
 
 /*
  * Originally, TheLarkInn added a tag system based on RPM.
@@ -112,7 +113,7 @@ const primitive_processing = (event, materialObj) => {
         { item: '2x #gtceu:coal_dusts', duration: 320, multiplier: 1, id: 'coal_dusts' },
         { item: '2x #gtceu:coal_blocks', duration: 2880, multiplier: 10, id: 'coal_blocks' },
     ].forEach(fuel => {
-        event.recipes.gtceu.primitive_ore_processing(`${materialObj.material}/${fuel.id}`)
+        event.recipes.gtceu.primitive_ore_processing(id(`${materialObj.material}/${fuel.id}`))
             .itemInputs(crushed_ore(materialObj.material, fuel.multiplier), fuel.item)
             .inputFluids(fluids.water)
             .itemOutputs(dust(materialObj.material, fuel.multiplier))
@@ -122,7 +123,7 @@ const primitive_processing = (event, materialObj) => {
             .duration(fuel.duration);
     });
     
-    event.recipes.gtceu.steam_ore_processing(`${materialObj.material}`)
+    event.recipes.gtceu.steam_ore_processing(id(`${materialObj.material}`))
             .itemInputs(crushed_ore(materialObj.material,  1))
             .inputFluids(fluids.water)
             .itemOutputs(dust(materialObj.material, 1))
@@ -139,7 +140,7 @@ const primitive_processing = (event, materialObj) => {
  * Chances are bossted.
 */
 const electric_primitive_processing = (event, materialObj) => {
-    event.recipes.gtceu.electric_ore_processing(`${materialObj.material}`)
+    event.recipes.gtceu.electric_ore_processing(id(`${materialObj.material}`))
         .itemInputs(crushed_ore(materialObj.material, 1))
         .inputFluids(fluids.water)
         .itemOutputs(dust(materialObj.material, 1))
@@ -162,7 +163,7 @@ const electric_processing = (event, materialObj, tier) => {
         'ev': GTValues.VA[GTValues.EV]
     }
     const fluid = (tier == 'lv' || tier == 'mv') ? fluids.distilled_water : fluids.sodium_persulfate;
-    event.recipes.gtceu.electric_ore_processing(`${materialObj.material}`)
+    event.recipes.gtceu.electric_ore_processing(id(`${materialObj.material}`))
         .itemInputs(crushed_ore(materialObj.material, 1))
         .inputFluids(fluid)
         .itemOutputs(dust(materialObj.material, 1))
@@ -180,7 +181,7 @@ const electric_processing = (event, materialObj, tier) => {
 * Chances are boosted.
 */
 const plant_primitive_processing = (event, materialObj) => {
-   event.recipes.gtceu.plant_ore_processing(`${materialObj.material}`)
+   event.recipes.gtceu.plant_ore_processing(id(`${materialObj.material}`))
        .itemInputs(crushed_ore(materialObj.material, 1))
        .inputFluids(fluids.water)
        .itemOutputs(dust(materialObj.material, 1))
@@ -204,7 +205,7 @@ const plant_electric_processing = (event, materialObj, tier) => {
         'ev': GTValues.VHA[GTValues.EV]
     }
     const fluid = (tier == 'lv' || tier == 'mv') ? fluids.distilled_water : fluids.sodium_persulfate;
-    event.recipes.gtceu.plant_ore_processing(`${materialObj.material}`)
+    event.recipes.gtceu.plant_ore_processing(id(`${materialObj.material}`))
         .itemInputs(crushed_ore(materialObj.material, 1))
         .inputFluids(fluid)
         .itemOutputs(dust(materialObj.material, 1))
@@ -220,7 +221,7 @@ const plant_electric_processing = (event, materialObj, tier) => {
  * Final form of 1-step ore processing.
 */
 const plant_ore_processing = (event, materialObj) => {
-    event.recipes.gtceu.plant_ore_processing(`${materialObj.material}`)
+    event.recipes.gtceu.plant_ore_processing(id(`${materialObj.material}`))
         .itemInputs(crushed_ore(materialObj.material, 1))
         .inputFluids(fluids.sodium_persulfate_5x)
         .itemOutputs(dust(materialObj.material, 1))

--- a/kubejs/server_scripts/recipe_changes.js
+++ b/kubejs/server_scripts/recipe_changes.js
@@ -3,7 +3,7 @@
 ServerEvents.recipes(event => {
     const id = global.id;
 
-    event.recipes.create.pressing('gtceu:compressed_fireclay', 'gtceu:fireclay_dust');
+    event.recipes.create.pressing('gtceu:compressed_fireclay', 'gtceu:fireclay_dust').id('start:pressing/compressed_fireclay');
 
     event.campfireCooking('gtceu:wrought_iron_ingot', 'minecraft:iron_ingot');
 
@@ -45,7 +45,7 @@ ServerEvents.recipes(event => {
         'SSS'
     ], {
         S: '#minecraft:wooden_slabs'
-    });
+    }).id('start:shaped/wood_plate');
 
     //glass tube shenanigans
     event.shaped(Item.of('gtceu:glass_tube'), [
@@ -54,7 +54,7 @@ ServerEvents.recipes(event => {
         'PPP'
     ], {
         P: 'minecraft:glass_pane'
-    });
+    }).id('start:shaped/glass_tube');
 
     ['tiled','framed','horizontal_framed','vertical_framed'].forEach(type => {
         event.remove({ id: `create:smelting/glass_pane_from_${type}_glass_pane`})
@@ -69,11 +69,11 @@ ServerEvents.recipes(event => {
     ], {
         'D': 'gtceu:fireclay_dust',
         'M': 'gtceu:brick_wooden_form'
-    }).keepIngredient('gtceu:brick_wooden_form');
+    }).keepIngredient('gtceu:brick_wooden_form').id('start:shaped/compressed_fireclay');
 
-    event.recipes.create.pressing('gtceu:rubber_plate', 'thermal:cured_rubber');
+    event.recipes.create.pressing('gtceu:rubber_plate', 'thermal:cured_rubber').id('start:pressing/rubber_plate');
 
-    event.recipes.gtceu.fluid_solidifier(id('gtceu:raw_rubber'))
+    event.recipes.gtceu.fluid_solidifier(id('raw_rubber'))
         .inputFluids('thermal:latex 250')
         .itemOutputs('thermal:rubber')
         .duration(120)
@@ -189,7 +189,7 @@ ServerEvents.recipes(event => {
     ], {
         H: '#forge:tools/hammers',
         R: 'thermal:cured_rubber'
-    })
+    }).id('start:shaped/rubber_plate');
 
     const casing = (type,material,casing_id) => {
         event.shaped(Item.of(`2x ${casing_id}:${type}_casing`), [
@@ -201,7 +201,7 @@ ServerEvents.recipes(event => {
             F: `gtceu:${material}_frame`,
             H: '#forge:tools/hammers',
             W: '#forge:tools/wrenches'
-        });
+        }).id(`start:shaped/${type}_casing`);
 
         event.recipes.gtceu.assembler(id(`${type}_casing`))
             .itemInputs(`gtceu:${material}_plate`, `gtceu:${material}_frame`)
@@ -249,7 +249,7 @@ ServerEvents.recipes(event => {
             F: `gtceu:${material}_frame`,
             H: '#forge:tools/hammers',
             W: '#forge:tools/wrenches'
-        });
+        }).id(`start:shaped/${type}_casing`);
 
         event.recipes.gtceu.assembler(id(`${type}_casing`))
             .itemInputs(`gtceu:double_${material}_plate`, `gtceu:${material}_frame`)
@@ -280,7 +280,7 @@ ServerEvents.recipes(event => {
             P: `gtceu:${material}_plate`,
             F: `gtceu:${material}_frame`,
             R: `gtceu:${material}_rod`
-        });
+        }).id(`start:${type}_firebox_casing`);
     };
 
     firebox('enriched_naquadah','enriched_naquadah','start_core')
@@ -296,7 +296,7 @@ ServerEvents.recipes(event => {
             G:  `gtceu:${material}_gear`,
             H: '#forge:tools/hammers',
             W: '#forge:tools/wrenches'
-        });
+        }).id(`start:${type}_gearbox`);
     
         event.recipes.gtceu.assembler(id(`${material}_gearbox`))
             .itemInputs(`4x gtceu:${material}_plate`,`2x gtceu:${material}_gear`,`gtceu:${material}_frame`)
@@ -317,7 +317,7 @@ ServerEvents.recipes(event => {
             P:  `gtceu:${material}_plate`,
             F:  `gtceu:${material}_frame`,
             L:  `gtceu:${pipe}_normal_fluid_pipe`
-        });
+        }).id(`start:${type}_pipe_casing`);
     };
 
     pipe('enriched_naquadah','enriched_naquadah','naquadah','kubejs');
@@ -333,7 +333,7 @@ ServerEvents.recipes(event => {
             R:  `gtceu:${material}_rotor`,
             H: '#forge:tools/hammers',
             W: '#forge:tools/wrenches'
-        });
+        }).id(`start:${type}_engine_intake_casing`);
 
         event.recipes.gtceu.assembler(id( `${type}_engine_intake_casing`))
             .itemInputs(`2x gtceu:${material}_rotor`,`4x gtceu:${pipe}_normal_fluid_pipe`,`${used_casing}_casing`)
@@ -364,7 +364,7 @@ ServerEvents.recipes(event => {
         C: '#gtceu:circuits/lv',
         K: 'minecraft:charcoal',
         s: 'create:shaft'
-    });
+    }).id('start:shaped/carbon_brushes');
 
     event.shaped(Item.of('create_new_age:magnetite_block'), [
         'SMS',
@@ -373,7 +373,7 @@ ServerEvents.recipes(event => {
     ], {
         S: 'minecraft:stone',
         M: 'gtceu:magnetite_dust'
-    });
+    }).id('start:shaped/magnetite_block');
 
     event.shaped(Item.of('3x create_new_age:redstone_magnet'), [
         'MRM',
@@ -383,17 +383,17 @@ ServerEvents.recipes(event => {
         B: 'create_new_age:magnetite_block',
         R: 'minecraft:redstone',
         M: 'gtceu:magnetite_dust'
-    });
+    }).id('start:shaped/redstone_magnet');
 
     event.shaped(Item.of('3x create:belt_connector'), [
         'RRR'
     ], {
         R: 'gtceu:rubber_plate'
-    });
+    }).id('start:shaped/belt_connector');
 
     //plates
     ['lead','silver','tin','zinc','bronze','red_alloy','nickel','invar','soul_infused','cobalt_brass','wrought_iron'].forEach(type => {
-        event.recipes.create.pressing(`gtceu:${type}_plate`,`gtceu:${type}_ingot`);
+        event.recipes.create.pressing(`gtceu:${type}_plate`,`gtceu:${type}_ingot`).id(`start:pressing/${type}_plate`);
     });
   
     event.replaceInput({id: 'enderchests:ender_pouch'}, 'minecraft:leather', 'gtceu:carbon_fiber_plate');
@@ -405,7 +405,7 @@ ServerEvents.recipes(event => {
         M: 'create_new_age:fluxuateted_magnetite',
         N: 'gtceu:neodymium_ingot',
         E: 'gtceu:energium_dust'
-    });
+    }).id('start:shaped/neodymium_magnet');
 
     event.recipes.thermal.lapidary_fuel('gtceu:diatron_gem', 750000);
     event.recipes.thermal.lapidary_fuel('gtceu:flawless_diatron_gem', 750000 * 2.5);
@@ -574,14 +574,14 @@ ServerEvents.recipes(event => {
     [
         'bender', 'centrifuge', 'electrolyzer', 'extruder', 'forming_press', 'lathe', 'mixer', 'ore_washer', 'sifter', 'thermal_centrifuge', 'wiremill', 'macerator', 'autoclave'
     ].forEach(machine=> {
-        event.recipes.create.item_application(`gtceu:t_large_${machine}`, [`gtceu:hv_${machine}`, 'kubejs:multiblock_upgrade_kit']);
+        event.recipes.create.item_application(`gtceu:t_large_${machine}`, [`gtceu:hv_${machine}`, 'kubejs:multiblock_upgrade_kit']).id(`start:item_application/large_${machine}`);
     });
-    event.recipes.create.item_application('gtceu:large_rock_crusher', ['gtceu:hv_rock_crusher', 'kubejs:multiblock_upgrade_kit']);
+    event.recipes.create.item_application('gtceu:large_rock_crusher', ['gtceu:hv_rock_crusher', 'kubejs:multiblock_upgrade_kit']).id('start:item_application/large_rock_crusher');
 
     // Mycelium Leather
-    event.recipes.create.pressing('kubejs:compressed_mycelium', 'kubejs:mycelium_growth');
-    event.smoking('kubejs:smoked_mycelium', 'kubejs:compressed_mycelium');
-    event.recipes.create.pressing('minecraft:leather', 'kubejs:smoked_mycelium');
+    event.recipes.create.pressing('kubejs:compressed_mycelium', 'kubejs:mycelium_growth').id('start:pressing/compressed_mycelium');
+    event.smoking('kubejs:smoked_mycelium', 'kubejs:compressed_mycelium').id('start:smoking/smoked_mycelium');
+    event.recipes.create.pressing('minecraft:leather', 'kubejs:smoked_mycelium').id('start:pressing/mycelium_leather');
 
     // Warping recipes
     [{input: 'architects_palette:abyssaline_lamp', output: 'architects_palette:hadaline_lamp'},
@@ -603,8 +603,8 @@ ServerEvents.recipes(event => {
         {input: 'minecraft:basalt', output: 'architects_palette:moonshale'},
         {input: '#minecraft:saplings', output: 'architects_palette:twisted_sapling'},
         {input: '#minecraft:leaves', output: 'architects_palette:twisted_leaves'}
-    ].forEach((prop) => {
-        event.recipes.create.haunting(Item.of(prop.output), Item.of(prop.input));
+    ].forEach(prop => {
+        event.recipes.create.haunting(Item.of(prop.output), Item.of(prop.input)).id(`start:haunting/${prop.output.split(':')[1]}`);
     });
 
     event.recipes.gtceu.circuit_assembler(id('data_dna_disk'))
@@ -657,7 +657,7 @@ ServerEvents.recipes(event => {
         .duration(240)
         .EUt(600);
 
-    event.recipes.create.item_application('minecraft:mycelium', ['minecraft:grass_block', 'exnihilosequentia:mycelium_spores']);
+    event.recipes.create.item_application('minecraft:mycelium', ['minecraft:grass_block', 'exnihilosequentia:mycelium_spores']).id('start:item_application/mycelium');
 
     //Tom's / Chipped Fixes
 
@@ -670,7 +670,7 @@ ServerEvents.recipes(event => {
     ], {
         P: 'gtceu:steel_plate',
         T: 'toms_storage:ts.wireless_terminal'
-    });
+    }).id('start:shaped/advanced_wireless_terminal');
 
     //Treated Wood Fixes/Additions
     event.remove({id: 'gtceu:macerator/macerate_treated_wood_chest_boat'})
@@ -684,7 +684,7 @@ ServerEvents.recipes(event => {
         .itemOutputs('gtceu:treated_wood_dust')
         .duration(98)
         .EUt(2);
-    event.recipes.create.filling('gtceu:treated_wood_planks', [Fluid.of('gtceu:creosote', 125), '#minecraft:planks']);
+    event.recipes.create.filling('gtceu:treated_wood_planks', [Fluid.of('gtceu:creosote', 125), '#minecraft:planks']).id('start:filling/treated_wood_planks');
 
     event.replaceOutput({ type: 'gtceu:cutter'}, 'ae2:certus_quartz_crystal', '2x ae2:certus_quartz_crystal');
 

--- a/kubejs/server_scripts/recipe_changes.js
+++ b/kubejs/server_scripts/recipe_changes.js
@@ -1,6 +1,7 @@
 // const $RockBreakerCondition = Java.loadClass('com.gregtechceu.gtceu.common.recipe.RockBreakerCondition')  
 
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     event.recipes.create.pressing('gtceu:compressed_fireclay', 'gtceu:fireclay_dust');
 
@@ -72,19 +73,19 @@ ServerEvents.recipes(event => {
 
     event.recipes.create.pressing('gtceu:rubber_plate', 'thermal:cured_rubber');
 
-    event.recipes.gtceu.fluid_solidifier('gtceu:raw_rubber')
+    event.recipes.gtceu.fluid_solidifier(id('gtceu:raw_rubber'))
         .inputFluids('thermal:latex 250')
         .itemOutputs('thermal:rubber')
         .duration(120)
         .EUt(8);
 
-    event.recipes.gtceu.extractor('latex_extraction')
+    event.recipes.gtceu.extractor(id('latex_extraction'))
         .itemInputs('thermal:rubber')
         .outputFluids('thermal:latex 250')
         .duration(120)
         .EUt(8);
 
-    event.recipes.gtceu.chemical_reactor('latex_rubber')
+    event.recipes.gtceu.chemical_reactor(id('latex_rubber'))
         .itemInputs('3x thermal:rubber', 'gtceu:sulfur_dust')
         .outputFluids('gtceu:rubber 576')
         .duration(240)
@@ -92,46 +93,46 @@ ServerEvents.recipes(event => {
 
     //Recipe conflict fix: ethane+chlorine
     event.remove({id: 'gtceu:chemical_reactor/vinyl_chloride_from_ethane'})
-    event.recipes.gtceu.chemical_reactor('vinyl_chloride_from_ethane')
+    event.recipes.gtceu.chemical_reactor(id('vinyl_chloride_from_ethane'))
         .inputFluids('gtceu:chlorine 4000', 'gtceu:ethane 1000')
         .outputFluids('gtceu:vinyl_chloride 1000','gtceu:hydrochloric_acid 3000')
         .duration(160)
         .EUt(30)
         .circuit(2);
 
-    event.recipes.gtceu.large_chemical_reactor('latex_rubber')
+    event.recipes.gtceu.large_chemical_reactor(id('latex_rubber'))
         .itemInputs('3x thermal:rubber', 'gtceu:sulfur_dust')
         .outputFluids('gtceu:rubber 576')
         .duration(240)
         .EUt(8);
 
-    event.recipes.gtceu.extractor('nether_agglomeration')
+    event.recipes.gtceu.extractor(id('nether_agglomeration'))
         .itemInputs('gtceu:netherrack_dust')
         .itemOutputs('mysticalagriculture:nether_agglomeratio')
         .duration(120)
         .EUt(80);
 
-    event.recipes.gtceu.extractor('end_agglomeration')
+    event.recipes.gtceu.extractor(id('end_agglomeration'))
         .itemInputs('gtceu:endstone_dust')
         .itemOutputs('mysticalagriculture:end_agglomeratio')
         .duration(120)
         .EUt(80);
 
-    event.recipes.gtceu.mixer('nether_air_mix')
+    event.recipes.gtceu.mixer(id('nether_air_mix'))
         .itemInputs('mysticalagriculture:nether_agglomeratio')
         .inputFluids('gtceu:air 12000')
         .outputFluids('gtceu:nether_air 12000')
         .duration(1200)
         .EUt(256);
 
-    event.recipes.gtceu.mixer('ender_air_mix')
+    event.recipes.gtceu.mixer(id('ender_air_mix'))
         .itemInputs('mysticalagriculture:end_agglomeratio')
         .inputFluids('gtceu:nether_air 6000')
         .outputFluids('gtceu:ender_air 6000')
         .duration(1200)
         .EUt(256);
 
-    event.recipes.gtceu.large_chemical_reactor('easy_netherrack')
+    event.recipes.gtceu.large_chemical_reactor(id('easy_netherrack'))
         .itemInputs('16x minecraft:redstone')
         .inputFluids('minecraft:lava 32000')
         .itemOutputs('32x minecraft:netherrack')
@@ -139,7 +140,7 @@ ServerEvents.recipes(event => {
         .EUt(20)
         .circuit(0);
 
-    event.recipes.gtceu.large_chemical_reactor('easy_endstone')
+    event.recipes.gtceu.large_chemical_reactor(id('easy_endstone'))
         .itemInputs('16x minecraft:glowstone_dust')
         .inputFluids('minecraft:lava 32000')
         .itemOutputs('32x minecraft:end_stone')
@@ -147,35 +148,35 @@ ServerEvents.recipes(event => {
         .EUt(20)
         .circuit(0);
 
-    event.recipes.gtceu.mixer('naquadic_netherite')
+    event.recipes.gtceu.mixer(id('naquadic_netherite'))
         .itemInputs('3x gtceu:naquadah_dust', '5x gtceu:pure_netherite_dust', '2x gtceu:caesium_dust', '5x gtceu:cerium_dust')
         .inputFluids('gtceu:fluorine 12000', 'gtceu:oxygen 32000')
         .itemOutputs('59x gtceu:naquadic_netherite_dust')
         .duration(7600)
         .EUt(6400);
 
-    event.recipes.gtceu.mixer('weapon_grade_naquadah')
+    event.recipes.gtceu.mixer(id('weapon_grade_naquadah'))
         .itemInputs('2x gtceu:pure_netherite_dust', '5x gtceu:neutronium_dust')
         .inputFluids('gtceu:naquadria 1008', 'gtceu:fluorine 16000')
         .itemOutputs('30x gtceu:weapon_grade_naquadah_dust')
         .duration(1200)
         .EUt(346000);
 
-    event.recipes.gtceu.alloy_smelter('rubber_sheet_from_thermal')
+    event.recipes.gtceu.alloy_smelter(id('rubber_sheet_from_thermal'))
         .itemInputs('2x thermal:cured_rubber')
         .notConsumable('gtceu:plate_casting_mold')
         .itemOutputs('gtceu:rubber_plate')
         .duration(10)
         .EUt(7);
 
-    event.recipes.gtceu.extruder('rubber_sheet_from_thermal_extruder')
+    event.recipes.gtceu.extruder(id('rubber_sheet_from_thermal_extruder'))
         .itemInputs('thermal:cured_rubber')
         .notConsumable('gtceu:plate_extruder_mold')
         .itemOutputs('gtceu:rubber_plate')
         .duration(5)
         .EUt(56);
 
-    event.recipes.gtceu.extractor('rubber_fluid_from_thermal')
+    event.recipes.gtceu.extractor(id('rubber_fluid_from_thermal'))
         .itemInputs('thermal:cured_rubber')
         .outputFluids('gtceu:rubber 144')
         .duration(5)
@@ -202,7 +203,7 @@ ServerEvents.recipes(event => {
             W: '#forge:tools/wrenches'
         });
 
-        event.recipes.gtceu.assembler(`${type}_casing`)
+        event.recipes.gtceu.assembler(id(`${type}_casing`))
             .itemInputs(`gtceu:${material}_plate`, `gtceu:${material}_frame`)
             .itemOutputs(`2x ${casing_id}:${type}_casing`)
             .duration(50)
@@ -250,7 +251,7 @@ ServerEvents.recipes(event => {
             W: '#forge:tools/wrenches'
         });
 
-        event.recipes.gtceu.assembler(`${type}_casing`)
+        event.recipes.gtceu.assembler(id(`${type}_casing`))
             .itemInputs(`gtceu:double_${material}_plate`, `gtceu:${material}_frame`)
             .itemOutputs(`2x ${casing_id}:${type}_casing`)
             .duration(50)
@@ -262,7 +263,7 @@ ServerEvents.recipes(event => {
     casingDouble('noble_mixing','astrenalloy_nx','kubejs');
     casingDouble('quake_proof','thacoloy_nq_42x','kubejs');
 
-    event.recipes.gtceu.assembler('silicone_rubber_casing')
+    event.recipes.gtceu.assembler(id('silicone_rubber_casing'))
         .itemInputs('gtceu:solid_machine_casing') 
         .inputFluids('gtceu:silicone_rubber 216')
         .itemOutputs('kubejs:silicone_rubber_casing')
@@ -297,7 +298,7 @@ ServerEvents.recipes(event => {
             W: '#forge:tools/wrenches'
         });
     
-        event.recipes.gtceu.assembler(`${material}_gearbox`)
+        event.recipes.gtceu.assembler(id(`${material}_gearbox`))
             .itemInputs(`4x gtceu:${material}_plate`,`2x gtceu:${material}_gear`,`gtceu:${material}_frame`)
             .itemOutputs(`2x ${casing_id}:${type}_gearbox`)
             .duration(50)
@@ -334,7 +335,7 @@ ServerEvents.recipes(event => {
             W: '#forge:tools/wrenches'
         });
 
-        event.recipes.gtceu.assembler( `${type}_engine_intake_casing`)
+        event.recipes.gtceu.assembler(id( `${type}_engine_intake_casing`))
             .itemInputs(`2x gtceu:${material}_rotor`,`4x gtceu:${pipe}_normal_fluid_pipe`,`${used_casing}_casing`)
             .itemOutputs(`2x ${casing_id}:${type}_engine_intake_casing`)
             .duration(50)
@@ -344,7 +345,7 @@ ServerEvents.recipes(event => {
     engine_intake('enriched_naquadah','enriched_naquadah','naquadah','start_core','kubejs:enriched_naquadah_machine');
 
     ['blackstone','calcite','tuff','dripstone_block'].forEach(stone => {
-    event.recipes.gtceu.rock_breaker(`${stone}`)
+    event.recipes.gtceu.rock_breaker(id(`${stone}`))
         .notConsumable(`minecraft:${stone}`)
         .itemOutputs(`minecraft:${stone}`)
         .duration(16)
@@ -475,96 +476,96 @@ ServerEvents.recipes(event => {
     SteamBoil('steamiest',40,'steamiester',30000);
     SteamBoil('steamiester',20,'steamiestest',80000);
 
-    event.recipes.gtceu.mixer('diatron_dust')
+    event.recipes.gtceu.mixer(id('diatron_dust'))
         .itemInputs('3x gtceu:energium_dust', '2x gtceu:diamond_dust')
         .itemOutputs('5x gtceu:diatron_dust')
         .duration(200)
         .EUt(480);
 
-    event.recipes.gtceu.autoclave('diatron_water')
+    event.recipes.gtceu.autoclave(id('diatron_water'))
         .itemInputs('gtceu:diatron_dust')
         .inputFluids('minecraft:water 250')
         .chancedOutput('gtceu:diatron_gem', 7000, 1000)
         .duration(1200)
         .EUt(24);
 
-    event.recipes.gtceu.autoclave('diatron_dis_water')
+    event.recipes.gtceu.autoclave(id('diatron_dis_water'))
         .itemInputs('gtceu:diatron_dust')
         .inputFluids('gtceu:distilled_water 50')
         .itemOutputs('gtceu:diatron_gem')
         .duration(600)
         .EUt(24);
 
-    event.recipes.gtceu.mixer('birmabright')
+    event.recipes.gtceu.mixer(id('birmabright'))
         .itemInputs('7x gtceu:aluminium_dust', '2x gtceu:magnesium_dust', '1x gtceu:manganese_dust')
         .itemOutputs('10x gtceu:birmabright_dust')
         .duration(350)
         .EUt(GTValues.VHA[GTValues.HV])
         .circuit(3);
 
-    event.recipes.gtceu.mixer('duralumin')
+    event.recipes.gtceu.mixer(id('duralumin'))
         .itemInputs('4x gtceu:aluminium_dust', '3x gtceu:copper_dust', '1x gtceu:magnesium_dust', '1x gtceu:manganese_dust')
         .itemOutputs('9x gtceu:duralumin_dust')
         .duration(400)
         .EUt(GTValues.VHA[GTValues.HV])
         .circuit(2);
 
-    event.recipes.gtceu.mixer('beryllium_aluminium_alloy')
+    event.recipes.gtceu.mixer(id('beryllium_aluminium_alloy'))
         .itemInputs('7x gtceu:beryllium_dust', '1x gtceu:aluminium_dust')
         .itemOutputs('8x gtceu:beryllium_aluminium_alloy_dust')
         .duration(310)
         .EUt(GTValues.VHA[GTValues.HV])
         .circuit(1);
 
-    event.recipes.gtceu.mixer('hydronalium')
+    event.recipes.gtceu.mixer(id('hydronalium'))
         .itemInputs('6x gtceu:aluminium_dust', '3x gtceu:magnesium_dust', '1x gtceu:manganese_dust')
         .itemOutputs('10x gtceu:hydronalium_dust')
         .duration(410)
         .EUt(GTValues.VHA[GTValues.HV])
         .circuit(2);
 
-    event.recipes.gtceu.mixer('elgiloy')
+    event.recipes.gtceu.mixer(id('elgiloy'))
         .itemInputs('4x gtceu:cobalt_dust', '2x gtceu:chromium_dust', '1x gtceu:nickel_dust', '1x gtceu:steel_dust', '1x gtceu:molybdenum_dust', '1x gtceu:manganese_dust')
         .itemOutputs('10x gtceu:elgiloy_dust')
         .duration(420)
         .EUt(GTValues.VHA[GTValues.HV]);
 
-    event.recipes.gtceu.mixer('beryllium_bronze')
+    event.recipes.gtceu.mixer(id('beryllium_bronze'))
         .itemInputs('10x gtceu:copper_dust', '1x gtceu:beryllium_dust')
         .itemOutputs('11x gtceu:beryllium_bronze_dust')
         .duration(290)
         .EUt(GTValues.VHA[GTValues.HV])
         .circuit(1);
 
-    event.recipes.gtceu.mixer('silicon_bronze')
+    event.recipes.gtceu.mixer(id('silicon_bronze'))
         .itemInputs('32x gtceu:copper_dust', '2x gtceu:silicon_dust', '1x gtceu:manganese_dust')
         .itemOutputs('35x gtceu:silicon_bronze_dust')
         .duration(600)
         .EUt(GTValues.VHA[GTValues.HV])
         .circuit(1);
 
-    event.recipes.gtceu.mixer('kovar')
+    event.recipes.gtceu.mixer(id('kovar'))
         .itemInputs('18x gtceu:iron_dust', '11x gtceu:nickel_dust', '6x gtceu:cobalt_dust')
         .itemOutputs('35x gtceu:kovar_dust')
         .duration(450)
         .EUt(GTValues.VHA[GTValues.HV])
         .circuit(3);
 
-    event.recipes.gtceu.mixer('zamak')
+    event.recipes.gtceu.mixer(id('zamak'))
         .itemInputs('1x gtceu:zinc_dust', '4x gtceu:aluminium_dust', '3x gtceu:copper_dust')
         .itemOutputs('8x gtceu:zamak_dust')
         .duration(350)
         .EUt(GTValues.VHA[GTValues.HV])
         .circuit(3);
 
-    event.recipes.gtceu.mixer('tumbaga')
+    event.recipes.gtceu.mixer(id('tumbaga'))
         .itemInputs('20x gtceu:copper_dust', '6x gtceu:gold_dust', '1x gtceu:silver_dust')
         .itemOutputs('27x gtceu:tumbaga_dust')
         .duration(470)
         .EUt(GTValues.VHA[GTValues.HV])
         .circuit(4);
 
-    event.recipes.gtceu.assembler('multiblock_upgrade_kit')
+    event.recipes.gtceu.assembler(id('multiblock_upgrade_kit'))
         .itemInputs('thermal:lumium_glass', '#gtceu:circuits/ev', '2x gtceu:double_signalum_plate', '12x gtceu:cobalt_foil')
         .itemOutputs('kubejs:multiblock_upgrade_kit')
         .duration(800)
@@ -606,7 +607,7 @@ ServerEvents.recipes(event => {
         event.recipes.create.haunting(Item.of(prop.output), Item.of(prop.input));
     });
 
-    event.recipes.gtceu.circuit_assembler('data_dna_disk')
+    event.recipes.gtceu.circuit_assembler(id('data_dna_disk'))
         .itemInputs('kubejs:draconic_wetware_printed_circuit_board','2x #gtceu:circuits/uhv','24x kubejs:qram_chip', 
             '16x kubejs:3d_nor_chip','16x kubejs:3d_nand_chip','32x gtceu:fine_iron_selenide_over_strontium_titanium_oxide_wire')
         .inputFluids('gtceu:indium_tin_lead_cadmium_soldering_alloy 144')
@@ -616,7 +617,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.V[GTValues.UHV]);
 
     event.remove({id: 'gtceu:macerator/macerate_naquadah_refined_ore_to_dust'});
-    event.recipes.gtceu.macerator('macerate_refined_naquadah_ore_to_dust')
+    event.recipes.gtceu.macerator(id('macerate_refined_naquadah_ore_to_dust'))
         .itemInputs('gtceu:refined_naquadah_ore')
         .itemOutputs('gtceu:naquadah_dust')
         .chancedOutput('gtceu:enriched_naquadah_dust', 350, 125)
@@ -625,7 +626,7 @@ ServerEvents.recipes(event => {
 
     //rutile fix
     event.remove({ id: 'gtceu:electric_blast_furnace/rutile_from_ilmenite' })
-    event.recipes.gtceu.electric_blast_furnace('electric_blast_furnace/rutile_from_ilmenite')
+    event.recipes.gtceu.electric_blast_furnace(id('electric_blast_furnace/rutile_from_ilmenite'))
         .itemInputs('10x gtceu:ilmenite_dust', '2x gtceu:carbon_dust')
         .itemOutputs('2x gtceu:wrought_iron_ingot','2x gtceu:rutile_dust')
         .outputFluids('gtceu:carbon_monoxide 2000')
@@ -641,14 +642,14 @@ ServerEvents.recipes(event => {
         event.remove({id: RecipeId})
     });
 
-    event.recipes.gtceu.mixer('indium_concentrate_fix')
+    event.recipes.gtceu.mixer(id('indium_concentrate_fix'))
         .itemInputs('gtceu:purified_sphalerite_ore', 'gtceu:purified_galena_ore')
         .inputFluids('gtceu:sulfuric_acid 2000')
         .outputFluids('gtceu:indium_concentrate 1000')
         .duration(60)
         .EUt(150);
 
-    event.recipes.gtceu.chemical_reactor('indium_concentrate_separation_fix')
+    event.recipes.gtceu.chemical_reactor(id('indium_concentrate_separation_fix'))
         .itemInputs('2x gtceu:aluminium_dust')
         .inputFluids('gtceu:indium_concentrate 2000', 'gtceu:oxygen 6000')
         .itemOutputs('5x gtceu:indium_oxide_dust', '14x gtceu:aluminium_sulfite_dust')
@@ -673,12 +674,12 @@ ServerEvents.recipes(event => {
 
     //Treated Wood Fixes/Additions
     event.remove({id: 'gtceu:macerator/macerate_treated_wood_chest_boat'})
-    event.recipes.gtceu.macerator('treated_wood_chest_boat')
+    event.recipes.gtceu.macerator(id('treated_wood_chest_boat'))
         .itemInputs('gtceu:treated_wood_chest_boat')
         .itemOutputs('5x gtceu:treated_wood_dust', '8x gtceu:wood_dust')
         .duration(1274)
         .EUt(2);
-    event.recipes.gtceu.macerator('treated_wood_planks')
+    event.recipes.gtceu.macerator(id('treated_wood_planks'))
         .itemInputs('gtceu:treated_wood_planks')
         .itemOutputs('gtceu:treated_wood_dust')
         .duration(98)

--- a/kubejs/server_scripts/removals.js
+++ b/kubejs/server_scripts/removals.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
     const toRemoveOutput = ['thermal:machine_furnace', 'thermal:machine_sawmill',
         'thermal:machine_pulverizer', 'thermal:machine_insolator', 'thermal:machine_centrifuge', 'thermal:machine_crucible', 'thermal:machine_chiller', 'thermal:machine_refinery',
         'thermal:machine_pyrolyzer', 'thermal:machine_bottler', 'thermal:machine_brewer', 'thermal:machine_crystallizer', 'thermal:machine_crafter', 'thermal:machine_smelter',

--- a/kubejs/server_scripts/resource gen/abandoned/filtration.js
+++ b/kubejs/server_scripts/resource gen/abandoned/filtration.js
@@ -1,4 +1,5 @@
 /*ServerEvents.recipes(event => {
+    const id = global.id;
   
   //stone dusts
   function crush(output, input){

--- a/kubejs/server_scripts/resource gen/abandoned/filtration.js
+++ b/kubejs/server_scripts/resource gen/abandoned/filtration.js
@@ -76,21 +76,21 @@
 
   //large stone barrel
   //mixing
-  event.recipes.gtceu.large_stone_barrel('iron_mixture')
+  event.recipes.gtceu.large_stone_barrel(id('iron_mixture'))
     .inputFluids('minecraft:lava 2000')
     .itemInputs('4x gtceu:granite_dust')
     .outputFluids('gtceu:iron_mixture 3000')
     .circuit(1)
     .duration(20);
   
-  event.recipes.gtceu.large_stone_barrel('copper_mixture')
+  event.recipes.gtceu.large_stone_barrel(id('copper_mixture'))
     .inputFluids('minecraft:lava 2000')
     .itemInputs('4x gtceu:andesite_dust')
     .outputFluids('gtceu:copper_mixture 3000')
     .circuit(2)
     .duration(20);
 
-  event.recipes.gtceu.large_stone_barrel('quartz_mixture')
+  event.recipes.gtceu.large_stone_barrel(id('quartz_mixture'))
     .inputFluids('minecraft:lava 2000')
     .itemInputs('4x gtceu:diorite_dust')
     .outputFluids('gtceu:quartz_mixture 3000')
@@ -98,28 +98,28 @@
     .duration(20);
 
   //drying
-  event.recipes.gtceu.large_stone_barrel('coagulated_iron_mixture')
+  event.recipes.gtceu.large_stone_barrel(id('coagulated_iron_mixture'))
     .inputFluids('gtceu:iron_mixture 1000')
     .itemInputs('minecraft:sand')
     .itemOutputs('kubejs:coagulated_iron_mixture')
     .circuit(1)
     .duration(20);
   
-  event.recipes.gtceu.large_stone_barrel('coagulated_copper_mixture')
+  event.recipes.gtceu.large_stone_barrel(id('coagulated_copper_mixture'))
     .inputFluids('gtceu:copper_mixture 1000')
     .itemInputs('minecraft:sand')
     .itemOutputs('kubejs:coagulated_copper_mixture')
     .circuit(2)
     .duration(20);
 
-  event.recipes.gtceu.large_stone_barrel('coagulated_quartz_mixture')
+  event.recipes.gtceu.large_stone_barrel(id('coagulated_quartz_mixture'))
     .inputFluids('gtceu:quartz_mixture 1000')
     .itemInputs('minecraft:sand')
     .itemOutputs('kubejs:coagulated_quartz_mixture')
     .circuit(3)
     .duration(20);
 
-  event.recipes.gtceu.large_stone_barrel('coagulated_lava')
+  event.recipes.gtceu.large_stone_barrel(id('coagulated_lava'))
     .inputFluids('minecraft:lava 1000')
     .itemInputs('minecraft:sand')
     .itemOutputs('kubejs:coagulated_lava')

--- a/kubejs/server_scripts/resource gen/abandoned/large_filtration.js
+++ b/kubejs/server_scripts/resource gen/abandoned/large_filtration.js
@@ -1,4 +1,5 @@
 // ServerEvents.recipes(event => {
+//     const id = global.id;
 
 //    /*
 //     //kinetic filtrator

--- a/kubejs/server_scripts/resource gen/abandoned/large_filtration.js
+++ b/kubejs/server_scripts/resource gen/abandoned/large_filtration.js
@@ -15,28 +15,28 @@
 //           E: 'gtceu:bronze_rotor'
 //     });      
 
-//     event.recipes.gtceu.kinetic_filtrator('iron_mixture_filtration_kinetic')
+//     event.recipes.gtceu.kinetic_filtrator(id('iron_mixture_filtration_kinetic'))
 //         .inputFluids('gtceu:iron_mixture 1000')
 //         .itemOutputs(['2x gtceu:crushed_iron_ore', 'gtceu:crushed_tin_ore', 'gtceu:crushed_magnetite_ore'])
 //         .duration(320)
 //         //.inputStress(128)
 //         //.rpm(128);
     
-//     event.recipes.gtceu.kinetic_filtrator('copper_mixture_filtration_kinetic')
+//     event.recipes.gtceu.kinetic_filtrator(id('copper_mixture_filtration_kinetic'))
 //         .inputFluids('gtceu:copper_mixture 1000')
 //         .itemOutputs(['2x gtceu:crushed_copper_ore', 'minecraft:glowstone_dust', 'minecraft:redstone'])
 //         .duration(320)
 //         //.inputStress(128)
 //         //.rpm(128);
     
-//     event.recipes.gtceu.kinetic_filtrator('quartz_mixture_filtration_kinetic')
+//     event.recipes.gtceu.kinetic_filtrator(id('quartz_mixture_filtration_kinetic'))
 //         .inputFluids('gtceu:quartz_mixture 1000')
 //         .itemOutputs(['2x minecraft:quartz', 'minecraft:diamond'])
 //         .duration(320)
 //         //.inputStress(128)
 //         //.rpm(128);
 
-//     event.recipes.gtceu.kinetic_filtrator('lava_filtration_kinetic')
+//     event.recipes.gtceu.kinetic_filtrator(id('lava_filtration_kinetic'))
 //         .inputFluids('minecraft:lava 1000')
 //         .itemOutputs(['2x gtceu:sulfur_dust', 'gtceu:crushed_sphalerite_ore', 'gtceu:crushed_galena_ore'])
 //         .duration(320)
@@ -58,7 +58,7 @@
 //             F: 'gtceu:steel_rotor'
 //     });
     
-//     event.recipes.gtceu.electro_kinetic_filtrator('iron_mixture_filtration_e_kinetic')
+//     event.recipes.gtceu.electro_kinetic_filtrator(id('iron_mixture_filtration_e_kinetic'))
 //         .inputFluids('gtceu:iron_mixture 1000')
 //         .itemOutputs(['2x gtceu:crushed_iron_ore', 'gtceu:crushed_tin_ore', 'gtceu:crushed_magnetite_ore'])
 //         .duration(320)
@@ -66,7 +66,7 @@
 //         //.rpm(128)
 //         .EUt(28);
         
-//     event.recipes.gtceu.electro_kinetic_filtrator('copper_mixture_filtration_e_kinetic')
+//     event.recipes.gtceu.electro_kinetic_filtrator(id('copper_mixture_filtration_e_kinetic'))
 //         .inputFluids('gtceu:copper_mixture 1000')
 //         .itemOutputs(['2x gtceu:crushed_copper_ore', 'minecraft:glowstone_dust', 'minecraft:redstone'])
 //         .duration(320)
@@ -74,7 +74,7 @@
 //         //.rpm(128)
 //         .EUt(28);
         
-//     event.recipes.gtceu.electro_kinetic_filtrator('quartz_mixture_filtration_e_kinetic')
+//     event.recipes.gtceu.electro_kinetic_filtrator(id('quartz_mixture_filtration_e_kinetic'))
 //         .inputFluids('gtceu:quartz_mixture 1000')
 //         .itemOutputs(['2x minecraft:quartz', 'minecraft:diamond'])
 //         .duration(320)
@@ -82,7 +82,7 @@
 //         //.rpm(128)
 //         .EUt(28);
     
-//     event.recipes.gtceu.electro_kinetic_filtrator('lava_filtration_e_kinetic')
+//     event.recipes.gtceu.electro_kinetic_filtrator(id('lava_filtration_e_kinetic'))
 //         .inputFluids('minecraft:lava 1000')
 //         .itemOutputs(['2x gtceu:sulfur_dust', 'gtceu:crushed_sphalerite_ore', 'gtceu:crushed_galena_ore'])
 //         .duration(320)

--- a/kubejs/server_scripts/resource gen/abandoned/meteorites.js
+++ b/kubejs/server_scripts/resource gen/abandoned/meteorites.js
@@ -1,20 +1,20 @@
 // ServerEvents.recipes(event => {
 
 //     /*/reflective metal //hardmode :)
-//     event.recipes.gtceu.mixer('reflective_metal_dust')
+//     event.recipes.gtceu.mixer(id('reflective_metal_dust'))
 //         .itemInputs('5x gtceu:aluminium_dust', '3x gtceu:steel_dust', '2x minecraft:glowstone')
 //         .itemOutputs('10x gtceu:reflective_metal_dust')
 //         .duration(240)
 //         .EUt(60);
 
-//     event.recipes.gtceu.chemical_bath('reflective_metal_cool_down_water')
+//     event.recipes.gtceu.chemical_bath(id('reflective_metal_cool_down_water'))
 //         .itemInputs('gtceu:hot_reflective_metal_ingot')
 //         .inputFluids('minecraft:water 100')
 //         .itemOutputs('gtceu:reflective_metal_ingot')
 //         .duration(400)
 //         .EUt(60);
 
-//     event.recipes.gtceu.chemical_bath('reflective_metal_cool_down_distilled_water')
+//     event.recipes.gtceu.chemical_bath(id('reflective_metal_cool_down_distilled_water'))
 //         .itemInputs('gtceu:hot_reflective_metal_ingot')
 //         .inputFluids('gtceu:distilled_water 100')
 //         .itemOutputs('gtceu:reflective_metal_ingot')
@@ -44,7 +44,7 @@
 //     });
 
 //     //scan files
-//     event.recipes.gtceu.assembler('undetermined_scan_file')
+//     event.recipes.gtceu.assembler(id('undetermined_scan_file'))
 //         .itemInputs('gtceu:phenolic_printed_circuit_board', 'gtceu:data_stick', '#forge:dyes/blue')
 //         .inputFluids('gtceu:soldering_alloy 288')
 //         .itemOutputs('kubejs:undetermined_scan_file')
@@ -66,7 +66,7 @@
 //     scan('lepidolite', 'gtceu:lithium_dust', 'helium', 6000, 512);
 //     scan('bastnasite', 'gtceu:cerium_dust', 'helium', 6000, 512);
 
-//     event.recipes.gtceu.assembler('cargo_drone')
+//     event.recipes.gtceu.assembler(id('cargo_drone'))
 //         .itemInputs('gtceu:power_thruster', '2x #gtceu:circuits/mv', 'gtceu:plastic_printed_circuit_board', '5x gtceu:double_stainless_steel_plate')
 //         .inputFluids('gtceu:soldering_alloy 288')
 //         .itemOutputs('kubejs:cargo_drone')
@@ -113,7 +113,7 @@
 //     event.remove({ id: 'ae2:inscriber/sky_stone_dust'});
 //     event.remove({ id: 'create:milling/compat/ae2/sky_stone_block'});
 
-//     event.recipes.gtceu.macerator('sky_stone_block')
+//     event.recipes.gtceu.macerator(id('sky_stone_block'))
 //         .itemInputs('ae2:sky_dust')
 //         .itemOutputs('ae2:sky_stone_block')
 //         .duration(1200)

--- a/kubejs/server_scripts/resource gen/abandoned/meteorites.js
+++ b/kubejs/server_scripts/resource gen/abandoned/meteorites.js
@@ -1,4 +1,5 @@
 // ServerEvents.recipes(event => {
+//     const id = global.id;
 
 //     /*/reflective metal //hardmode :)
 //     event.recipes.gtceu.mixer(id('reflective_metal_dust'))

--- a/kubejs/server_scripts/resource gen/abandoned/produce.js
+++ b/kubejs/server_scripts/resource gen/abandoned/produce.js
@@ -8,6 +8,7 @@
 // });
 
 // ServerEvents.recipes(event => {
+//     const id = global.id;
 
 //     //Multi for greens
 //     event.recipes.gtceu.large_greens_extractor(id('harvesting'))

--- a/kubejs/server_scripts/resource gen/abandoned/produce.js
+++ b/kubejs/server_scripts/resource gen/abandoned/produce.js
@@ -10,7 +10,7 @@
 // ServerEvents.recipes(event => {
 
 //     //Multi for greens
-//     event.recipes.gtceu.large_greens_extractor('harvesting')
+//     event.recipes.gtceu.large_greens_extractor(id('harvesting'))
 //         .notConsumable('minecraft:stone_hoe')
 //         .chancedInput('4x gtceu:fertilizer', 2500, 0)
 //         .inputFluids('minecraft:water 1000')
@@ -28,7 +28,7 @@
 //         "result": 'kubejs:ball_compost'
 //     });
 
-//     event.recipes.gtceu.large_barrel('ball_compost')
+//     event.recipes.gtceu.large_barrel(id('ball_compost'))
 //         .itemInputs('#kubejs:ball_of_greens')
 //         .inputFluids('exnihilosequentia:sea_water 1000')
 //         .itemOutputs('kubejs:ball_compost')
@@ -40,7 +40,7 @@
 //     switcher('farmersdelight:tomato_seeds', 'thermal:tomato_seeds');
 
 //     //Automating grinding
-//     event.recipes.gtceu.centrifuge('ball_plants')
+//     event.recipes.gtceu.centrifuge(id('ball_plants'))
 //         .itemInputs('kubejs:ball_plants')
 //         .chancedOutput('minecraft:bamboo', 7000, 1000)
 //         .chancedOutput('minecraft:cactus', 7000, 1000)
@@ -52,7 +52,7 @@
 //         .duration(240)
 //         .EUt(32);
 
-//     event.recipes.gtceu.centrifuge('ball_seeds')
+//     event.recipes.gtceu.centrifuge(id('ball_seeds'))
 //         .itemInputs('kubejs:ball_seeds')
 //         .chancedOutput('minecraft:wheat_seeds', 500, 1000)
 //         .chancedOutput('minecraft:pumpkin_seeds', 1000, 1000)
@@ -64,7 +64,7 @@
 //         .duration(240)
 //         .EUt(32);
 
-//     event.recipes.gtceu.centrifuge('ball_roots')
+//     event.recipes.gtceu.centrifuge(id('ball_roots'))
 //         .itemInputs('kubejs:ball_roots')
 //         .chancedOutput('minecraft:carrot', 1000, 1000)
 //         .chancedOutput('minecraft:potato', 1000, 1000)
@@ -72,7 +72,7 @@
 //         .duration(240)
 //         .EUt(32);
 
-//     event.recipes.gtceu.centrifuge('ball_compost')
+//     event.recipes.gtceu.centrifuge(id('ball_compost'))
 //         .itemInputs('kubejs:ball_compost')
 //         .chancedOutput('exnihilosequentia:mycelium_spores', 3000, 1000)
 //         .chancedOutput('thermal:slime_mushroom_spores', 5000, 1000)

--- a/kubejs/server_scripts/resource gen/dimensional_destabilising.js
+++ b/kubejs/server_scripts/resource gen/dimensional_destabilising.js
@@ -1,12 +1,13 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.vacuum_freezer('pcb_cooling')
+    event.recipes.gtceu.vacuum_freezer(id('pcb_cooling'))
         .inputFluids('gtceu:hot_pcb_coolant 1200')
         .outputFluids('gtceu:pcb_coolant 1000')
         .duration(140)
         .EUt(512);
 
-    event.recipes.gtceu.dimensional_destabiliser('naquadah_mining')
+    event.recipes.gtceu.dimensional_destabiliser(id('naquadah_mining'))
         .itemInputs('mysticalagradditions:nether_star_shard')
         .inputFluids('gtceu:pcb_coolant 8000')
         .itemOutputs('64x gtceu:raw_naquadah', 'gtceu:tiny_nether_star_dust')
@@ -14,7 +15,7 @@ ServerEvents.recipes(event => {
         .duration(1500)
         .EUt(4096);
 
-    event.recipes.gtceu.assembler('dimensional_destabiliser')
+    event.recipes.gtceu.assembler(id('dimensional_destabiliser'))
         .itemInputs('gtceu:luv_machine_hull', '2x #gtceu:circuits/luv', '4x gtceu:double_pure_netherite_plate', '2x gtceu:ruridit_gear')
         .itemOutputs('gtceu:dimensional_destabiliser')
         .duration(1800)

--- a/kubejs/server_scripts/resource gen/geodes.js
+++ b/kubejs/server_scripts/resource gen/geodes.js
@@ -1,5 +1,5 @@
 ServerEvents.recipes(event => {
-  const id = global.id;
+    const id = global.id;
     
   //sifting
   event.shaped('gtceu:rock_filtrator',[
@@ -10,7 +10,7 @@ ServerEvents.recipes(event => {
       A: '#gtceu:circuits/lv',
       B: 'gtceu:lv_electric_motor',
       C: 'gtceu:steel_machine_casing'
-  });
+  }).id('start:shaped/rock_filtrator');
 
   event.shaped('gtceu:rock_sifter',[
       'ABA',
@@ -20,7 +20,7 @@ ServerEvents.recipes(event => {
       A: '#gtceu:circuits/luv',
       B: 'gtceu:luv_electric_motor',
       C: 'gtceu:watertight_casing'
-  });
+  }).id('start:shaped/rock_sifter');
   
   //Generalist Recipes
   event.recipes.gtceu.rock_filtrator(id('lv_geodes'))
@@ -163,7 +163,7 @@ ServerEvents.recipes(event => {
 //       D: 'gtceu:cupronickel_coil_block',
 //       E: 'gtceu:solid_machine_casing',
 //       F: 'gtceu:lv_conveyor_module'
-//     });
+//     }).id('start:shaped/heated_cracking_unit');
 
 //   event.shaped('gtceu:pressure_cracker',[
 //       'ABC',
@@ -176,7 +176,7 @@ ServerEvents.recipes(event => {
 //       D: 'gtceu:hssg_coil_block',
 //       E: 'gtceu:heatproof_machine_casing',
 //       F: 'gtceu:luv_conveyor_module'
-//   });
+//   }).id('start:shaped/pressure_cracker');
 
 //   ['diamond', 'emerald', 'ruby', 'green_sapphire', 'sapphire', 'quartzite', 'certus_quartz', 'blue_topaz', 'topaz', 'amethyst'].forEach(type => {
 //     event.recipes.gtceu.heated_cracking_unit(`${type}_cracking`)

--- a/kubejs/server_scripts/resource gen/geodes.js
+++ b/kubejs/server_scripts/resource gen/geodes.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+  const id = global.id;
     
   //sifting
   event.shaped('gtceu:rock_filtrator',[
@@ -22,7 +23,7 @@ ServerEvents.recipes(event => {
   });
   
   //Generalist Recipes
-  event.recipes.gtceu.rock_filtrator('lv_geodes')
+  event.recipes.gtceu.rock_filtrator(id('lv_geodes'))
     .itemInputs('32x minecraft:gravel')
     .inputFluids('gtceu:distilled_water 1000')
     .chancedOutput('kubejs:diamond_geode', 3500, 750)
@@ -35,7 +36,7 @@ ServerEvents.recipes(event => {
     .duration(1200)
     .EUt(GTValues.VHA[GTValues.LV]);
 
-  event.recipes.gtceu.rock_filtrator('mv_geodes')
+  event.recipes.gtceu.rock_filtrator(id('mv_geodes'))
     .itemInputs('32x minecraft:sand')
     .inputFluids('gtceu:distilled_water 1000')
     .chancedOutput('kubejs:blue_topaz_geode', 3500, 750)
@@ -47,7 +48,7 @@ ServerEvents.recipes(event => {
     .EUt(GTValues.VHA[GTValues.MV]);
 
   //Specialist Recipes LV
-  event.recipes.gtceu.rock_filtrator('lv_geodes_gem')
+  event.recipes.gtceu.rock_filtrator(id('lv_geodes_gem'))
     .itemInputs('32x minecraft:gravel')
     .inputFluids('gtceu:distilled_water 1000')
     .chancedOutput('kubejs:diamond_geode', 3500, 750)
@@ -57,7 +58,7 @@ ServerEvents.recipes(event => {
     .circuit(1)
     .EUt(GTValues.VHA[GTValues.LV]);
 
-  event.recipes.gtceu.rock_filtrator('lv_geodes_sapphire')
+  event.recipes.gtceu.rock_filtrator(id('lv_geodes_sapphire'))
     .itemInputs('32x minecraft:gravel')
     .inputFluids('gtceu:distilled_water 1000')
     .chancedOutput('kubejs:green_sapphire_geode', 5000, 500)
@@ -66,7 +67,7 @@ ServerEvents.recipes(event => {
     .circuit(2)
     .EUt(GTValues.VHA[GTValues.LV]);
 
-  event.recipes.gtceu.rock_filtrator('lv_geodes_quartz')
+  event.recipes.gtceu.rock_filtrator(id('lv_geodes_quartz'))
     .itemInputs('32x minecraft:gravel')
     .inputFluids('gtceu:distilled_water 1000')
     .chancedOutput('kubejs:quartzite_geode', 3500, 500)
@@ -76,7 +77,7 @@ ServerEvents.recipes(event => {
     .EUt(GTValues.VHA[GTValues.LV]);
 
   //Specialist Recipes MV
-  event.recipes.gtceu.rock_filtrator('mv_geodes_gem')
+  event.recipes.gtceu.rock_filtrator(id('mv_geodes_gem'))
     .itemInputs('32x minecraft:sand')
     .inputFluids('gtceu:distilled_water 1000')
     .chancedOutput('kubejs:apatite_geode', 4500, 1000)
@@ -86,7 +87,7 @@ ServerEvents.recipes(event => {
     .circuit(1)
     .EUt(GTValues.VHA[GTValues.MV]);
 
-  event.recipes.gtceu.rock_filtrator('mv_geodes_topaz')
+  event.recipes.gtceu.rock_filtrator(id('mv_geodes_topaz'))
     .itemInputs('32x minecraft:sand')
     .inputFluids('gtceu:distilled_water 1000')
     .chancedOutput('kubejs:blue_topaz_geode', 3500, 750)
@@ -101,13 +102,13 @@ ServerEvents.recipes(event => {
   const geodeMV = ['apatite', 'topaz', 'blue_topaz', 'spessartine', 'monazite'];
   
   geodeLV.forEach(type => {
-    event.recipes.gtceu.cutter(`${type}_geode`)
+    event.recipes.gtceu.cutter(id(`${type}_geode`))
       .itemInputs(`kubejs:${type}_geode`)
       .itemOutputs(`gtceu:raw_${type}`, 'gtceu:stone_dust')
       .duration(200)
       .EUt(GTValues.VA[GTValues.LV]);
 
-    event.recipes.gtceu.macerator(`${type}_geode`)
+    event.recipes.gtceu.macerator(id(`${type}_geode`))
       .itemInputs(`kubejs:${type}_geode`)
       .itemOutputs(`gtceu:crushed_${type}_ore`)
       .chancedOutput(`gtceu:crushed_${type}_ore`, 5000, 250)
@@ -118,13 +119,13 @@ ServerEvents.recipes(event => {
   });
 
   geodeMV.forEach(type => {
-    event.recipes.gtceu.cutter(`${type}_geode`)
+    event.recipes.gtceu.cutter(id(`${type}_geode`))
       .itemInputs(`kubejs:${type}_geode`)
       .itemOutputs(`gtceu:raw_${type}`, 'gtceu:stone_dust')
       .duration(200)
       .EUt(GTValues.VA[GTValues.MV]);
 
-    event.recipes.gtceu.macerator(`${type}_geode`)
+    event.recipes.gtceu.macerator(id(`${type}_geode`))
       .itemInputs(`kubejs:${type}_geode`)
       .itemOutputs(`gtceu:crushed_${type}_ore`)
       .chancedOutput(`gtceu:crushed_${type}_ore`, 5000, 250)
@@ -135,7 +136,7 @@ ServerEvents.recipes(event => {
   });
   
 
-  // event.recipes.gtceu.rock_sifter('geode_harvesting')
+  // event.recipes.gtceu.rock_sifter(id('geode_harvesting'))
   //   .itemInputs('64x minecraft:gravel')
   //   .chancedOutput('kubejs:diamond_geode', 3500, 500)
   //   .chancedOutput('kubejs:emerald_geode', 3500, 500)

--- a/kubejs/server_scripts/resource gen/latex.js
+++ b/kubejs/server_scripts/resource gen/latex.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+  const id = global.id;
 
     //Early Rubbers
     event.custom({
@@ -21,7 +22,7 @@ ServerEvents.recipes(event => {
 
     event.recipes.create.mixing('3x thermal:cured_rubber', ['3x thermal:rubber', '#forge:dusts/sulfur']).heatRequirement('lowheated');
 
-    event.recipes.gtceu.alloy_smelter('latex_rubber')
+    event.recipes.gtceu.alloy_smelter(id('latex_rubber'))
         .itemInputs('3x thermal:rubber', 'gtceu:sulfur_dust')
         .itemOutputs('3x thermal:cured_rubber')
         .duration(240)
@@ -48,7 +49,7 @@ ServerEvents.recipes(event => {
 		.duration(160);
     const latexType = [{ fuel: 'minecraft:bone_meal', circ: '1' }, { fuel: 'thermal:compost', circ: '2' }, { fuel: 'gtceu:fertilizer', circ: '3' }]
 	latexType.forEach(latex => {
-		event.recipes.gtceu.latex_plantation(`latex_${latex.circ}`)
+		event.recipes.gtceu.latex_plantation(id(`latex_${latex.circ}`))
 			.chancedInput(`${latex.fuel}`, 2500, 0)
 			.notConsumable('gtceu:iron_screw')
 			.circuit(latex.circ)

--- a/kubejs/server_scripts/resource gen/latex.js
+++ b/kubejs/server_scripts/resource gen/latex.js
@@ -1,5 +1,5 @@
 ServerEvents.recipes(event => {
-  const id = global.id;
+    const id = global.id;
 
     //Early Rubbers
     event.custom({
@@ -20,7 +20,7 @@ ServerEvents.recipes(event => {
         'cookingtime': 200
       });
 
-    event.recipes.create.mixing('3x thermal:cured_rubber', ['3x thermal:rubber', '#forge:dusts/sulfur']).heatRequirement('lowheated');
+    event.recipes.create.mixing('3x thermal:cured_rubber', ['3x thermal:rubber', '#forge:dusts/sulfur']).heatRequirement('lowheated').id('start:create_mixing/cured_rubber');
 
     event.recipes.gtceu.alloy_smelter(id('latex_rubber'))
         .itemInputs('3x thermal:rubber', 'gtceu:sulfur_dust')
@@ -40,7 +40,7 @@ ServerEvents.recipes(event => {
 		G: '#forge:glass',
 		B: 'minecraft:bricks',
 		T: 'thermal:redstone_servo'
-	});
+	}).id('start:shaped/latex_plantation');
 
     //Usage
     event.recipes.gtceu.latex_plantation(`latex`)

--- a/kubejs/server_scripts/resource gen/mechanical_sieve.js
+++ b/kubejs/server_scripts/resource gen/mechanical_sieve.js
@@ -13,7 +13,7 @@ ServerEvents.recipes(event => {
         P: 'gtceu:brass_plate',
         B: 'gtceu:lv_electric_motor',
         M: 'gtceu:lv_machine_hull'
-    });
+    }).id('start:shaped/mechanical_sieve');
 
     event.recipes.gtceu.assembler(id('large_sieve'))
         .itemInputs('gtceu:iv_machine_hull', '2x #gtceu:circuits/iv', '2x gtceu:double_tungsten_steel_plate' ,'4x gtceu:pure_netherite_gear')
@@ -34,9 +34,9 @@ ServerEvents.recipes(event => {
         W: 'gtceu:treated_wood_plate',
         F: 'gtceu:treated_wood_frame',
         H: '#forge:tools/hammers'
-    });
+    }).id('start:shaped/wood_casing');
 
-    event.recipes.gtceu.assembler(id('start:assembler_wood_casing'))
+    event.recipes.gtceu.assembler(id('wood_casing'))
         .itemInputs('4x gtceu:brass_screw', '2x gtceu:treated_wood_plate', 'gtceu:treated_wood_frame')
         .itemOutputs('2x kubejs:wood_casing')
         .circuit(6)
@@ -51,9 +51,9 @@ ServerEvents.recipes(event => {
     ], {
         M: 'exnihilosequentia:string_mesh',
         S: 'gtceu:treated_wood_rod'
-    });
+    }).id('start:shaped/mesh_block');
 
-    event.recipes.gtceu.assembler(id('start:assembler_meshblock'))
+    event.recipes.gtceu.assembler(id('meshblock'))
         .itemInputs('5x exnihilosequentia:string_mesh', '4x gtceu:treated_wood_rod')
         .itemOutputs('kubejs:meshblock')
         .circuit(6)

--- a/kubejs/server_scripts/resource gen/mechanical_sieve.js
+++ b/kubejs/server_scripts/resource gen/mechanical_sieve.js
@@ -1,7 +1,7 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     //Controllers
-
     event.shaped(Item.of('gtceu:mechanical_sieve'), [
         'ESE',
         'PDP',
@@ -15,7 +15,7 @@ ServerEvents.recipes(event => {
         M: 'gtceu:lv_machine_hull'
     });
 
-    event.recipes.gtceu.assembler('large_sieve')
+    event.recipes.gtceu.assembler(id('large_sieve'))
         .itemInputs('gtceu:iv_machine_hull', '2x #gtceu:circuits/iv', '2x gtceu:double_tungsten_steel_plate' ,'4x gtceu:pure_netherite_gear')
         .itemOutputs('gtceu:large_sieve')
         .duration(1200)
@@ -36,7 +36,7 @@ ServerEvents.recipes(event => {
         H: '#forge:tools/hammers'
     });
 
-    event.recipes.gtceu.assembler('start:assembler_wood_casing')
+    event.recipes.gtceu.assembler(id('start:assembler_wood_casing'))
         .itemInputs('4x gtceu:brass_screw', '2x gtceu:treated_wood_plate', 'gtceu:treated_wood_frame')
         .itemOutputs('2x kubejs:wood_casing')
         .circuit(6)
@@ -53,23 +53,23 @@ ServerEvents.recipes(event => {
         S: 'gtceu:treated_wood_rod'
     });
 
-    event.recipes.gtceu.assembler('start:assembler_meshblock')
+    event.recipes.gtceu.assembler(id('start:assembler_meshblock'))
         .itemInputs('5x exnihilosequentia:string_mesh', '4x gtceu:treated_wood_rod')
         .itemOutputs('kubejs:meshblock')
         .circuit(6)
         .duration(50)
         .EUt(16)
 
-    function MechanicalSieving(input, outputs) {
+    const MechanicalSieving = (input, outputs) => {
 
-        event.recipes.gtceu.mechanical_sieve(`${input.path}_mechanical_sieve`)
+        event.recipes.gtceu.mechanical_sieve(id(`${input.path}_mechanical_sieve`))
             .itemInputs(`64x ${input}`)
             .notConsumable(`exnihilosequentia:string_mesh`)
             .itemOutputs(outputs)
             .duration(1200)
             .EUt(GTValues.VA[GTValues.LV])
             
-        event.recipes.gtceu.large_sieve(`${input.path}_mechanical_sieve`)
+        event.recipes.gtceu.large_sieve(id(`${input.path}_mechanical_sieve`))
             .itemInputs(`48x ${input}`)
             .itemOutputs(outputs)
             .duration(1200)

--- a/kubejs/server_scripts/resource gen/seawater.js
+++ b/kubejs/server_scripts/resource gen/seawater.js
@@ -1,6 +1,7 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.centrifuge('sea_water')
+    event.recipes.gtceu.centrifuge(id('sea_water'))
         .inputFluids('exnihilosequentia:sea_water 1250')
         .outputFluids('gtceu:salt_water 1000')
         .itemOutputs('gtceu:crushed_saltpeter_ore', 'gtceu:crushed_rock_salt_ore')
@@ -8,13 +9,13 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VHA[GTValues.LV]);
 
     //large barrel
-    event.recipes.gtceu.large_barrel('sea_water')
+    event.recipes.gtceu.large_barrel(id('sea_water'))
         .notConsumable('minecraft:sand')
         .inputFluids('minecraft:water 1000')
         .outputFluids('exnihilosequentia:sea_water 1000')
         .duration(80);
 
-    event.recipes.gtceu.centrifuge('brackish_water')
+    event.recipes.gtceu.centrifuge(id('brackish_water'))
         .inputFluids('gtceu:brackish_water 4000')
         .outputFluids('exnihilosequentia:sea_water 2500')
         .outputFluids('minecraft:water 1500')

--- a/kubejs/server_scripts/resource gen/vibration_laser_engraving.js
+++ b/kubejs/server_scripts/resource gen/vibration_laser_engraving.js
@@ -1,6 +1,7 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.heat_chamber('tiny_purified_naquadah')
+    event.recipes.gtceu.heat_chamber(id('tiny_purified_naquadah'))
         .itemInputs('gtceu:tiny_naquadah_dust')
         .inputFluids('gtceu:neon 120')
         .itemOutputs('gtceu:tiny_purified_naquadah_dust')
@@ -8,7 +9,7 @@ ServerEvents.recipes(event => {
         .duration(640)
         .EUt(16384);
 
-    event.recipes.gtceu.vibration_laser_engraver('echo_shard')
+    event.recipes.gtceu.vibration_laser_engraver(id('echo_shard'))
         .itemInputs('gtceu:exquisite_purified_naquadah_gem')
         .notConsumable('gtceu:nether_star_lens')
         .inputFluids('gtceu:lubricant 1000', 'gtceu:pcb_coolant 16000')
@@ -17,7 +18,7 @@ ServerEvents.recipes(event => {
         .duration(8000)
         .EUt(65536);
 
-    event.recipes.gtceu.assembly_line('vibration_laser_engraver')
+    event.recipes.gtceu.assembly_line(id('vibration_laser_engraver'))
         .itemInputs('gtceu:uv_laser_engraver','6x gtceu:uv_electric_piston','4x gtceu:uv_emitter','4x gtceu:uv_emitter','4x gtceu:uv_field_generator', '64x gtceu:fine_trinaquadalloy_wire','64x gtceu:fine_trinaquadalloy_wire', '6x #gtceu:circuits/uv')
         .inputFluids('gtceu:naquadria 13248', 'gtceu:trinaquadalloy 9936'   )
         .itemOutputs('gtceu:vibration_laser_engraver')

--- a/kubejs/server_scripts/resource gen/vibration_laser_engraving.js
+++ b/kubejs/server_scripts/resource gen/vibration_laser_engraving.js
@@ -1,5 +1,5 @@
 ServerEvents.recipes(event => {
-    const id = global.id;
+    const id = global.id;    
 
     event.recipes.gtceu.heat_chamber(id('tiny_purified_naquadah'))
         .itemInputs('gtceu:tiny_naquadah_dust')

--- a/kubejs/server_scripts/resource gen/void_drill_line/clusters.js
+++ b/kubejs/server_scripts/resource gen/void_drill_line/clusters.js
@@ -12,7 +12,7 @@ ServerEvents.recipes(event => {
         E: '#gtceu:circuits/lv',
         F: 'gtceu:lv_robot_arm',
         G: 'gtceu:lv_conveyor_module'
-    });
+    }).id('start:shaped/void_extractor');
 
     event.shaped('gtceu:void_excavator',[
         'ABC',
@@ -25,7 +25,7 @@ ServerEvents.recipes(event => {
         E: '#gtceu:circuits/luv',
         F: 'gtceu:luv_robot_arm',
         G: 'gtceu:luv_conveyor_module'
-    });
+    }).id('start:shaped/void_excavator');
 
     event.recipes.gtceu.void_excavation(id('mining'))
         .inputFluids('gtceu:drilling_fluid 5000')

--- a/kubejs/server_scripts/resource gen/void_drill_line/clusters.js
+++ b/kubejs/server_scripts/resource gen/void_drill_line/clusters.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     event.shaped('gtceu:void_extractor',[
         'ABC',
@@ -26,7 +27,7 @@ ServerEvents.recipes(event => {
         G: 'gtceu:luv_conveyor_module'
     });
 
-    event.recipes.gtceu.void_excavation('mining')
+    event.recipes.gtceu.void_excavation(id('mining'))
         .inputFluids('gtceu:drilling_fluid 5000')
         .chancedOutput('5x gtceu:raw_coal', 5000, 1000)
         .chancedOutput('2x minecraft:raw_gold', 4000, 750)

--- a/kubejs/server_scripts/resource gen/void_drill_line/crystallisation.js
+++ b/kubejs/server_scripts/resource gen/void_drill_line/crystallisation.js
@@ -1,14 +1,15 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     //alternate production
-    event.recipes.gtceu.mixer('molten_ore_mixture_recycling')
+    event.recipes.gtceu.mixer(id('molten_ore_mixture_recycling'))
         .inputFluids(`minecraft:lava 32000`)
         .itemInputs(`32x gtceu:stone_dust`, `16x #forge:crushed_ores`)
         .outputFluids('gtceu:molten_ore_mixture 6000')
         .duration(800)
         .EUt(GTValues.VA[GTValues.EV]);
 
-    event.recipes.gtceu.mixer('molten_ore_mixture_looping')
+    event.recipes.gtceu.mixer(id('molten_ore_mixture_looping'))
         .inputFluids(`minecraft:lava 48000`)
         .itemInputs(`48x gtceu:stone_dust`, `2x gtceu:metal_mixture_dust`)
         .outputFluids('gtceu:molten_ore_mixture 20000')
@@ -16,7 +17,7 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.IV]);
     
     //distilling
-    event.recipes.gtceu.distillation_tower('molten_ore_mixture')
+    event.recipes.gtceu.distillation_tower(id('molten_ore_mixture'))
         .inputFluids('gtceu:molten_ore_mixture 10000')
         .itemOutputs('gtceu:metal_mixture_dust')
         .outputFluids('gtceu:molten_bauxite_ore 1500', 'gtceu:molten_pitchblende_ore 1250', 'gtceu:molten_molybdenite_ore 1000', 'gtceu:molten_ilmenite_ore 1000', 'gtceu:molten_bastnasite_ore 1000' ,'gtceu:molten_tungstate_ore 2000', 'gtceu:molten_cooperite_ore 2250')
@@ -24,27 +25,27 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.EV]);
 
     //amethyst line
-    event.recipes.gtceu.cutter('small_amethyst_bud')
+    event.recipes.gtceu.cutter(id('small_amethyst_bud'))
         .itemInputs('minecraft:amethyst_shard')
         .itemOutputs('2x minecraft:small_amethyst_bud')
         .duration(240)
         .EUt(512);
 
-    event.recipes.gtceu.laser_engraver('medium_amethyst_bud')
+    event.recipes.gtceu.laser_engraver(id('medium_amethyst_bud'))
         .itemInputs('2x minecraft:small_amethyst_bud')
         .notConsumable('#forge:lenses/purple')
         .itemOutputs('minecraft:medium_amethyst_bud')
         .duration(240)
         .EUt(512);
 
-    event.recipes.gtceu.chemical_bath('large_amethyst_bud')
+    event.recipes.gtceu.chemical_bath(id('large_amethyst_bud'))
         .itemInputs('minecraft:medium_amethyst_bud')
         .inputFluids('minecraft:water 1000')
         .itemOutputs('minecraft:large_amethyst_bud')
         .duration(240)
         .EUt(512);
 
-    event.recipes.gtceu.autoclave('amethyst_cluster')
+    event.recipes.gtceu.autoclave(id('amethyst_cluster'))
         .itemInputs('minecraft:large_amethyst_bud', 'gtceu:calcite_dust')
         .inputFluids('gtceu:distilled_water 125')
         .itemOutputs('minecraft:amethyst_cluster')
@@ -53,7 +54,7 @@ ServerEvents.recipes(event => {
 
     //crystallising
     ['bauxite', 'pitchblende', 'molybdenite', 'ilmenite', 'tungstate', 'cooperite', 'bastnasite'].forEach(type => {
-        event.recipes.gtceu.autoclave(`raw_${type}`)
+        event.recipes.gtceu.autoclave(id(`raw_${type}`))
             .itemInputs('gtceu:stone_dust')
             .inputFluids(`gtceu:molten_${type}_ore 500`)
             .itemOutputs(`gtceu:raw_${type}`)

--- a/kubejs/server_scripts/resource gen/void_drill_line/minerals.js
+++ b/kubejs/server_scripts/resource gen/void_drill_line/minerals.js
@@ -1,7 +1,8 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     //mixture
-    event.recipes.gtceu.centrifuge('raw_ore_slurry')
+    event.recipes.gtceu.centrifuge(id('raw_ore_slurry'))
         .inputFluids('gtceu:raw_ore_slurry 1000')
         .itemOutputs('gtceu:crushed_lepidolite_ore', 'gtceu:crushed_pyrochlore_ore', 'gtceu:crushed_pyrolusite_ore')
         .outputFluids('gtceu:mixed_mineral_residue 750', 'gtceu:molten_ore_mixture 250')
@@ -9,20 +10,20 @@ ServerEvents.recipes(event => {
         .EUt(GTValues.VA[GTValues.MV]);
 
     //dissolving
-    event.recipes.gtceu.electrolyzer('mixed_mineral_residue')
+    event.recipes.gtceu.electrolyzer(id('mixed_mineral_residue'))
         .inputFluids('gtceu:mixed_mineral_residue 1000')
         .itemOutputs('gtceu:crushed_beryllium_ore')
         .outputFluids('gtceu:sulfuric_mineral_mixture 400', 'gtceu:oxygenous_mineral_mixture 600')
         .duration(240)
         .EUt(GTValues.VA[GTValues.HV]);
 
-    event.recipes.gtceu.centrifuge('sulfuric_mineral_mixture')
+    event.recipes.gtceu.centrifuge(id('sulfuric_mineral_mixture'))
         .inputFluids('gtceu:sulfuric_mineral_mixture 500')
         .itemOutputs('gtceu:crushed_barite_ore', 'gtceu:crushed_chalcopyrite_ore', 'gtceu:crushed_bornite_ore')
         .duration(230)
         .EUt(GTValues.VA[GTValues.HV]);
 
-    event.recipes.gtceu.centrifuge('oxygenous_mineral_mixture')
+    event.recipes.gtceu.centrifuge(id('oxygenous_mineral_mixture'))
         .inputFluids('gtceu:oxygenous_mineral_mixture 500')
         .itemOutputs('gtceu:crushed_tantalite_ore', 'gtceu:crushed_pollucite_ore', 'gtceu:crushed_cassiterite_ore')
         .duration(230)

--- a/kubejs/server_scripts/resource gen/void_drill_line/rare_ore_residue.js
+++ b/kubejs/server_scripts/resource gen/void_drill_line/rare_ore_residue.js
@@ -1,6 +1,7 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
-    event.recipes.gtceu.electrolyzer('rare_ore_residue')
+    event.recipes.gtceu.electrolyzer(id('rare_ore_residue'))
         .inputFluids('gtceu:rare_ore_residue 1000')
         .itemOutputs('gtceu:chromite_sludge_dust', 'gtceu:rare_sludge_dust', 'gtceu:vanadium_magnetite_sludge_dust', 'gtceu:cobaltite_sludge_dust')
         .chancedOutput('ae2:sky_dust', 3250, 750)
@@ -8,31 +9,31 @@ ServerEvents.recipes(event => {
         .duration(50)
         .EUt(GTValues.VA[GTValues.MV]);
 
-    event.recipes.gtceu.centrifuge('cobaltite_sludge')
+    event.recipes.gtceu.centrifuge(id('cobaltite_sludge'))
         .itemInputs('gtceu:cobaltite_sludge_dust')
         .itemOutputs('2x gtceu:cobaltite_dust', 'gtceu:rare_metallic_residue_dust')
         .duration(50)
         .EUt(GTValues.VHA[GTValues.MV]);
 
-    event.recipes.gtceu.centrifuge('chromite_sludge')
+    event.recipes.gtceu.centrifuge(id('chromite_sludge'))
         .itemInputs('gtceu:chromite_sludge_dust')
         .itemOutputs('2x gtceu:chromite_dust', 'gtceu:rare_metallic_residue_dust')
         .duration(50)
         .EUt(GTValues.VHA[GTValues.MV]);
 
-    event.recipes.gtceu.centrifuge('rare_sludge')
+    event.recipes.gtceu.centrifuge(id('rare_sludge'))
         .itemInputs('gtceu:rare_sludge_dust')
         .itemOutputs('2x gtceu:rare_earth_dust', 'gtceu:rare_metallic_residue_dust')
         .duration(50)
         .EUt(GTValues.VHA[GTValues.MV]);
 
-    event.recipes.gtceu.centrifuge('vanadium_magnetite_sludge')
+    event.recipes.gtceu.centrifuge(id('vanadium_magnetite_sludge'))
         .itemInputs('gtceu:vanadium_magnetite_sludge_dust')
         .itemOutputs('2x gtceu:vanadium_magnetite_dust', 'gtceu:rare_metallic_residue_dust')
         .duration(50)
         .EUt(GTValues.VHA[GTValues.MV]);
 
-    event.recipes.gtceu.electrolyzer('rare_metallic_residue')
+    event.recipes.gtceu.electrolyzer(id('rare_metallic_residue'))
         .itemInputs('gtceu:rare_metallic_residue_dust')
         .itemOutputs('2x gtceu:calcite_dust', 'gtceu:silver_dust')
         .duration(50)

--- a/kubejs/server_scripts/superconductors.js
+++ b/kubejs/server_scripts/superconductors.js
@@ -1,6 +1,6 @@
 ServerEvents.recipes(event => {
 
-    event.recipes.gtceu.macerator('soul_sand_dust')
+    event.recipes.gtceu.macerator(id('soul_sand_dust'))
         .itemInputs('minecraft:soul_sand')
         .itemOutputs('thermal_extra:soul_sand_dust')
         .duration(20)
@@ -14,76 +14,76 @@ ServerEvents.recipes(event => {
         ]
     );
 
-    event.recipes.gtceu.mixer('soul_infused_dust')
+    event.recipes.gtceu.mixer(id('soul_infused_dust'))
         .itemInputs('gtceu:invar_dust', '2x thermal_extra:soul_sand_dust')
         .itemOutputs('3x gtceu:soul_infused_dust')
         .duration(200)
         .EUt(8);
 
-    event.recipes.gtceu.alloy_smelter('soul_infused_from_dust')
+    event.recipes.gtceu.alloy_smelter(id('soul_infused_from_dust'))
         .itemInputs('gtceu:invar_dust', '2x thermal_extra:soul_sand_dust')
         .itemOutputs('3x gtceu:soul_infused_ingot')
         .duration(200)
         .EUt(8);
 
-    event.recipes.gtceu.alloy_smelter('soul_infused_from_ingot')
+    event.recipes.gtceu.alloy_smelter(id('soul_infused_from_ingot'))
         .itemInputs('gtceu:invar_ingot', '2x thermal_extra:soul_sand_dust')
         .itemOutputs('3x gtceu:soul_infused_ingot')
         .duration(200)
         .EUt(8);
 
-    event.recipes.gtceu.mixer('signalum_dust')
+    event.recipes.gtceu.mixer(id('signalum_dust'))
         .itemInputs('gtceu:silver_dust', '3x gtceu:copper_dust', '4x minecraft:redstone')
         .itemOutputs('4x gtceu:signalum_dust')
         .duration(300)
         .EUt(20)
         .circuit(3);
 
-    event.recipes.gtceu.mixer('lumium_dust')
+    event.recipes.gtceu.mixer(id('lumium_dust'))
         .itemInputs('gtceu:silver_dust', '3x gtceu:tin_dust', '2x minecraft:glowstone_dust')
         .itemOutputs('4x gtceu:lumium_dust')
         .duration(400)
         .EUt(80);
 
-    event.recipes.gtceu.mixer('enderium_dust')
+    event.recipes.gtceu.mixer(id('enderium_dust'))
         .itemInputs('3x gtceu:lead_dust', '1x gtceu:diamond_dust', '2x gtceu:ender_pearl_dust')
         .itemOutputs('4x gtceu:enderium_dust')
         .duration(600)
         .EUt(400);
 
-    event.recipes.gtceu.mixer('shellite_dust')
+    event.recipes.gtceu.mixer(id('shellite_dust'))
         .itemInputs('gtceu:black_bronze_dust', '3x gtceu:signalum_dust')
         .itemOutputs('4x gtceu:shellite_dust')
         .duration(700)
         .EUt(1024);
 
-    event.recipes.gtceu.mixer('twinite_dust')
+    event.recipes.gtceu.mixer(id('twinite_dust'))
         .itemInputs('3x gtceu:enderium_dust', '2x gtceu:amethyst_dust', 'gtceu:lumium_dust')
         .itemOutputs('6x gtceu:twinite_dust')
         .duration(800)
         .EUt(6400);
 
-    event.recipes.gtceu.mixer('dragonsteel_dust')
+    event.recipes.gtceu.mixer(id('dragonsteel_dust'))
         .itemInputs('4x gtceu:tungsten_dust', '8x gtceu:shellite_dust', '2x gtceu:twinite_dust')
         .inputFluids('thermal_extra:refined_sunflower_oil 1000')
         .itemOutputs('14x gtceu:dragonsteel_dust')
         .duration(900)
         .EUt(16000);
 
-    event.recipes.gtceu.mixer('prismalium_dust')
+    event.recipes.gtceu.mixer(id('prismalium_dust'))
         .itemInputs('8x gtceu:naquadah_dust', '4x gtceu:shellite_dust', '7x gtceu:tungsten_carbide_dust')
         .itemOutputs('19x gtceu:prismalium_dust')
         .duration(1000)
         .EUt(65536);
 
-    event.recipes.gtceu.mixer('melodium_dust')
+    event.recipes.gtceu.mixer(id('melodium_dust'))
         .itemInputs('14x gtceu:electrum_dust', '3x gtceu:amethyst_dust', '4x gtceu:darmstadtium_dust', '7x gtceu:europium_dust')
         .inputFluids('gtceu:mercury_barium_calcium_cuprate 288')
         .itemOutputs('30x gtceu:melodium_dust')
         .duration(1100)
         .EUt(100000);
 
-    event.recipes.gtceu.mixer('stellarium_dust')
+    event.recipes.gtceu.mixer(id('stellarium_dust'))
         .itemInputs('4x gtceu:melodium_dust', '1x gtceu:dragonsteel_dust')
         .inputFluids('gtceu:neutronium 1728')
         .itemOutputs('17x gtceu:stellarium_dust')

--- a/kubejs/server_scripts/superconductors.js
+++ b/kubejs/server_scripts/superconductors.js
@@ -1,4 +1,5 @@
 ServerEvents.recipes(event => {
+    const id = global.id;
 
     event.recipes.gtceu.macerator(id('soul_sand_dust'))
         .itemInputs('minecraft:soul_sand')
@@ -12,7 +13,7 @@ ServerEvents.recipes(event => {
             'minecraft:soul_sand',
             '#forge:tools/mortars'
         ]
-    );
+    ).id('start:shapeless/soul_sand_dust');
 
     event.recipes.gtceu.mixer(id('soul_infused_dust'))
         .itemInputs('gtceu:invar_dust', '2x thermal_extra:soul_sand_dust')

--- a/kubejs/server_scripts/universal_circuits.js
+++ b/kubejs/server_scripts/universal_circuits.js
@@ -1,8 +1,11 @@
-const tiers = ['ulv', 'lv', 'mv', 'hv', 'ev', 'iv', 'luv', 'zpm', 'uv', 'uhv', 'uev','uiv'];
 
+const tiers = ['ulv', 'lv', 'mv', 'hv', 'ev', 'iv', 'luv', 'zpm', 'uv', 'uhv', 'uev','uiv'];
+	
 ServerEvents.recipes(event => {
+    const id = global.id;
+	
 	tiers.forEach(tier => {
-		event.recipes.gtceu.assembler(`${tier}_universal_circuit`)
+		event.recipes.gtceu.assembler(id(`${tier}_universal_circuit`))
             .circuit(5)
             .itemInputs(`#gtceu:circuits/${tier}`)
             .itemOutputs(`kubejs:${tier}_universal_circuit`)
@@ -11,6 +14,7 @@ ServerEvents.recipes(event => {
 	});
 
 });
+
 ServerEvents.tags('item', event => {
 	tiers.forEach(tier => {
 		event.add(`gtceu:circuits/${tier}`, `kubejs:${tier}_universal_circuit`);

--- a/kubejs/startup_scripts/framework/framework.js
+++ b/kubejs/startup_scripts/framework/framework.js
@@ -187,5 +187,8 @@ global.machines = (func, priority) => {
     controller.add('machine', func, priority);
 }
 
+global.id = (id) => {
+    `start:${id}`
+}
 
 global.finalize = () => {controller.register()}

--- a/kubejs/startup_scripts/framework/framework.js
+++ b/kubejs/startup_scripts/framework/framework.js
@@ -187,8 +187,4 @@ global.machines = (func, priority) => {
     controller.add('machine', func, priority);
 }
 
-global.id = (id) => {
-    `start:${id}`
-}
-
 global.finalize = () => {controller.register()}

--- a/kubejs/startup_scripts/materials/materials.js
+++ b/kubejs/startup_scripts/materials/materials.js
@@ -254,126 +254,70 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
     // Materials from elements
     const compIngot = (name, elements, color, icon, blasting, flags) => {
         if (blasting.includes(blasting[0])){
-            event.create(name).ingot()
-                .composition(elements)
-                .color(color)
-                .iconSet(icon)
-                .flags(flags)
-                .blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]);
+            event.create(name).ingot().components(elements).color(color).iconSet(icon).flags(flags).blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]);
         } else {
-            event.create(name).ingot().fluid()
-                .composition(elements)
-                .color(color)
-                .iconSet(icon)
-                .flags(flags);
+            event.create(name).ingot().fluid().components(elements).color(color).iconSet(icon).flags(flags);
         }
     }
 
     const elemIngot = (name, element, color, icon, blasting, flags) => {
         if (blasting.includes(blasting[0])){
-            event.create(name).ingot()
-                .element(GTElements.get(element))
-                .color(color)
-                .iconSet(icon)
-                .flags(flags)
-                .blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]);
+            event.create(name).ingot().element(GTElements.get(element)).color(color).iconSet(icon).flags(flags).blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]);
         } else {
-            event.create(name).ingot().fluid()
-                .element(GTElements.get(element))
-                .color(color)
-                .iconSet(icon)
-                .flags(flags);
+            event.create(name).ingot().fluid().element(GTElements.get(element)).color(color).iconSet(icon).flags(flags);
         }
     }
 
     const compIngotFluid = (name, elements, color, icon, blasting, flags) => {
         if (blasting.includes(blasting[0])){
-            event.create(name).ingot().fluid()
-                .components(elements).color(color)
-                .iconSet(icon)
-                .flags(flags)
-                .blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]);
+            event.create(name).ingot().fluid().components(elements).color(color).iconSet(icon).flags(flags).blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]);
         } else {
-            event.create(name).ingot().fluid()
-                .components(elements)
-                .color(color)
-                .iconSet(icon)
-                .flags(flags);
+            event.create(name).ingot().fluid().components(elements).color(color).iconSet(icon).flags(flags);
         }
     }
 
     const elemIngotFluid = (name, color, icon, blasting, flags) => {
         if (blasting.includes(blasting[0])){
-            event.create(name).ingot().fluid()
-                .element(GTElements.get(name))
-                .color(color).iconSet(icon)
-                .flags(flags)
-                .blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]);
+            event.create(name).ingot().fluid().element(GTElements.get(name)).color(color).iconSet(icon).flags(flags).blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]);
         } else {
-            event.create(name).ingot().fluid()
-                .element(GTElements.get(name))
-                .color(color)
-                .iconSet(icon)
-                .flags(flags);
+            event.create(name).ingot().fluid().element(GTElements.get(name)).color(color).iconSet(icon).flags(flags);
         }
     }
     
     const compFluid = (name, elements, color, flags) => {
-        event.create(name).fluid()
-            .composition(elements)
-            .color(color)
-            .flags(flags);
+        event.create(name).fluid().components(elements).color(color).flags(flags);
     }
 
     const elemFluid = (name, color, flags) => {
-        event.create(name).fluid()
-            .element(GTElements.get(name))
-            .color(color)
-            .flags(flags);
+        event.create(name).fluid().element(GTElements.get(name)).color(color).flags(flags);
     }
     
     const compDustFluid = (name, elements, color, flags) => {
-        event.create(name).dust().fluid()
-            .composition(elements)
-            .color(color)
-            .flags(flags);
+        event.create(name).dust().fluid().components(elements).color(color).flags(flags);
     }
 
     const elemDustFluid = (name, color, flags) => {
-        event.create(name).dust().fluid()
-            .element(GTElements.get(name))
-            .color(color)
-            .flags(flags);
+        event.create(name).dust().fluid().element(GTElements.get(name)).color(color).flags(flags);
     }
     
     const compDust = (name, elements, color, flags) => {
-        event.create(name).dust()
-            .composition(elements)
-            .color(color)
-            .flags(flags);
+        event.create(name).dust().components(elements).color(color).flags(flags);
+    }
+    
+    const compDustIcon = (name, elements, color, icon, flags) => {
+        event.create(name).dust().components(elements).color(color).iconSet(icon).flags(flags);
     }
 
     const elemDust = (name, color, flags) => {
-        event.create(name).dust()
-            .element(GTElements.get(name))
-            .color(color)
-            .flags(flags);
+        event.create(name).dust().element(GTElements.get(name)).color(color).flags(flags);
     }
     
     const compGem = (name, elements, color, icon, flags) => {
-        event.create(name).gem()
-            .composition(elements)
-            .color(color)
-            .iconSet(icon)
-            .flags(flags);
+        event.create(name).gem().components(elements).color(color).iconSet(icon).flags(flags);
     }
 
     const elemGem = (name, color, icon, flags) => {
-        event.create(name).gem()
-            .element(GTElements.get(name))
-            .iconSet(icon)
-            .color(color)
-            .flags(flags);
+        event.create(name).gem().element(GTElements.get(name)).iconSet(icon).color(color).flags(flags);
     }
 
 
@@ -407,24 +351,13 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         .fluidPipeProperties(18000, 7200, true,true,true,true);
 
     // Thermal Superconductors (twinite and higher rotor values by @richie3366)
-    const conductor = (name, elements, color, blasting, cable, rotor, flags) => {
+    const conductor = (name, elements, color, blasting, cable, rotorstat) => {
         if (blasting.includes(blasting[0])){
-            event.create(name).ingot().fluid()
-                .components(elements)
-                .color(color)
-                .iconSet(SHINY)
-                .flags(flags)
-                .blastTemp(blasting[0], blasting[1], blasting[2], blasting[3])
-                .cableProperties(cable[0], cable[1], cable[2], cable[3])
-                .rotorStats(rotor[0], rotor[1], rotor[2], rotor[3]);
+            event.create(name).ingot().fluid().components(elements).color(color).iconSet(SHINY).flags(foil, gear, long_rod, plates, rod, rotor, small_gear, ring, frame)
+                .blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]).cableProperties(cable[0], cable[1], cable[2], cable[3]).rotorStats(rotorstat[0], rotorstat[1], rotorstat[2], rotorstat[3]);
         } else {
-            event.create(name).ingot().fluid()
-                .components(elements)
-                .color(color)
-                .iconSet(SHINY)
-                .flags(foil, gear, long_rod, plates, rod, rotor, small_gear, ring, frame)
-                .cableProperties(cable[0], cable[1], cable[2], cable[3])
-                .rotorStats(rotor[0], rotor[1], rotor[2], rotor[3]);
+            event.create(name).ingot().fluid().components(elements).color(color).iconSet(SHINY).flags(foil, gear, long_rod, plates, rod, rotor, small_gear, ring, frame)
+                .cableProperties(cable[0], cable[1], cable[2], cable[3]).rotorStats(rotorstat[0], rotorstat[1], rotorstat[2], rotorstat[3]);
         }
     }
 
@@ -498,652 +431,240 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
 
     compDust('ethylene_oxide', ['2x carbon', '4x hydrogen', '1x oxygen'], 0xd9d9d9, []);
 
-    event.create('lithium_perchlorate')
-        .dust()
-        .components('1x lithium', '1x chlorine', '4x oxygen')
-        .color(0xe6f2ff);
+    compDust('lithium_perchlorate', ['1x lithium', '1x chlorine', '4x oxygen'], 0xe6f2ff, []);
 
-    event.create('sodium_perchlorate')
-        .dust()
-        .components('1x sodium', '1x chlorine', '4x oxygen')
-        .color(0xccf2ff);
+    compDust('sodium_perchlorate', ['1x sodium', '1x chlorine', '4x oxygen'], 0xccf2ff, []);
 
-    event.create('sodium_chlorate')
-        .dust()
-        .components('1x sodium', '1x chlorine', '3x oxygen')
-        .color(0xccf2ff);
+    compDust('sodium_chlorate', ['1x sodium', '1x chlorine', '3x oxygen'], 0xccf2ff, []);
 
-    event.create('silver_oxide')
-        .dust()
-        .components('2x silver', '1x oxygen')
-        .color(0xffffff);
+    compDust('silver_oxide', ['2x silver', '1x oxygen'], 0xffffff, []);
 
-    event.create('12_crown_4')
-        .fluid()
-        .components('8x carbon', '16x hydrogen', '4x oxygen')
-        .color(0xcc6699);
+    compFluid('12_crown_4', ['8x carbon', '16x hydrogen', '4x oxygen'], 0xcc6699, []);
 
-    event.create('15_crown_5')
-        .fluid()
-        .components('10x carbon', '20x hydrogen', '5x oxygen')
-        .color(0x0099cc);
+    compFluid('15_crown_5', ['10x carbon', '20x hydrogen', '5x oxygen'], 0x0099cc, []);
 
-    event.create('18_crown_6')
-        .fluid()
-        .components('12x carbon', '24x hydrogen', '6x oxygen')
-        .color(0x99ff33);
+    compFluid('18_crown_6', ['12x carbon', '24x hydrogen', '6x oxygen'], 0x99ff33, []);
 
-    event.create('12_crown_4_li')
-        .fluid()
-        .components('1x lithium', '8x carbon', '16x hydrogen', '4x oxygen')
-        .color(0x993366)
-        .flags(no_decomp);
+    compFluid('12_crown_4_li', ['1x lithium', '8x carbon', '16x hydrogen', '4x oxygen'], 0x993366, [no_decomp]);
 
-    event.create('15_crown_5_na')
-        .fluid()
-        .components('1x sodium', '10x carbon', '20x hydrogen', '5x oxygen')
-        .color(0x006080)
-        .flags(no_decomp);
+    compFluid('15_crown_5_na', ['1x sodium', '10x carbon', '20x hydrogen', '5x oxygen'], 0x006080, [no_decomp]);
 
-    event.create('18_crown_6_k')
-        .fluid()
-        .components('1x potassium', '12x carbon', '24x hydrogen', '6x oxygen')
-        .color(0x4d9900)
-        .flags(no_decomp);
+    compFluid('18_crown_6_k', ['1x potassium', '12x carbon', '24x hydrogen', '6x oxygen'], 0x4d9900, [no_decomp]);
 
-    event.create('4_toluenesulfonyl_chloride')
-        .dust()
-        .components('7x carbon', '7x hydrogen', '2x chlorine', '2x oxygen', '1x sulfur')
-        .color(0xffcccc);
+    compDust('4_toluenesulfonyl_chloride', ['7x carbon', '7x hydrogen', '2x chlorine', '2x oxygen', '1x sulfur'], 0xffccc, []);
 
-    event.create('triethylene_glycol_ditosylate')
-        .dust()
-        .components('20x carbon', '26x hydrogen', '8x oxygen', '2x sulfur')
-        .color(0xb8b894);
+    compDust('triethylene_glycol_ditosylate', ['20x carbon', '26x hydrogen', '8x oxygen', '2x sulfur'], 0xb8b894, []);
 
-    event.create('sodium_azide')
-        .dust()
-        .components('1x sodium', '3x nitrogen')
-        .color(0xcc6699);
+    compDust('sodium_azide', ['1x sodium', '3x nitrogen'], 0xcc6699, []);
 
-    event.create('palladium_on_carbon')
-        .dust()
-        .components('1x palladium', '1x carbon')
-        .color(0xff9900);
+    compDust('palladium_on_carbon', ['1x palladium', '1x carbon'], 0xff9900, []);
 
-    event.create('sodium_p_toluenesulfonate')
-        .dust()
-        .components('7x carbon', '7x hydrogen', '1x sodium', '3x oxygen', '1x sulfur')
-        .color(0x00cc00);
+    compDust('sodium_p_toluenesulfonate', ['7x carbon', '7x hydrogen', '1x sodium', '3x oxygen', '1x sulfur'], 0x00cc00, []);
 
-    event.create('triethylene_glycol_diazide')
-        .dust()
-        .components('6x carbon', '12x hydrogen', '2x oxygen', '6x nitrogen')
-        .color(0x6666ff);
+    compDust('triethylene_glycol_diazide', ['6x carbon', '12x hydrogen', '2x oxygen', '6x nitrogen'], 0x6666ff, []);
 
-    event.create('triethylene_glycol_diamine')
-        .dust()
-        .components('6x carbon', '16x hydrogen', '2x oxygen', '2x nitrogen')
-        .color(0xcc00cc);
+    compDust('triethylene_glycol_diamine', ['6x carbon', '16x hydrogen', '2x oxygen', '2x nitrogen'], 0xcc00cc, []);
 
-    event.create('cryptand')
-        .fluid()
-        .components('18x carbon', '36x hydrogen', '6x oxygen', '2x nitrogen')
-        .color(0x993333);
+    compFluid('cryptand', ['18x carbon', '36x hydrogen', '6x oxygen', '2x nitrogen'], 0x993333, []);
 
-    event.create('cryptand_k')
-        .fluid()
-        .components('1x potassium', '18x carbon', '36x hydrogen', '6x oxygen', '2x nitrogen')
-        .color(0x602020)
-        .flags(no_decomp);
+    compFluid('cryptand_k', ['1x potassium', '18x carbon', '36x hydrogen', '6x oxygen', '2x nitrogen'], 0x602020, [no_decomp]);
 
-    event.create('cryptand_na')
-        .fluid()
-        .components('1x sodium', '18x carbon', '36x hydrogen', '6x oxygen', '2x nitrogen')
-        .color(0x602020)
-        .flags(no_decomp);
+    compFluid('cryptand_na', ['1x sodium', '18x carbon', '36x hydrogen', '6x oxygen', '2x nitrogen'], 0x602020, [no_decomp]);
 
-    event.create('cryptand_li')
-        .fluid()
-        .components('1x lithium', '18x carbon', '36x hydrogen', '6x oxygen', '2x nitrogen')
-        .color(0x602020)
-        .flags(no_decomp);
+    compFluid('cryptand_li', ['1x lithium', '18x carbon', '36x hydrogen', '6x oxygen', '2x nitrogen'], 0x602020, [no_decomp]);
 
     // Mystical Agriculture Alloys
-    event.create('inferium_steel')
-        .ingot()
-        .components('1x steel', '1x mystery')
-        .iconSet(DULL)
-        .color(0x66ff33)
-        .flags(plates, rod, no_decomp);
-
-    event.create('prudentium_steel')
-        .ingot()
-        .components('1x steel', '1x mystery')
-        .iconSet(DULL)
-        .color(0x336600)
-        .flags(plates, rod, no_decomp);
-
-    event.create('tertium_steel')
-        .ingot()
-        .components('1x steel', '1x mystery')
-        .iconSet(DULL)
-        .color(0xff6600)
-        .flags(plates, rod, no_decomp);
-
-    event.create('imperium_steel')
-        .ingot()
-        .components('1x steel', '1x mystery')
-        .iconSet(DULL)
-        .color(0x0099ff)
-        .flags(plates, rod, no_decomp);
-
-    event.create('supremium_steel')
-        .ingot()
-        .components('1x steel', '1x mystery')
-        .iconSet(DULL)
-        .color(0xff0000)
-        .flags(plates, rod, no_decomp);
-
-    event.create('awakened_supremium_steel')
-        .ingot()
-        .components('1x steel', '1x mystery')
-        .iconSet(DULL)
-        .color(0xff3300)
-        .flags(plates, rod, no_decomp);
-
-    event.create('insanium_steel')
-        .ingot()
-        .components('1x steel', '1x mystery')
-        .iconSet(DULL)
-        .color(0x9900cc)
-        .flags(plates, rod, no_decomp);
+    [
+        {tier: 'inferium', color: 0x66ff33},
+        {tier: 'prudentium', color: 0x336600},
+        {tier: 'tertium', color: 0xff6600},
+        {tier: 'imperium', color: 0x0099ff},
+        {tier: 'supremium', color: 0xff0000},
+        {tier: 'awakened_supremium', color: 0xff3300},
+        {tier: 'insanium', color: 0x9900cc},
+    ].forEach(essence => {
+        compIngot(`${essence.tier}_steel`, ['1x steel', '1x mystery'], essence.color, DULL, [], [plates, rod, no_decomp]);
+    })
 
     // Diatrons
-    event.create('diatron')
-        .gem()
-        .color(0x6699ff)
-        .iconSet(LAPIS)
-        .flags(no_decomp);
+    compGem('diatron', [], 0x6699ff, LAPIS, [no_decomp]);
 
     // Echo/Void Line
-    event.create('echo_r')
-        .element(GTElements.get('echo_r'))
-        .fluid()
-        .color(0x003333)
-        .iconSet(DULL);
+    elemFluid('echo_r', 0x003333, []);
 
-    event.create('raw_void')
-        .components('1x echo_r', '1x neutronium')
-        .ingot(1)
-        .color(0x006666)
-        .flags(no_decomp)
-        .iconSet(DULL);
+    compIngot('raw_void', ['1x echo_r', '1x neutronium'], 0x006666, DULL, [], [no_decomp]);
 
-    event.create('void')
-        .components('1x echo_r', '1x neutronium')
-        .ingot(1)
-        .blastTemp(10799, 'highest', VA('uev'), 8000)
-        .color(0x001a1a)
-        .iconSet(DULL)
-        .flags(rod, foil, plates, long_rod, frame, no_decomp);
+    compIngot('void', ['1x echo_r', '1x neutronium'], 0x001a1a, DULL, [10799, 'highest', VA('uev'), 8000], [rod, foil, plates, long_rod, frame, no_decomp]);
     
     //Extended Sculk
-    event.create('ionized_sculk')
-        .dust()
-        .color(0x061A0D)
-        .iconSet(RADIOACTIVE)
-        .flags(no_decomp);
+    compDustIcon('ionized_sculk', [], 0x061A0D, RADIOACTIVE, [no_decomp]);
 
-    event.create('sodium_over_sculk')
-        .dust()
-        .color(0x071A22)
-        .components('1x sodium','1x mystery')
-        .flags(no_decomp);
+    compDust('sodium_over_sculk', ['1x sodium','1x mystery'], 0x071A22, [no_decomp]);
     
     // Extras
-    event.create('trinaquadalloy')
-        .ingot().fluid()
-        .color(0x281832)
-        .iconSet(BRIGHT)
-        .flags(plates, rod, frame, fine_wire, foil, dense_plate)
-        .components('6x trinium', '2x naquadah', '1x carbon')
-        .blastTemp(8747, 'higher', VA('zpm'), 1200)
+    compIngotFluid('trinaquadalloy', ['6x trinium', '2x naquadah', '1x carbon'], 0x281832, BRIGHT, [8747, 'higher', VA('zpm'), 1200], [plates, rod, frame, fine_wire, foil, dense_plate]);
 
-    event.create('perchloric_acid')
-        .fluid()
-        .components('1x hydrogen', '1x chlorine', '4x oxygen')
-        .color(0xffe6e6);
+    compFluid('perchloric_acid', ['1x hydrogen', '1x chlorine', '4x oxygen'], 0xffe6e6, []);
 
-    // event.create('iodic_acid')
-    //     .fluid()
-    //     .components('1x hydrogen', '1x iodine', '3x oxygen')
-    //     .color(0xcc33ff);
+    compDust('calcium_perchlorate', ['1x calcium', '2x chlorine', '8x oxygen'], 0xffff99, []);
 
-    event.create('calcium_perchlorate')
-        .dust()
-        .components('1x calcium', '2x chlorine', '8x oxygen')
-        .color(0xffff99);
+    compFluid('silica_gel', ['1x chlorine', '1x hydrogen', '6x oxygen', '1x silicon'], 0xe6e6e6, [no_decomp]);
 
-    event.create('silica_gel')
-        .fluid()
-        .components('1x chlorine', '1x hydrogen', '6x oxygen', '1x silicon')
-        .color(0xe6e6e6)
-        .flags(no_decomp);
+    compDust('calcium_sulfate', ['1x calcium', '1x sulfur', '4x oxygen'], 0xffbf80, []);
 
-    event.create('calcium_sulfate')
-        .dust()
-        .components('1x calcium', '1x sulfur', '4x oxygen')
-        .color(0xffbf80);
+    compDust('sodium_oxide', ['2x sodium', '1x oxygen'], 0x6666ff, []);
 
-    event.create('sodium_oxide')
-        .dust()
-        .components('2x sodium', '1x oxygen')
-        .color(0x6666ff);
+    compDust('iron_selenide', ['1x iron', '1x selenium'], 0xb3ff66, []);
 
-    event.create('iron_selenide')
-        .dust()
-        .components('1x iron', '1x selenium')
-        .color(0xb3ff66);
+    compDust('strontium_oxide', ['1x strontium', '1x oxygen'], 0xffcc99, []);
 
-    event.create('strontium_oxide')
-        .dust()
-        .components('1x strontium', '1x oxygen')
-        .color(0xffcc99);
+    compDust('titanium_oxide', ['1x titanium', '2x oxygen'], 0xff66cc, []);
 
-    event.create('titanium_oxide')
-        .dust()
-        .components('1x titanium', '2x oxygen')
-        .color(0xff66cc);
+    compDust('strontium_titanium_oxide', ['1x strontium', '1x titanium', '3x oxygen'], 0xff0000, []);
 
-    event.create('strontium_titanium_oxide')
-        .dust()
-        .components('1x strontium', '1x titanium', '3x oxygen')
-        .color(0xff0000);
+    compDust('copper_chloride', ['1x copper', '1x chlorine'], 0xffffff, []);
 
-    event.create('npk_solution')
-        .fluid()
-        .color(0xb8c3f5);
+    compFluid('npk_solution', [], 0xb8c3f5, []);
 
-    event.create('copper_chloride')
-        .dust()
-        .components('1x copper', '1x chlorine');
-
-    event.create('cupric_chloride_solution')
-        .fluid()
-        .components('1x copper_chloride', '1x hydrochloric_acid')
-        .color(0x336600);
+    compFluid('cupric_chloride_solution', ['1x copper_chloride', '1x hydrochloric_acid'], 0x336600, []);
 
     // Ores and bedrock fluids
+    const compDustFluidOre = (name, elements, color, flags) => {
+        event.create(name).dust().liquid().ore(2, 1).components(elements).color(color).flags(flag);
+    }
     
-    event.create('titanite')
-        .dust()
-        .liquid()
-        .ore(2, 1)
-        .components('1x calcium', '1x titanium', '1x silicon', '5x oxygen')
-        .color(0x66ffff)
-        .flags(no_decomp);
+    const compDustOre = (name, elements, color) => {
+        event.create(name).dust().ore(2, 1).components(elements).color(color).flags(no_decomp);
+    }
+    
+    const compGemOre = (name, elements, color, icon) => {
+        event.create(name).gem().ore(2, 1).components(elements).color(color).iconSet(icon);
+    }
 
-    event.create('zapolite')
-        .dust()
-        .liquid()
-        .ore(2, 1)
-        .components('2x zapolgium', '4x iodine', '2x aluminium', '5x oxygen')
-        .color(0xcc0099)
-        .flags(no_decomp);
+    compDustFluidOre('titanite', ['1x calcium', '1x titanium', '1x silicon', '5x oxygen'], 0x66ffff, [no_decomp]);
 
-    event.create('lautarite')
-        .dust()
-        .ore(2, 1)
-        .components('1x calcium', '2x iodine', '6x oxygen')
-        .color(0x6666ff)
-        .flags(no_decomp);
+    compDustFluidOre('zapolite', ['2x zapolgium', '4x iodine', '2x aluminium', '5x oxygen'], 0xcc0099, [no_decomp]);
 
-    event.create('iodargyrite')
-        .dust()
-        .liquid()
-        .ore(2, 1)
-        .components('1x silver', '1x iodine')
-        .color(0x8080ff)
-        .flags(no_decomp);
+    compDustOre('lautarite', ['1x calcium', '2x iodine', '6x oxygen'], 0x6666ff);
 
-    event.create('clausthalite')
-        .dust()
-        .liquid()
-        .ore(2, 1)
-        .components('1x lead', '1x selenium')
-        .color(0x666633)
-        .flags(no_decomp);
+    compDustFluidOre('iodargyrite', ['1x silver', '1x iodine'], 0x8080ff, [no_decomp]);
 
-    event.create('crookesite')
-        .dust()
-        .liquid()
-        .ore(2, 1)
-        .components('7x copper', '1x thallium', '4x selenium')
-        .color(0x00ff99)
-        .flags(no_decomp);
+    compDustFluidOre('clausthalite', ['1x lead', '1x selenium'], 0x666633, [no_decomp]);
 
-    event.create('calaverite')
-        .dust()
-        .liquid()
-        .ore(2, 1)
-        .components('1x gold', '2x tellurium')
-        .color(0xcc9900)
-        .flags(no_decomp);
+    compDustFluidOre('crookesite', ['7x copper', '1x thallium', '4x selenium'], 0x00ff99, [no_decomp]);
 
-    event.create('sylvanite')
-        .dust()
-        .liquid()
-        .ore(2, 1)
-        .components('1x silver', '2x tellurium')
-        .color(0xff5050)
-        .flags(no_decomp);
+    compDustFluidOre('calaverite', ['1x gold', '2x tellurium'], 0xcc9900, [no_decomp]);
 
-    event.create('tiemannite')
-        .dust()
-        .liquid()
-        .ore(2, 1)
-        .components('1x mercury', '1x selenium')
-        .color(0xcc0066)
-        .flags(no_decomp);
+    compDustFluidOre('sylvanite', ['1x silver', '2x tellurium'], 0xff5050, [no_decomp]);
 
-    event.create('klockmannite')
-        .dust()
-        .ore(2, 1)
-        .components('1x copper', '1x selenium')
-        .color(0x009999)
-        .flags(no_decomp);
+    compDustFluidOre('tiemannite', ['1x mercury', '1x selenium'], 0xcc0066, [no_decomp]);
 
-    event.create('stibiopalladinite')
-        .dust()
-        .ore(2, 1)
-        .components('5x palladium', '2x antimony')
-        .color(0x333399)
-        .flags(no_decomp);
+    compDustOre('klockmannite', ['1x copper', '1x selenium'], 0x009999);
 
-    event.create('berzelianite')
-        .dust()
-        .ore(2, 1)
-        .components('2x copper', '1x selenium')
-        .color(0x990000)
-        .flags(no_decomp);
+    compDustOre('stibiopalladinite', ['5x palladium', '2x antimony'], 0x333399);
 
-    event.create('umangite')
-        .dust()
-        .ore(2, 1)
-        .components('3x copper', '2x selenium')
-        .color(0x006699)
-        .flags(no_decomp);
+    compFluid('berzelianite', ['2x copper', '1x selenium'], 0x990000);
 
-    event.create('aguilarite')
-        .dust()
-        .ore(2, 1)
-        .components('3x silver', '1x selenium', '1x sulfur')
-        .color(0xff5050)
-        .flags(no_decomp);
+    compFluid('umangite', ['3x copper', '2x selenium'], 0x006699);
 
-    event.create('polybasite')
-        .dust()
-        .components('12x silver', '4x copper', '2x arsenic', '13x sulfur')
-        .color(0xcc6600);
+    compFluid('aguilarite', ['3x silver', '1x selenium', '1x sulfur'], 0xff5050);
 
-    event.create('strontianite')
-        .dust()    
-        .liquid()
-        .ore(2, 1)
-        .components('1x strontium', '1x carbon', '3x oxygen')
-        .color(0xe6ffff);
+    compDustFluidOre('strontianite', ['1x strontium', '1x carbon', '3x oxygen'], 0xe6ffff, []);
 
-    event.create('celestine')
-        .gem()
-        .ore(4, 1)
-        .components('1x strontium', '1x carbon', '4x oxygen')
-        .color(0xe6ffff)
-        .iconSet(GEM_VERTICAL);
+    compGemOre('celestine', ['1x strontium', '1x carbon', '4x oxygen'], 0xe6ffff, GEM_VERTICAL);
 
-    event.create('abydos_titanite_rich_magma')
-        .liquid(new GTFluidBuilder().temperature(3520))
-        .components('6x titanite', '2x calaverite','2x sylvanite', '2x tiemannite', '1x strontianite')
-        .flags(no_decomp)    
-        .color(0xe65c00);
+    compDust('polybasite', ['12x silver', '4x copper', '2x arsenic', '13x sulfur'], 0xcc6600, []);
 
-    event.create('abydos_zapolite_rich_magma')
-        .liquid(new GTFluidBuilder().temperature(4980))
-        .components('7x zapolite', '3x crookesite', '2x clausthalite', '1x iodargyrite')
-        .color(0xff471a)
-        .flags(no_decomp);
+    const compFluidTemp = (name, heat, elements, color, flags) => {
+        event.create(name).liquid(new GTFluidBuilder().temperature(heat)).components(elements).color(color).flags(flags);
+    }
+
+    compFluidTemp('abydos_titanite_rich_magma', 3520, ['6x titanite', '2x calaverite','2x sylvanite', '2x tiemannite', '1x strontianite'], 0xe65c00, [no_decomp]);
+
+    compFluidTemp('abydos_zapolite_rich_magma', 4980, ['7x zapolite', '3x crookesite', '2x clausthalite', '1x iodargyrite'], 0xff471a, [no_decomp]);
 
     // Nether
        
         //Extended Debris
-        event.create('ancient_debris')
-            .dust()
-            .fluid()
-            .components('1x mystery')
-            .color(0x603D1A)
-            .flags(no_decomp);
+        compDustFluid('ancient_debris', ['1x mystery'], 0x603d1a, [no_decomp]);
 
-        event.create('ancient_netherite')
-            .ingot()
-            .dust()
-            .flags(plates,rod,no_decomp)
-            .components('4x gold','4x mystery')
-            .color(0x46271B)
-            .blastTemp(12349, 'low', VA('uev'), 2400);
-          
+        compIngot('ancient_netherite', ['4x gold','4x mystery'], 0x46271b, [], [12349, 'low', VA('uev'), 2400], [plates,rod,no_decomp]);
+
         //Atomic Nether Dust Line
-        event.create('atomic_nether_sludge')
-            .dust()
-            .components('1x mystery','1x mystery','1x mystery','1x mystery')
-            .color(0x883039)
-            .iconSet(RADIOACTIVE)
-            .flags(no_decomp);
+        compDustIcon('atomic_nether_sludge', ['1x mystery','1x mystery','1x mystery','1x mystery'], 0x883039, RADIOACTIVE, [no_decomp]);
 
-        event.create('deactivated_nether')
-            .dust()
-            .components('1x mystery','1x mystery')
-            .color(0x664C4C)
-            .flags(no_decomp);
+        compDust('deactivated_nether', ['1x mystery','1x mystery'], 0x664C4C, [no_decomp]);
         
-        event.create('activated_nether')
-            .dust()
-            .components('1x mystery','1x mystery')
-            .color(0xA01819)
-            .flags(no_decomp);
+        compDust('activated_nether', ['1x mystery','1x mystery'], 0xA01819, [no_decomp]);
 
         //Estalt Line
-        event.create('molten_estaltadyne_mixture')
-            .liquid(new GTFluidBuilder().temperature(3500))
-            .components('1x mystery','1x estalt','1x mystery')
-            .color(0x8E0505)
-            .flags(no_decomp);
+        compFluidTemp('molten_estaltadyne_mixture', 3500, ['1x mystery','1x estalt','1x mystery'], 0x8E0505, [no_decomp]);
 
-        event.create('estaltadyne')
-            .dust()
-            .fluid()
-            .components('4x estalt','3x titanium','2x aluminium','5x sulfur','4x oxygen')
-            .color(0x8E0535)
-            .flags(no_decomp);
+        compDustFluid('estaltadyne', ['4x estalt','3x titanium','2x aluminium','5x sulfur','4x oxygen'], 0x8E0535, [no_decomp]);
 
-        event.create('metmalic_estaltadyne')
-            .dust()
-            .components('4x estalt','3x titanium','2x aluminium','5x sulfur')
-            .color(0x8E0560)
-            .flags(no_decomp);
+        compDust('metmalic_estaltadyne', ['4x estalt','3x titanium','2x aluminium','5x sulfur'], 0x8E0560, [no_decomp]);
 
-        event.create('magnemalic_estaltadyne')
-            .dust()
-            .components('4x estalt','3x titanium','5x sulfur')
-            .color(0x8E0480)
-            .flags(no_decomp);
+        compDust('magnemalic_estaltadyne', ['4x estalt','3x titanium','5x sulfur'], 0x8E0480, [no_decomp]);
 
-        event.create('tytite_estaltadyne')
-            .dust()
-            .components('4x estalt','3x titanium')
-            .color(0x8E0340)
-            .flags(no_decomp);
+        compDust('tytite_estaltadyne', ['4x estalt','3x titanium'], 0x8E0340, [no_decomp]);
 
-        event.create('estaltadyne_hydride')
-            .dust()
-            .components('4x estalt','9x hydrogen')
-            .color(0x8E0505)
-            .flags(no_decomp);
+        compDust('estaltadyne_hydride', ['4x estalt','9x hydrogen'], 0x8E0505, [no_decomp]);
         
         //Enriched Estalt Line
-        event.create('enriched_estaltadyne_mixture')
-            .fluid()
-            .components('1x mystery','1x enriched_estalt','1x mystery')
-            .color(0xBE4747)
-            .flags(no_decomp);
+        compFluid('enriched_estaltadyne_mixture', ['1x mystery','1x enriched_estalt','1x mystery'], 0xBE4747, [no_decomp]);
 
-        event.create('enriched_estaltadyne_solution')
-            .fluid()
-            .components('1x mystery','1x enriched_estalt','1x mystery')
-            .color(0xBE4717)
-            .flags(no_decomp);
+        compFluid('enriched_estaltadyne_solution', ['1x mystery','1x enriched_estalt','1x mystery'], 0xBE4717, [no_decomp]);
 
-        event.create('enriched_estaltadyne_slurry')
-            .fluid()
-            .components('1x mystery','1x enriched_estalt','1x mystery')
-            .color(0xBE4777)
-            .flags(no_decomp);
+        compFluid('enriched_estaltadyne_slurry', ['1x mystery','1x enriched_estalt','1x mystery'], 0xBE4777, [no_decomp]);
 
-        event.create('enriched_estaltadyne_naquide_slurry_mixture')
-            .fluid()
-            .components('1x mystery','1x enriched_estalt','1x enriched_naquadah','1x mystery')
-            .color(0xBE4697)
-            .flags(no_decomp);
+        compFluid('enriched_estaltadyne_naquide_slurry_mixture', ['1x mystery','1x enriched_estalt','1x enriched_naquadah','1x mystery'], 0xBE4697, [no_decomp]);
 
-        event.create('hyper_enriched_estaltadyne_slurry_mixture')
-            .fluid()
-            .components('1x mystery','2x enriched_estalt')
-            .color(0xBE4697)
-            .flags(no_decomp);
+        compFluid('hyper_enriched_estaltadyne_slurry_mixture', ['1x mystery','2x enriched_estalt'], 0xBE4697, [no_decomp]);
         
-        event.create('hyper_enriched_estaltadyne_slurry_residue')
-            .fluid()
-            .components('1x mystery','2x enriched_estalt')
-            .color(0xBE4677)
-            .flags(no_decomp);
+        compFluid('hyper_enriched_estaltadyne_slurry_residue', ['1x mystery','2x enriched_estalt'],0xBE4677, [no_decomp]);
 
-        event.create('sodium_hyper_enriched_estaltadyne_sludge')
-            .fluid()
-            .components('2x sodium','1x mystery','2x enriched_estalt')
-            .color(0xBE4697)
-            .flags(no_decomp);
+        compFluid('sodium_hyper_enriched_estaltadyne_sludge', ['2x sodium','1x mystery','2x enriched_estalt'], 0xBE4697, [no_decomp]);
 
-        event.create('hyper_enriched_estaltadyne_concentrate')
-            .fluid()
-            .components('2x enriched_estalt','1x mystery')
-            .color(0xBE4587)
-            .flags(no_decomp);
+        compFluid('hyper_enriched_estaltadyne_concentrate', ['2x enriched_estalt','1x mystery'], 0xBE4587, [no_decomp]);
         
         //Adamantine Line
-        event.create('enriched_adamantamite_mixture')
-            .fluid()
-            .components('1x mystery','1x adamantine','1x mystery')
-            .color(0x866E4B)
-            .flags(no_decomp);
+        compFluid('enriched_adamantamite_mixture', ['1x mystery','1x adamantine','1x mystery'], 0x866E4B, [no_decomp]);
 
-        event.create('molten_adamantamite_mixture')
-            .liquid(new GTFluidBuilder().temperature(3700))
-            .components('1x mystery','1x adamantine','1x mystery')
-            .color(0x866E7B)
-            .flags(no_decomp);
+        compFluidTemp('molten_adamantamite_mixture', 3700, ['1x mystery','1x adamantine','1x mystery'], 0x866E7B, [no_decomp]);
 
-        event.create('adamantamite')
-            .dust()
-            .fluid()
-            .components('5x adamantine','4x titanium','2x iron','6x nitrogen','12x oxygen')
-            .color(0x825F2B)
-            .flags(no_decomp);
+        compDustFluid('adamantamite', ['5x adamantine','4x titanium','2x iron','6x nitrogen','12x oxygen'], 0x825F2B, [no_decomp]);
 
-        event.create('adamantamite_metaltide')
-            .dust()
-            .components('5x adamantine','4x titanium','2x iron','6x nitrogen')
-            .color(0x8F611E)
-            .flags(no_decomp);
+        compDust('adamantamite_metaltide', ['5x adamantine','4x titanium','2x iron','6x nitrogen'], 0x8F611E, [no_decomp]);
 
-        event.create('adamantamite_magnide')
-            .dust()
-            .components('5x adamantine','4x titanium','2x iron')
-            .color(0x744D13)
-            .flags(no_decomp);
+        compDust('adamantamite_magnide', ['5x adamantine','4x titanium','2x iron'], 0x744D13, [no_decomp]);
 
-        event.create('adamantamite_titite')
-            .dust()
-            .components('5x adamantine','4x titanium')
-            .color(0xB68E52)
-            .flags(no_decomp);
+        compDust('adamantamite_titite', ['5x adamantine','4x titanium'], 0xB68E52, [no_decomp]);
 
-        event.create('adamantine_5')
-            .dust()
-            .components('5x adamantine')
-            .color(0xCB9D58)
-            .flags(no_decomp);
+        compDust('adamantine_5', ['5x adamantine'], 0xCB9D58, [no_decomp]);
 
-        event.create('adamantine_hydroxide')
-            .dust()
-            .components('1x adamantine','3x hydrogen','3x oxygen')
-            .color(0xCB8858)
-            .flags(no_decomp);
+        compDust('adamantine_hydroxide', ['1x adamantine','3x hydrogen','3x oxygen'], 0xCB8858, [no_decomp]);
         
         //Mythril Line
-        event.create('enriched_mythrillic_mixture')
-            .fluid()
-            .components('1x mystery','1x mythril','1x mystery')
-            .color(0x238213)
-            .flags(no_decomp);
+        compFluid('enriched_mythrillic_mixture', ['1x mystery','1x mythril','1x mystery'], 0x238213, [no_decomp]);
         
-        event.create('molten_mythrillic_mixture')
-            .liquid(new GTFluidBuilder().temperature(3100))
-            .components('1x mystery','1x mythril','1x mystery')
-            .color(0x238342)
-            .flags(no_decomp);
+        compFluidTemp('molten_mythrillic_mixture', 3100, ['1x mystery','1x mythril','1x mystery'], 0x238342, [no_decomp]);
 
-        event.create('mythrillic')
-            .dust()
-            .fluid()
-            .components('6x mythril','6x carbon','14x hydrogen','3x zirconium','2x vanadium')
-            .color(0x238362)
-            .flags(no_decomp);
+        compDustFluid('mythrillic', ['6x mythril','6x carbon','14x hydrogen','3x zirconium','2x vanadium'], 0x238362, [no_decomp]);
 
-        event.create('mythrillic_carbinide')
-            .dust()
-            .components('6x mythril','6x carbon','3x zirconium','2x vanadium')
-            .color(0x238441)
-            .flags(no_decomp);
+        compDust('mythrillic_carbinide', ['6x mythril','6x carbon','3x zirconium','2x vanadium'], 0x238441, [no_decomp]);
 
-        event.create('mythrillic_metlide')
-            .dust()
-            .components('6x mythril','3x zirconium','2x vanadium')
-            .color(0x238451)
-            .flags(no_decomp);
+        compDust('mythrillic_metlide', ['6x mythril','3x zirconium','2x vanadium'], 0x238451, [no_decomp]);
 
-        event.create('mythrillic_metnide')
-            .dust()
-            .components('6x mythril','3x zirconium')
-            .color(0x238432)
-            .flags(no_decomp);
+        compDust('mythrillic_metnide', ['6x mythril','3x zirconium'], 0x238432, [no_decomp]);
 
-        event.create('mythrillic_hydride')
-            .dust()
-            .components('1x mythril','2x hydrogen')
-            .color(0x238338)
-            .flags(no_decomp);
+        compDust('mythrillic_hydride', ['1x mythril','2x hydrogen'], 0x238338, [no_decomp]);
         
         // Calamatium/Isovol Line
-        event.create('impure_calamatium_solution')
-            .fluid()
-            .color(0x990000);
+        compFluid('impure_calamatium_solution', [], 0x990000, []);
 
-        event.create('impure_isovol_solution')
-            .fluid()
-            .color(0x000066);
+        compFluid('impure_isovol_solution', [], 0x000066, []);
 
-        event.create('calamatium_solution')
-            .fluid()
-            .color(0xe60000);
+        compFluid('calamatium_solution', [], 0xe60000, []);
 
         event.create('isovol_solution')
             .fluid()
@@ -1151,17 +672,17 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
 
         event.create('calamatium_fluoride')
             .dust()
-            .components('1x calamatium', '2x fluorine')
+            .components(['1x calamatium', '2x fluorine'])
             .color(0xcc0066)
-            .flags(no_decomp);
+            .flags([no_decomp]);
 
         event.create('isovol_fluoride')
             .dust()
-            .components('1x isovol', '2x fluorine')
+            .components(['1x isovol', '2x fluorine'])
             .color(0x9900ff)
-            .flags(no_decomp);
+            .flags([no_decomp]);
 
-        // //Magmas
+        // Magmas
         event.create('highly_unstable_nether_magma')
             .liquid(new GTFluidBuilder().temperature(9001))
             .components('1x mystery')

--- a/kubejs/startup_scripts/materials/materials.js
+++ b/kubejs/startup_scripts/materials/materials.js
@@ -268,11 +268,19 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         }
     }
 
-    const compIngotFluid = (name, elements, color, icon, blasting, flags) => {
+    const compIngotLiquid = (name, elements, color, icon, blasting, flags) => {
         if (blasting.includes(blasting[0])){
             event.create(name).ingot().fluid().components(elements).color(color).iconSet(icon).flags(flags).blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]);
         } else {
             event.create(name).ingot().fluid().components(elements).color(color).iconSet(icon).flags(flags);
+        }
+    }
+
+    const compIngotLiquidSeccolor = (name, elements, color1, color2, icon, blasting, flags) => {
+        if (blasting.includes(blasting[0])){
+            event.create(name).ingot().fluid().components(elements).color(color1).secondaryColor(color2).iconSet(icon).flags(flags).blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]);
+        } else {
+            event.create(name).ingot().fluid().components(elements).color(color1).secondaryColor(color2).iconSet(icon).flags(flags);
         }
     }
 
@@ -284,15 +292,23 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         }
     }
     
-    const compFluid = (name, elements, color, flags) => {
+    const compLiquid = (name, elements, color, flags) => {
         event.create(name).fluid().components(elements).color(color).flags(flags);
     }
 
-    const elemFluid = (name, color, flags) => {
-        event.create(name).fluid().element(GTElements.get(name)).color(color).flags(flags);
+    const elemFluid = (name, element, color, flags) => {
+        event.create(name).fluid().element(GTElements.get(element)).color(color).flags(flags);
+    }
+
+    const compLiquidTemp = (name, heat, elements, color, flags) => {
+        event.create(name).liquid(new GTFluidBuilder().temperature(heat)).components(elements).color(color).flags(flags);
     }
     
-    const compDustFluid = (name, elements, color, flags) => {
+    const compLiquidStill = (name, elements, flags) => {
+        event.create(name).liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill()).components(elements).flags(flags);
+    }
+    
+    const compDustLiquid = (name, elements, color, flags) => {
         event.create(name).dust().fluid().components(elements).color(color).flags(flags);
     }
 
@@ -318,6 +334,52 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
 
     const elemGem = (name, color, icon, flags) => {
         event.create(name).gem().element(GTElements.get(name)).iconSet(icon).color(color).flags(flags);
+    }
+    
+    const compGas = (name, elements, color, flags) => {
+        event.create(name).gas().components(elements).color(color).flags(flags);
+    }
+
+    const elemGas = (name, color, flags) => {
+        event.create(name).gas().element(GTElements.get(name)).color(color).flags(flags);
+    }
+
+    const polymerFluid = (name, elements, color, pipe, flags) => {
+            event.create(name).polymer().fluid().components(elements).color(color).flags(flags).fluidPipeProperties(pipe[0], pipe[1], pipe[2], pipe[3], pipe[4], pipe[5]);
+    }
+
+    const conductor = (name, elements, color, icon, blasting, cable, flags) => {
+        event.create(name).ingot().fluid().components(elements).color(color).iconSet(icon).flags(flags).blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]).cableProperties(cable[0], cable[1], cable[2], cable[3]);
+    }
+    
+    const conductorSuper = (name, elements, color, blasting, cable, rotorstat) => {
+        if (blasting.includes(blasting[0])){
+            event.create(name).ingot().fluid().components(elements).color(color).iconSet(SHINY).flags(foil, gear, long_rod, plates, rod, rotor, small_gear, ring, frame)
+                .blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]).cableProperties(cable[0], cable[1], cable[2], cable[3]).rotorStats(rotorstat[0], rotorstat[1], rotorstat[2], rotorstat[3]);
+        } else {
+            event.create(name).ingot().fluid().components(elements).color(color).iconSet(SHINY).flags(foil, gear, long_rod, plates, rod, rotor, small_gear, ring, frame)
+                .cableProperties(cable[0], cable[1], cable[2], cable[3]).rotorStats(rotorstat[0], rotorstat[1], rotorstat[2], rotorstat[3]);
+        }
+    }
+
+    const compDustLiquidOre = (name, elements, color, flags) => {
+        event.create(name).dust().liquid().ore(2, 1).components(elements).color(color).flags(flags);
+    }
+    
+    const compDustOre = (name, elements, color) => {
+        event.create(name).dust().ore(2, 1).components(elements).color(color).flags(no_decomp);
+    }
+    
+    const compGemOre = (name, elements, color, icon) => {
+        event.create(name).gem().ore(2, 1).components(elements).color(color).iconSet(icon);
+    }
+
+    const compIngotPlasma = (name, elements, color, icon, blasting, flags) => {
+        event.create(name).ingot().plasma().components(elements).color(color).iconSet(icon).flags(flags).blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]);
+    }
+
+    const conductorPlasma = (name, elements, color, icon, blasting, cable, flags) => {
+        event.create(name).ingot().plasma().components(elements).color(color).iconSet(icon).flags(flags).blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]).cableProperties(cable[0], cable[1], cable[2], cable[3]);
     }
 
 
@@ -351,57 +413,47 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         .fluidPipeProperties(18000, 7200, true,true,true,true);
 
     // Thermal Superconductors (twinite and higher rotor values by @richie3366)
-    const conductor = (name, elements, color, blasting, cable, rotorstat) => {
-        if (blasting.includes(blasting[0])){
-            event.create(name).ingot().fluid().components(elements).color(color).iconSet(SHINY).flags(foil, gear, long_rod, plates, rod, rotor, small_gear, ring, frame)
-                .blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]).cableProperties(cable[0], cable[1], cable[2], cable[3]).rotorStats(rotorstat[0], rotorstat[1], rotorstat[2], rotorstat[3]);
-        } else {
-            event.create(name).ingot().fluid().components(elements).color(color).iconSet(SHINY).flags(foil, gear, long_rod, plates, rod, rotor, small_gear, ring, frame)
-                .cableProperties(cable[0], cable[1], cable[2], cable[3]).rotorStats(rotorstat[0], rotorstat[1], rotorstat[2], rotorstat[3]);
-        }
-    }
+    conductorSuper('soul_infused', ['1x invar', '2x mystery'], 0xcc9966, [], [V('lv'), 4, 0, true], [150, 130, 3, 37600]);
 
-    conductor('soul_infused', ['1x invar', '2x mystery'], 0xcc9966, [], [V('lv'), 4, 0, true], [150, 130, 3, 37600]);
+    conductorSuper('signalum', ['1x silver', '3x copper', '4x redstone'], 0xff3300, [1700, 'low', VA('mv'), 1200], [V('mv'), 16, 0, true], [190, 150, 3, 24000]);
 
-    conductor('signalum', ['1x silver', '3x copper', '4x redstone'], 0xff3300, [1700, 'low', VA('mv'), 1200], [V('mv'), 16, 0, true], [190, 150, 3, 24000]);
+    conductorSuper('lumium', ['1x silver', '3x tin', '2x glowstone'], 0xffffb3, [1700, 'low', VA('hv'), 1500], [V('hv'), 16, 0, true], [220, 170, 3, 24000]);
 
-    conductor('lumium', ['1x silver', '3x tin', '2x glowstone'], 0xffffb3, [1700, 'low', VA('hv'), 1500], [V('hv'), 16, 0, true], [220, 170, 3, 24000]);
+    conductorSuper('enderium', ['3x lead', '1x diamond', '2x ender_pearl'], 0x006666, [3500, 'low', VA('ev'), 1500], [V('ev'), 32, 0, true], [300, 190, 3, 45600]);
 
-    conductor('enderium', ['3x lead', '1x diamond', '2x ender_pearl'], 0x006666, [3500, 'low', VA('ev'), 1500], [V('ev'), 32, 0, true], [300, 190, 3, 45600]);
+    conductorSuper('shellite', ['1x black_bronze', '3x signalum'], 0x9933ff, [4400, 'mid', VA('iv'), 1800], [V('iv'), 64, 0, true], [450, 220, 3, 37600]);
 
-    conductor('shellite', ['1x black_bronze', '3x signalum'], 0x9933ff, [4400, 'mid', VA('iv'), 1800], [V('iv'), 64, 0, true], [450, 220, 3, 37600]);
+    conductorSuper('twinite', ['3x manganese_phosphide', '2x amethyst', '1x lumium'], 0xf66999, [5300, 'mid', VA('luv'), 2100], [V('luv'), 64, 0, true], [700, 260, 3, 24000]);
 
-    conductor('twinite', ['3x manganese_phosphide', '2x amethyst', '1x lumium'], 0xf66999, [5300, 'mid', VA('luv'), 2100], [V('luv'), 64, 0, true], [700, 260, 3, 24000]);
+    conductorSuper('dragonsteel', ['4x tungsten', '8x magnesium_diboride', '2x cadmium'], 0x3333cc, [7100, 'high', VA('zpm'), 2400], [V('zpm'), 96, 0, true], [1100, 380, 3, 32000]);
 
-    conductor('dragonsteel', ['4x tungsten', '8x magnesium_diboride', '2x cadmium'], 0x3333cc, [7100, 'high', VA('zpm'), 2400], [V('zpm'), 96, 0, true], [1100, 380, 3, 32000]);
+    conductorSuper('prismalium', ['8x naquadah', '4x mercury_barium_calcium_cuprate', '7x tungsten_carbide'], 0x66ffff, [9000, 'high', VA('zpm'), 2700], [V('uv'), 48, 0, true], [1600, 470, 3, 48000]);
 
-    conductor('prismalium', ['8x naquadah', '4x mercury_barium_calcium_cuprate', '7x tungsten_carbide'], 0x66ffff, [9000, 'high', VA('zpm'), 2700], [V('uv'), 48, 0, true], [1600, 470, 3, 48000]);
+    conductorSuper('melodium', ['2x uranium_triplatinum', '14x electrum', '3x amethyst', '4x darmstadtium', '7x europium'], 0xd9b3ff, [10000, 'higher', VA('uv'), 3000], [V('uv'), 128, 0, true], [2000, 550, 3, 64000]);
 
-    conductor('melodium', ['2x uranium_triplatinum', '14x electrum', '3x amethyst', '4x darmstadtium', '7x europium'], 0xd9b3ff, [10000, 'higher', VA('uv'), 3000], [V('uv'), 128, 0, true], [2000, 550, 3, 64000]);
+    conductorSuper('stellarium', ['12x neutronium', '4x melodium', '1x samarium_iron_arsenic_oxide'], 0xccffff, [10799, 'highest', VA('uhv'), 4000], [V('uhv'), 192, 0, true], [3200, 660, 3, 96000]);
 
-    conductor('stellarium', ['12x neutronium', '4x melodium', '1x samarium_iron_arsenic_oxide'], 0xccffff, [10799, 'highest', VA('uhv'), 4000], [V('uhv'), 192, 0, true], [3200, 660, 3, 96000]);
-
-    conductor('ancient_runicalium', ['5x zapolgium', '18x stellarium', '8x zirconium'], 0xFAB922, [11749, 'highest', VA('uev'), 5000], [V('uev'), 256, 0, true], [6400, 720, 3, 128000]);
+    conductorSuper('ancient_runicalium', ['5x zapolgium', '18x stellarium', '8x zirconium'], 0xFAB922, [11749, 'highest', VA('uev'), 5000], [V('uev'), 256, 0, true], [6400, 720, 3, 128000]);
 
     // Nuclear Reactor Materials
     compIngot('austenitic_stainless_steel_304', ['35x steel', '10x chromium', '4x nickel', '1x manganese', '1x silicon'], 0x800040, METALLIC, [3500, 'low', VA('ev'), 1500], [plates, rod, frame]);
 
     compIngot('inconel_625', ['7x nickel', '2x chromium', '1x steel'], 0xa3a375, SHINY, [3500, 'low', VA('ev'), 1500], [plates, rod, frame]);
 
-    compFluid('nuclear_steam', ['1x steam', '1x mystery'], 0xcccccc, [no_decomp]);
+    compLiquid('nuclear_steam', ['1x steam', '1x mystery'], 0xcccccc, [no_decomp]);
 
-    compFluid('hot_sodium_potassium', ['1x sodium_potassium', '1x mystery'], 0x82fcc3, [no_decomp]);
+    compLiquid('hot_sodium_potassium', ['1x sodium_potassium', '1x mystery'], 0x82fcc3, [no_decomp]);
 
-    compFluid('hot_pcb_coolant', ['1x pcb_coolant', '1x mystery'], 0xc9ca81, [no_decomp]);
+    compLiquid('hot_pcb_coolant', ['1x pcb_coolant', '1x mystery'], 0xc9ca81, [no_decomp]);
 
     // Netherite Line
     elemDustFluid('debris', 0x804000, [no_decomp]);
 
     compDust('purified_debris', ['debris'], 0xcc0000, []);
 
-    compFluid('chlorine_trifluoride', ['1x chlorine', '3x fluorine'], 0xb3ff99, []);
+    compLiquid('chlorine_trifluoride', ['1x chlorine', '3x fluorine'], 0xb3ff99, []);
 
-    compFluid('tetrachloroethylene', ['2x carbon', '4x chlorine'], 0xd966ff, []);
+    compLiquid('tetrachloroethylene', ['2x carbon', '4x chlorine'], 0xd966ff, []);
     
     // Netherite Derivatives/Alloys
     elemIngotFluid('pure_netherite', 0x1a0d00, DULL, [5000, 'low', VA('iv'), 1200], [foil, gear, long_rod, plates, rod, rotor, small_gear, ring]);
@@ -410,12 +462,12 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
 
     compGem('naquadic_netherite', ['3x naquadah', '5x pure_netherite', '2x caesium', '5x cerium', '12x fluorine', '32x oxygen'], 0xffd966, DIAMOND, []);
 
-    compIngotFluid('weapon_grade_naquadah', ['7x naquadria', '2x pure_netherite', '5x neutronium', '16x fluorine'], 0xccff33, DULL, [10500, 'highest', VHA('uv'), 2700], [foil, gear, long_rod, plates, rod, rotor, small_gear, ring, frame]);
+    compIngotLiquid('weapon_grade_naquadah', ['7x naquadria', '2x pure_netherite', '5x neutronium', '16x fluorine'], 0xccff33, DULL, [10500, 'highest', VHA('uv'), 2700], [foil, gear, long_rod, plates, rod, rotor, small_gear, ring, frame]);
 
     compGem('runic_laser_source_base', ['2x naquadic_netherite', '10x tritanium', '2x trinium'], 0x00ff00, OPAL, []);
 
     // Crown Ethers
-    compFluid('sulfur_dichloride', ['1x sulfur', '2x chlorine'], 0xcc0000, []);
+    compLiquid('sulfur_dichloride', ['1x sulfur', '2x chlorine'], 0xcc0000, []);
 
     compDust('thionyl_chloride', ['1x sulfur', '1x oxygen', '2x chlorine'], 0xffffcc, []);
 
@@ -439,17 +491,17 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
 
     compDust('silver_oxide', ['2x silver', '1x oxygen'], 0xffffff, []);
 
-    compFluid('12_crown_4', ['8x carbon', '16x hydrogen', '4x oxygen'], 0xcc6699, []);
+    compLiquid('12_crown_4', ['8x carbon', '16x hydrogen', '4x oxygen'], 0xcc6699, []);
 
-    compFluid('15_crown_5', ['10x carbon', '20x hydrogen', '5x oxygen'], 0x0099cc, []);
+    compLiquid('15_crown_5', ['10x carbon', '20x hydrogen', '5x oxygen'], 0x0099cc, []);
 
-    compFluid('18_crown_6', ['12x carbon', '24x hydrogen', '6x oxygen'], 0x99ff33, []);
+    compLiquid('18_crown_6', ['12x carbon', '24x hydrogen', '6x oxygen'], 0x99ff33, []);
 
-    compFluid('12_crown_4_li', ['1x lithium', '8x carbon', '16x hydrogen', '4x oxygen'], 0x993366, [no_decomp]);
+    compLiquid('12_crown_4_li', ['1x lithium', '8x carbon', '16x hydrogen', '4x oxygen'], 0x993366, [no_decomp]);
 
-    compFluid('15_crown_5_na', ['1x sodium', '10x carbon', '20x hydrogen', '5x oxygen'], 0x006080, [no_decomp]);
+    compLiquid('15_crown_5_na', ['1x sodium', '10x carbon', '20x hydrogen', '5x oxygen'], 0x006080, [no_decomp]);
 
-    compFluid('18_crown_6_k', ['1x potassium', '12x carbon', '24x hydrogen', '6x oxygen'], 0x4d9900, [no_decomp]);
+    compLiquid('18_crown_6_k', ['1x potassium', '12x carbon', '24x hydrogen', '6x oxygen'], 0x4d9900, [no_decomp]);
 
     compDust('4_toluenesulfonyl_chloride', ['7x carbon', '7x hydrogen', '2x chlorine', '2x oxygen', '1x sulfur'], 0xffccc, []);
 
@@ -465,13 +517,13 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
 
     compDust('triethylene_glycol_diamine', ['6x carbon', '16x hydrogen', '2x oxygen', '2x nitrogen'], 0xcc00cc, []);
 
-    compFluid('cryptand', ['18x carbon', '36x hydrogen', '6x oxygen', '2x nitrogen'], 0x993333, []);
+    compLiquid('cryptand', ['18x carbon', '36x hydrogen', '6x oxygen', '2x nitrogen'], 0x993333, []);
 
-    compFluid('cryptand_k', ['1x potassium', '18x carbon', '36x hydrogen', '6x oxygen', '2x nitrogen'], 0x602020, [no_decomp]);
+    compLiquid('cryptand_k', ['1x potassium', '18x carbon', '36x hydrogen', '6x oxygen', '2x nitrogen'], 0x602020, [no_decomp]);
 
-    compFluid('cryptand_na', ['1x sodium', '18x carbon', '36x hydrogen', '6x oxygen', '2x nitrogen'], 0x602020, [no_decomp]);
+    compLiquid('cryptand_na', ['1x sodium', '18x carbon', '36x hydrogen', '6x oxygen', '2x nitrogen'], 0x602020, [no_decomp]);
 
-    compFluid('cryptand_li', ['1x lithium', '18x carbon', '36x hydrogen', '6x oxygen', '2x nitrogen'], 0x602020, [no_decomp]);
+    compLiquid('cryptand_li', ['1x lithium', '18x carbon', '36x hydrogen', '6x oxygen', '2x nitrogen'], 0x602020, [no_decomp]);
 
     // Mystical Agriculture Alloys
     [
@@ -490,7 +542,7 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
     compGem('diatron', [], 0x6699ff, LAPIS, [no_decomp]);
 
     // Echo/Void Line
-    elemFluid('echo_r', 0x003333, []);
+    elemFluid('echo_r', 'echo_r', 0x003333, []);
 
     compIngot('raw_void', ['1x echo_r', '1x neutronium'], 0x006666, DULL, [], [no_decomp]);
 
@@ -502,13 +554,13 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
     compDust('sodium_over_sculk', ['1x sodium','1x mystery'], 0x071A22, [no_decomp]);
     
     // Extras
-    compIngotFluid('trinaquadalloy', ['6x trinium', '2x naquadah', '1x carbon'], 0x281832, BRIGHT, [8747, 'higher', VA('zpm'), 1200], [plates, rod, frame, fine_wire, foil, dense_plate]);
+    compIngotLiquid('trinaquadalloy', ['6x trinium', '2x naquadah', '1x carbon'], 0x281832, BRIGHT, [8747, 'higher', VA('zpm'), 1200], [plates, rod, frame, fine_wire, foil, dense_plate]);
 
-    compFluid('perchloric_acid', ['1x hydrogen', '1x chlorine', '4x oxygen'], 0xffe6e6, []);
+    compLiquid('perchloric_acid', ['1x hydrogen', '1x chlorine', '4x oxygen'], 0xffe6e6, []);
 
     compDust('calcium_perchlorate', ['1x calcium', '2x chlorine', '8x oxygen'], 0xffff99, []);
 
-    compFluid('silica_gel', ['1x chlorine', '1x hydrogen', '6x oxygen', '1x silicon'], 0xe6e6e6, [no_decomp]);
+    compLiquid('silica_gel', ['1x chlorine', '1x hydrogen', '6x oxygen', '1x silicon'], 0xe6e6e6, [no_decomp]);
 
     compDust('calcium_sulfate', ['1x calcium', '1x sulfur', '4x oxygen'], 0xffbf80, []);
 
@@ -524,69 +576,54 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
 
     compDust('copper_chloride', ['1x copper', '1x chlorine'], 0xffffff, []);
 
-    compFluid('npk_solution', [], 0xb8c3f5, []);
+    compLiquid('npk_solution', [], 0xb8c3f5, []);
 
-    compFluid('cupric_chloride_solution', ['1x copper_chloride', '1x hydrochloric_acid'], 0x336600, []);
+    compLiquid('cupric_chloride_solution', ['1x copper_chloride', '1x hydrochloric_acid'], 0x336600, []);
 
     // Ores and bedrock fluids
-    const compDustFluidOre = (name, elements, color, flags) => {
-        event.create(name).dust().liquid().ore(2, 1).components(elements).color(color).flags(flag);
-    }
-    
-    const compDustOre = (name, elements, color) => {
-        event.create(name).dust().ore(2, 1).components(elements).color(color).flags(no_decomp);
-    }
-    
-    const compGemOre = (name, elements, color, icon) => {
-        event.create(name).gem().ore(2, 1).components(elements).color(color).iconSet(icon);
-    }
 
-    compDustFluidOre('titanite', ['1x calcium', '1x titanium', '1x silicon', '5x oxygen'], 0x66ffff, [no_decomp]);
+    compDustLiquidOre('titanite', ['1x calcium', '1x titanium', '1x silicon', '5x oxygen'], 0x66ffff, [no_decomp]);
 
-    compDustFluidOre('zapolite', ['2x zapolgium', '4x iodine', '2x aluminium', '5x oxygen'], 0xcc0099, [no_decomp]);
+    compDustLiquidOre('zapolite', ['2x zapolgium', '4x iodine', '2x aluminium', '5x oxygen'], 0xcc0099, [no_decomp]);
 
     compDustOre('lautarite', ['1x calcium', '2x iodine', '6x oxygen'], 0x6666ff);
 
-    compDustFluidOre('iodargyrite', ['1x silver', '1x iodine'], 0x8080ff, [no_decomp]);
+    compDustLiquidOre('iodargyrite', ['1x silver', '1x iodine'], 0x8080ff, [no_decomp]);
 
-    compDustFluidOre('clausthalite', ['1x lead', '1x selenium'], 0x666633, [no_decomp]);
+    compDustLiquidOre('clausthalite', ['1x lead', '1x selenium'], 0x666633, [no_decomp]);
 
-    compDustFluidOre('crookesite', ['7x copper', '1x thallium', '4x selenium'], 0x00ff99, [no_decomp]);
+    compDustLiquidOre('crookesite', ['7x copper', '1x thallium', '4x selenium'], 0x00ff99, [no_decomp]);
 
-    compDustFluidOre('calaverite', ['1x gold', '2x tellurium'], 0xcc9900, [no_decomp]);
+    compDustLiquidOre('calaverite', ['1x gold', '2x tellurium'], 0xcc9900, [no_decomp]);
 
-    compDustFluidOre('sylvanite', ['1x silver', '2x tellurium'], 0xff5050, [no_decomp]);
+    compDustLiquidOre('sylvanite', ['1x silver', '2x tellurium'], 0xff5050, [no_decomp]);
 
-    compDustFluidOre('tiemannite', ['1x mercury', '1x selenium'], 0xcc0066, [no_decomp]);
+    compDustLiquidOre('tiemannite', ['1x mercury', '1x selenium'], 0xcc0066, [no_decomp]);
 
     compDustOre('klockmannite', ['1x copper', '1x selenium'], 0x009999);
 
     compDustOre('stibiopalladinite', ['5x palladium', '2x antimony'], 0x333399);
 
-    compFluid('berzelianite', ['2x copper', '1x selenium'], 0x990000);
+    compDustOre('berzelianite', ['2x copper', '1x selenium'], 0x990000, []);
 
-    compFluid('umangite', ['3x copper', '2x selenium'], 0x006699);
+    compDustOre('umangite', ['3x copper', '2x selenium'], 0x006699, []);
 
-    compFluid('aguilarite', ['3x silver', '1x selenium', '1x sulfur'], 0xff5050);
+    compDustOre('aguilarite', ['3x silver', '1x selenium', '1x sulfur'], 0xff5050, []);
 
-    compDustFluidOre('strontianite', ['1x strontium', '1x carbon', '3x oxygen'], 0xe6ffff, []);
+    compDustLiquidOre('strontianite', ['1x strontium', '1x carbon', '3x oxygen'], 0xe6ffff, []);
 
     compGemOre('celestine', ['1x strontium', '1x carbon', '4x oxygen'], 0xe6ffff, GEM_VERTICAL);
 
     compDust('polybasite', ['12x silver', '4x copper', '2x arsenic', '13x sulfur'], 0xcc6600, []);
 
-    const compFluidTemp = (name, heat, elements, color, flags) => {
-        event.create(name).liquid(new GTFluidBuilder().temperature(heat)).components(elements).color(color).flags(flags);
-    }
+    compLiquidTemp('abydos_titanite_rich_magma', 3520, ['6x titanite', '2x calaverite','2x sylvanite', '2x tiemannite', '1x strontianite'], 0xe65c00, [no_decomp]);
 
-    compFluidTemp('abydos_titanite_rich_magma', 3520, ['6x titanite', '2x calaverite','2x sylvanite', '2x tiemannite', '1x strontianite'], 0xe65c00, [no_decomp]);
-
-    compFluidTemp('abydos_zapolite_rich_magma', 4980, ['7x zapolite', '3x crookesite', '2x clausthalite', '1x iodargyrite'], 0xff471a, [no_decomp]);
+    compLiquidTemp('abydos_zapolite_rich_magma', 4980, ['7x zapolite', '3x crookesite', '2x clausthalite', '1x iodargyrite'], 0xff471a, [no_decomp]);
 
     // Nether
        
         //Extended Debris
-        compDustFluid('ancient_debris', ['1x mystery'], 0x603d1a, [no_decomp]);
+        compDustLiquid('ancient_debris', ['1x mystery'], 0x603d1a, [no_decomp]);
 
         compIngot('ancient_netherite', ['4x gold','4x mystery'], 0x46271b, [], [12349, 'low', VA('uev'), 2400], [plates,rod,no_decomp]);
 
@@ -598,9 +635,9 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         compDust('activated_nether', ['1x mystery','1x mystery'], 0xA01819, [no_decomp]);
 
         //Estalt Line
-        compFluidTemp('molten_estaltadyne_mixture', 3500, ['1x mystery','1x estalt','1x mystery'], 0x8E0505, [no_decomp]);
+        compLiquidTemp('molten_estaltadyne_mixture', 3500, ['1x mystery','1x estalt','1x mystery'], 0x8E0505, [no_decomp]);
 
-        compDustFluid('estaltadyne', ['4x estalt','3x titanium','2x aluminium','5x sulfur','4x oxygen'], 0x8E0535, [no_decomp]);
+        compDustLiquid('estaltadyne', ['4x estalt','3x titanium','2x aluminium','5x sulfur','4x oxygen'], 0x8E0535, [no_decomp]);
 
         compDust('metmalic_estaltadyne', ['4x estalt','3x titanium','2x aluminium','5x sulfur'], 0x8E0560, [no_decomp]);
 
@@ -611,28 +648,28 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         compDust('estaltadyne_hydride', ['4x estalt','9x hydrogen'], 0x8E0505, [no_decomp]);
         
         //Enriched Estalt Line
-        compFluid('enriched_estaltadyne_mixture', ['1x mystery','1x enriched_estalt','1x mystery'], 0xBE4747, [no_decomp]);
+        compLiquid('enriched_estaltadyne_mixture', ['1x mystery','1x enriched_estalt','1x mystery'], 0xBE4747, [no_decomp]);
 
-        compFluid('enriched_estaltadyne_solution', ['1x mystery','1x enriched_estalt','1x mystery'], 0xBE4717, [no_decomp]);
+        compLiquid('enriched_estaltadyne_solution', ['1x mystery','1x enriched_estalt','1x mystery'], 0xBE4717, [no_decomp]);
 
-        compFluid('enriched_estaltadyne_slurry', ['1x mystery','1x enriched_estalt','1x mystery'], 0xBE4777, [no_decomp]);
+        compLiquid('enriched_estaltadyne_slurry', ['1x mystery','1x enriched_estalt','1x mystery'], 0xBE4777, [no_decomp]);
 
-        compFluid('enriched_estaltadyne_naquide_slurry_mixture', ['1x mystery','1x enriched_estalt','1x enriched_naquadah','1x mystery'], 0xBE4697, [no_decomp]);
+        compLiquid('enriched_estaltadyne_naquide_slurry_mixture', ['1x mystery','1x enriched_estalt','1x enriched_naquadah','1x mystery'], 0xBE4697, [no_decomp]);
 
-        compFluid('hyper_enriched_estaltadyne_slurry_mixture', ['1x mystery','2x enriched_estalt'], 0xBE4697, [no_decomp]);
+        compLiquid('hyper_enriched_estaltadyne_slurry_mixture', ['1x mystery','2x enriched_estalt'], 0xBE4697, [no_decomp]);
         
-        compFluid('hyper_enriched_estaltadyne_slurry_residue', ['1x mystery','2x enriched_estalt'],0xBE4677, [no_decomp]);
+        compLiquid('hyper_enriched_estaltadyne_slurry_residue', ['1x mystery','2x enriched_estalt'],0xBE4677, [no_decomp]);
 
-        compFluid('sodium_hyper_enriched_estaltadyne_sludge', ['2x sodium','1x mystery','2x enriched_estalt'], 0xBE4697, [no_decomp]);
+        compLiquid('sodium_hyper_enriched_estaltadyne_sludge', ['2x sodium','1x mystery','2x enriched_estalt'], 0xBE4697, [no_decomp]);
 
-        compFluid('hyper_enriched_estaltadyne_concentrate', ['2x enriched_estalt','1x mystery'], 0xBE4587, [no_decomp]);
+        compLiquid('hyper_enriched_estaltadyne_concentrate', ['2x enriched_estalt','1x mystery'], 0xBE4587, [no_decomp]);
         
         //Adamantine Line
-        compFluid('enriched_adamantamite_mixture', ['1x mystery','1x adamantine','1x mystery'], 0x866E4B, [no_decomp]);
+        compLiquid('enriched_adamantamite_mixture', ['1x mystery','1x adamantine','1x mystery'], 0x866E4B, [no_decomp]);
 
-        compFluidTemp('molten_adamantamite_mixture', 3700, ['1x mystery','1x adamantine','1x mystery'], 0x866E7B, [no_decomp]);
+        compLiquidTemp('molten_adamantamite_mixture', 3700, ['1x mystery','1x adamantine','1x mystery'], 0x866E7B, [no_decomp]);
 
-        compDustFluid('adamantamite', ['5x adamantine','4x titanium','2x iron','6x nitrogen','12x oxygen'], 0x825F2B, [no_decomp]);
+        compDustLiquid('adamantamite', ['5x adamantine','4x titanium','2x iron','6x nitrogen','12x oxygen'], 0x825F2B, [no_decomp]);
 
         compDust('adamantamite_metaltide', ['5x adamantine','4x titanium','2x iron','6x nitrogen'], 0x8F611E, [no_decomp]);
 
@@ -645,11 +682,11 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         compDust('adamantine_hydroxide', ['1x adamantine','3x hydrogen','3x oxygen'], 0xCB8858, [no_decomp]);
         
         //Mythril Line
-        compFluid('enriched_mythrillic_mixture', ['1x mystery','1x mythril','1x mystery'], 0x238213, [no_decomp]);
+        compLiquid('enriched_mythrillic_mixture', ['1x mystery','1x mythril','1x mystery'], 0x238213, [no_decomp]);
         
-        compFluidTemp('molten_mythrillic_mixture', 3100, ['1x mystery','1x mythril','1x mystery'], 0x238342, [no_decomp]);
+        compLiquidTemp('molten_mythrillic_mixture', 3100, ['1x mystery','1x mythril','1x mystery'], 0x238342, [no_decomp]);
 
-        compDustFluid('mythrillic', ['6x mythril','6x carbon','14x hydrogen','3x zirconium','2x vanadium'], 0x238362, [no_decomp]);
+        compDustLiquid('mythrillic', ['6x mythril','6x carbon','14x hydrogen','3x zirconium','2x vanadium'], 0x238362, [no_decomp]);
 
         compDust('mythrillic_carbinide', ['6x mythril','6x carbon','3x zirconium','2x vanadium'], 0x238441, [no_decomp]);
 
@@ -660,728 +697,348 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         compDust('mythrillic_hydride', ['1x mythril','2x hydrogen'], 0x238338, [no_decomp]);
         
         // Calamatium/Isovol Line
-        compFluid('impure_calamatium_solution', [], 0x990000, []);
+        compLiquid('impure_calamatium_solution', [], 0x990000, []);
 
-        compFluid('impure_isovol_solution', [], 0x000066, []);
+        compLiquid('impure_isovol_solution', [], 0x000066, []);
 
-        compFluid('calamatium_solution', [], 0xe60000, []);
+        compLiquid('calamatium_solution', [], 0xe60000, []);
 
-        event.create('isovol_solution')
-            .fluid()
-            .color(0x6600cc);
+        compLiquid('isovol_solution', [], 0x6600cc, []);
 
-        event.create('calamatium_fluoride')
-            .dust()
-            .components(['1x calamatium', '2x fluorine'])
-            .color(0xcc0066)
-            .flags([no_decomp]);
+        compDust('calamatium_fluoride', ['1x calamatium', '2x fluorine'], 0xcc0066, [no_decomp]);
 
-        event.create('isovol_fluoride')
-            .dust()
-            .components(['1x isovol', '2x fluorine'])
-            .color(0x9900ff)
-            .flags([no_decomp]);
+        compDust('isovol_fluoride', ['1x isovol', '2x fluorine'], 0x9900ff, [no_decomp]);
 
         // Magmas
-        event.create('highly_unstable_nether_magma')
-            .liquid(new GTFluidBuilder().temperature(9001))
-            .components('1x mystery')
-            .color(0xFFA025)
-            .flags(no_decomp);
+        compLiquidTemp('highly_unstable_nether_magma', 9001, ['1x mystery'], 0xFFA025, [no_decomp]);
 
-        event.create('magmatic')
-            .plasma(new GTFluidBuilder().temperature(14600))
-            .components('1x mystery','1x iron','1x mystery')
-            .color(0xFFD39A)
-            .flags(no_decomp);
+        compLiquidTemp('magmatic', 14600, ['1x mystery','1x iron','1x mystery'], 0xFFD39A, [no_decomp]);
 
-        event.create('debris_rich_nether_magma')
-            .liquid(new GTFluidBuilder().temperature(7600))
-            .components('1x mystery')
-            .color(0x6C3628)
-            .flags(no_decomp);
+        compLiquidTemp('debris_rich_nether_magma', 7600, ['1x mystery'], 0x6C3628, [no_decomp]);
  
-        event.create('mythrillic_nether_magma')
-            .liquid(new GTFluidBuilder().temperature(9299))
-            .components('1x mystery','1x mythril','1x mystery')
-            .color(0x238383)
-            .flags(no_decomp);
+        compLiquidTemp('mythrillic_nether_magma', 9299, ['1x mystery','1x mythril','1x mystery'], 0x238383, [no_decomp]);
 
-        event.create('adamantamite_nether_magma')
-            .liquid(new GTFluidBuilder().temperature(11299))
-            .components('1x mystery','1x adamantine','1x mystery')
-            .color(0x826944)
-            .flags(no_decomp);
+        compLiquidTemp('adamantamite_nether_magma', 11299, ['1x mystery','1x adamantine','1x mystery'], 0x826944, [no_decomp]);
 
-        event.create('estaltadyne_nether_magma')
-            .liquid(new GTFluidBuilder().temperature(10299))
-            .components('1x mystery','1x estalt','1x mystery')
-            .color(0xA92323)
-            .flags(no_decomp);
+        compLiquidTemp('estaltadyne_nether_magma', 10299, ['1x mystery','1x estalt','1x mystery'], 0xA92323, [no_decomp]);
 
-        event.create('mystical_nether_magma')
-            .liquid(new GTFluidBuilder().temperature(11600))
-            .components('1x mystery','1x adamantine','1x mystery','1x estalt','1x mystery','1x mythril','1x mystery')
-            .color(0xF26B87)
-            .flags(no_decomp);
+        compLiquidTemp('mystical_nether_magma', 11600, ['1x mystery','1x adamantine','1x mystery','1x estalt','1x mystery','1x mythril','1x mystery'], 0xF26B87 ,[no_decomp]);
         
-        event.create('enriched_mystical_concentrate')
-            .liquid(new GTFluidBuilder().temperature(1260))
-            .components('1x mystery','1x adamantine','1x mystery','1x enriched_estalt','1x mystery','1x mythril','1x mystery')
-            .color(0xF26B87)
-            .flags(no_decomp);
+        compLiquidTemp('enriched_mystical_concentrate', 1260, ['1x mystery','1x adamantine','1x mystery','1x enriched_estalt','1x mystery','1x mythril','1x mystery'], 0xF26B87, [no_decomp]);
 
     // End
 
-    // Titanite(Zirconium) Line
-    event.create('titanite_slurry')
-        .fluid()
-        .components('1x titanite', '1x mystery')
-        .color(0x862d2d)
-        .flags(no_decomp);
+    // Abydos
+        // Titanite(Zirconium) Line
+        compLiquid('titanite_slurry', ['1x titanite', '1x mystery'], 0x862d2d, [no_decomp]);
 
-    event.create('titanite_slurry_residue')
-        .fluid()
-        .components('1x rutile', '1x mystery')
-        .color(0xbf4040)
-        .flags(no_decomp);
+        compLiquid('titanite_slurry_residue', ['1x rutile', '1x mystery'], 0xbf4040, [no_decomp]);
 
-    event.create('hydroxo_dioxo_titanite_mixture')
-        .fluid()
-        .components('2x sodium', '1x rutile', '2x oxygen', '2x hydrogen', '1x mystery')
-        .color(0xd27979)
-        .flags(no_decomp);
+        compLiquid('hydroxo_dioxo_titanite_mixture', ['2x sodium', '1x rutile', '2x oxygen', '2x hydrogen', '1x mystery'], 0xd27979, [no_decomp]);
 
-    event.create('titanite_residue')
-        .fluid()
-        .components('1x rutile', '1x mystery')
-        .color(0xe6004c)
-        .flags(no_decomp);
+        compLiquid('titanite_residue', ['1x rutile', '1x mystery'], 0xe6004c, [no_decomp]);
 
-    event.create('titanium_tetrachloride_mixture')
-        .fluid()
-        .components('1x titanium_tetrachloride', '1x mystery')
-        .color(0xff1a66)
-        .flags(no_decomp);
+        compLiquid('titanium_tetrachloride_mixture', ['1x titanium_tetrachloride', '1x mystery'], 0xff1a66, [no_decomp]);
 
-    event.create('zirconium_tetrachloride')
-        .dust()
-        .components('1x zirconium', '4x chlorine')
-        .color(0xffad33)
-        .flags(no_decomp);
+        compDust('zirconium_tetrachloride', ['1x zirconium', '4x chlorine'], 0xffad33, [no_decomp]);
 
-    // Zapolite(Zapolgium) line
-    event.create('zapolgium_aluminium_oxide')
-        .dust()
-        .components('1x zapolgium', '2x iodine', '2x aluminium', '4x oxygen')
-        .color(0x6666ff)
-        .flags(no_decomp);
+        // Zapolite(Zapolgium) line
+        compDust('zapolgium_aluminium_oxide', ['1x zapolgium', '2x iodine', '2x aluminium', '4x oxygen'], 0x6666ff, [no_decomp]);
 
-    event.create('zapolgium_diiodide_dioxide')
-        .dust()
-        .components('1x zapolgium', '2x iodine', '2x oxygen')
-        .color(0x660066)
-        .flags(no_decomp);
+        compDust('zapolgium_diiodide_dioxide', ['1x zapolgium', '2x iodine', '2x oxygen'], 0x660066, [no_decomp]);
 
-    event.create('zapolgium_diiodide_oxide')
-        .dust()
-        .components('1x zapolgium', '2x iodine', '1x oxygen')
-        .color(0xff66ff)
-        .flags(no_decomp);
+        compDust('zapolgium_diiodide_oxide', ['1x zapolgium', '2x iodine', '1x oxygen'], 0xff66ff, [no_decomp]);
 
-    event.create('zapolgium_oxide')
-        .dust()
-        .components('1x zapolgium', '1x oxygen')
-        .color(0xff9933)
-        .flags(no_decomp);
+        compDust('zapolgium_oxide', ['1x zapolgium', '1x oxygen'], 0xff9933, [no_decomp]);
 
-    event.create('zapolgium_chloride')
-        .dust()
-        .components('1x zapolgium', '2x chlorine')
-        .color(0x99ff33)
-        .flags(no_decomp);
+        compDust('zapolgium_chloride', ['1x zapolgium', '2x chlorine'], 0x99ff33, [no_decomp]);
 
-    event.create('zapolgium_hydroxide')
-        .dust()
-        .components('1x zapolgium', '2x oxygen', '2x hydrogen')
-        .color(0x00ff99)
-        .flags(no_decomp);
+        compDust('zapolgium_hydroxide', ['1x zapolgium', '2x oxygen', '2x hydrogen'], 0x00ff99, [no_decomp]);
 
-    // Alloys and other compounds
-    event.create('zalloy')
-        .ingot()
-        .fluid()
-        .components('3x zapolgium', '4x duranium', '2x europium')
-        .color(0xff66ff)
-        .iconSet(METALLIC)
-        .blastTemp(10799, 'highest', VA('luv'), 6000)
-        .flags(plates, frame, rod, bolt_and_screw, round, long_rod, gear, small_gear, ring)
-        .cableProperties(V('uv'), 2, 4, false);
+        // Alloys and other compounds
+        conductor('zalloy', ['3x zapolgium', '4x duranium', '2x europium'], 0xff66ff, METALLIC, [10799, 'highest', VA('luv'), 6000], [V('uv'), 2, 4, false], [plates, frame, rod, bolt_and_screw, round, long_rod, gear, small_gear, ring]);
 
-    event.create('zirconium_selenide_diiodide')
-        .ingot()
-        .fluid()
-        .components('1x zirconium', '1x selenium', '2x iodine')
-        .color(0x6600cc)
-        .iconSet(DULL)
-        .flags(spring)
-        .blastTemp(8900, 'higher', VA('luv'), 4000)
-        .cableProperties(V('uhv'), 8, 16, false);
+        conductor('zirconium_selenide_diiodide', ['1x zirconium', '1x selenium', '2x iodine'], 0x6600cc, DULL, [8900, 'higher', VA('luv'), 4000], [V('uhv'), 8, 16, false], [spring]);
 
-    event.create('indium_tin_lead_cadmium_soldering_alloy')
-        .ingot()
-        .fluid()
-        .components('14x indium', '3x tin', '2x lead', '1x cadmium')
-        .color(0xa6a6a6)
-        .iconSet(DULL);
+        compIngotLiquid('zircalloy_4', ['251x zirconium', '3x tin', '2x chromium', '1x iron'], 0xff9999, DULL, [8900, 'higher', VA('luv'), 2000], [gear, small_gear, rotor]);
 
-    event.create('zircalloy_4')
-        .ingot()
-        .fluid()
-        .components('251x zirconium', '3x tin', '2x chromium', '1x iron')
-        .color(0xff9999)
-        .iconSet(DULL)
-        .blastTemp(8900, 'higher', VA('luv'), 2000)
-        .flags(gear, small_gear, rotor);
+        conductor('iron_selenide_over_strontium_titanium_oxide', ['1x iron_selenide', '1x strontium_titanium_oxide'], 0x66ff33, DULL, [10299, 'highest', VA('uv'), 2500], [V('uhv'), 4, 12, false], [fine_wire, bolt_and_screw]);
 
-    event.create('iron_selenide_over_strontium_titanium_oxide')
-        .ingot()
-        .components('1x iron_selenide', '1x strontium_titanium_oxide')
-        .color(0x66ff33)
-        .iconSet(DULL)
-        .flags(fine_wire, bolt_and_screw)
-        .blastTemp(10299, 'highest', VA('uv'), 2500)
-        .cableProperties(V('uhv'), 4, 12, false);
+    // Misc
+    compIngotLiquid('indium_tin_lead_cadmium_soldering_alloy', ['14x indium', '3x tin', '2x lead', '1x cadmium'], 0xa6a6a6, DULL, [], []);
 
-    event.create('star_steel')
-        .ingot()
-        .fluid()
-        .components('2x steel', '1x mystery')
-        .color(0xccffcc)
-        .flags(no_decomp, plates, rod, frame)
-        .iconSet(METALLIC);
+    compIngotLiquid('star_steel', ['2x steel', '1x mystery'], 0xccffcc, METALLIC, [], [no_decomp, plates, rod, frame]);
 
-    event.create('thorium_plut_duranide_241')
-        .ingot()
-        .fluid()
-        .components('4x thorium', '1x duranium', '3x plutonium_241')
-        .color(0xEC342A)
-        .flags(fine_wire, no_decomp, foil)
-        .blastTemp(10199, 'highest', VA('uv'), 850)
+    compIngotLiquid('thorium_plut_duranide_241',  ['4x thorium', '1x duranium', '3x plutonium_241'], 0xEC342A, [], [10199, 'highest', VA('uv'), 850], [fine_wire, no_decomp, foil]);
 
     // PEEK plastic Line
+    compDust('disodium_salt_of_hydroquinone', ['6x carbon','4x hydrogen','2x oxygen','2x sodium'], 0xeaeaf9, no_decomp);
 
-    event.create('disodium_salt_of_hydroquinone')
-        .dust()
-        .components('6x carbon','4x hydrogen','2x oxygen','2x sodium')
-        .color(0xeaeaf9)
-        .flags(no_decomp);
+    compDust('hydroquinone', ['6x carbon','6x hydrogen','2x oxygen'], 0xf9f9ff, []);
 
-    event.create('hydroquinone')
-        .dust()
-        .components('6x carbon','6x hydrogen','2x oxygen')
-        .color(0xf9f9ff);
+    compGas('carbon_acid', ['2x hydrogen','1x carbon','3x oxygen'], 0x333333, [no_decomp]);
 
-    event.create('carbon_acid')
-        .gas()
-        .components('2x hydrogen','1x carbon','3x oxygen')
-        .color(0x333333)
-        .flags(no_decomp);
+    compLiquid('fluorobenzene', ['6x carbon','5x hydrogen','1x fluorine'], 0xffffff, []);
 
-    event.create('fluorobenzene')
-        .fluid()
-        .components('6x carbon','5x hydrogen','1x fluorine')
-        .color(0xffffff);
-
-    event.create('4_fluorobenzoyl_chloride')
-        .fluid()
-        .components('7x carbon','4x hydrogen','1x chlorine','1x fluorine','1x oxygen')
-        .color(0xfffff0);
+    compLiquid('4_fluorobenzoyl_chloride', ['7x carbon','4x hydrogen','1x chlorine','1x fluorine','1x oxygen'], 0xfffff0, []);
     
-    event.create('benzoyl_chloride')
-        .fluid()
-        .components('7x carbon','5x hydrogen','1x chlorine','1x oxygen')
-        .color(0xfffadf);
+    compLiquid('benzoyl_chloride', ['7x carbon','5x hydrogen','1x chlorine','1x oxygen'], 0xfffadf, []);
 
-    event.create('benzotrichloride')
-        .fluid()
-        .components('7x carbon','5x hydrogen','3x chlorine')
-        .color(0xddd8bc);
+    compLiquid('benzotrichloride', ['7x carbon','5x hydrogen','3x chlorine'], 0xddd8bc, []);
 
-    event.create('44_difluorobenzophenone') //naming like this: 4_4_di... will make kubejs go error to annoy you :)
-        .dust()
-        .components('13x carbon','8x hydrogen','1x oxygen','2x fluorine') 
-        .color(0xeee1c9)
-        .flags(no_decomp);
+    compDust('44_difluorobenzophenone', ['13x carbon','8x hydrogen','1x oxygen','2x fluorine'], 0xeee1c9 ,[no_decomp]); //naming like this: 4_4_di... will make kubejs go error to annoy you :)
     
-    event.create('polyether_ether_ketone')
-        .fluid()
-        .polymer()
-        .components('19x carbon','12x hydrogen','3x oxygen') 
-        .color(0xccbba7)
-        .flags(no_decomp)
-        .flags(foil, plates, ring, plates)
-        .fluidPipeProperties(550, 600, true, true, true, false);
+    polymerFluid('polyether_ether_ketone', ['19x carbon','12x hydrogen','3x oxygen'], 0xccbba7, [550, 600, true, true, true, false], [foil, plates, ring, plates, no_decomp]);
     
     // SiC/Bi2Te3 Line
+    compDust('sodium_borohydride', ['1x sodium','1x boron','4x hydrogen'], 0xE3DEC8, []);
 
-    event.create('sodium_borohydride')
-        .dust()
-        .components('1x sodium','1x boron','4x hydrogen')
-        .color(0xE3DEC8);
+    compGas('nitrate', ['1x nitrogen', '3x oxygen'], 0xDBC365, []);
 
-    event.create('nitrate')
-        .gas()
-        .components('1x nitrogen', '3x oxygen')
-        .color(0xDBC365);
+    compDust('bismuth_3_nitrate', ['1x bismuth', '3x nitrate'], 0xDEDBCD, []);
 
-    event.create('bismuth_3_nitrate')
-        .dust()
-        .components('1x bismuth', '3x nitrate')
-        .color(0xDEDBCD);
+    compDust('sodium_nitrate', ['1x sodium','1x nitrogen','3x oxygen'], 0xE6E5E5, []);
 
-    event.create('sodium_nitrate')
-        .dust()
-        .components('1x sodium','1x nitrogen','3x oxygen')
-        .color(0xE6E5E5);
+    compGas('diborane', ['2x boron','6x hydrogen'], 0xFDFFE1, []);
 
-    event.create('diborane')
-        .gas()
-        .components('2x boron','6x hydrogen')
-        .color(0xFDFFE1);
-
-    event.create('silicon_carbide')
-        .dust()
-        .components('1x silicon', '1x carbon')
-        .color(0xB79F8D);
+    compDust('silicon_carbide', ['1x silicon', '1x carbon'], 0xB79F8D, []);
         
-    event.create('bismuth_tritelluride')
-        .dust()
-        .components('2x bismuth', '3x tellurium')
-        .color(0xDEB18E);
+    compDust('bismuth_tritelluride', ['2x bismuth', '3x tellurium'], 0xDEB18E, []);
 
-    event.create('silicon_carbide_over_bismuth_tritelluride')
-        .dust()
-        .components('1x silicon_carbide', '1x bismuth_tritelluride')
-        .color(0x86C455);
+    compDust('silicon_carbide_over_bismuth_tritelluride', ['1x silicon_carbide', '1x bismuth_tritelluride'], 0x86C455, []);
 
-//Hexafluorobromic Acid
+    //Hexafluorobromic Acid
+    compDustIcon('nickel_fluoride', ['1x nickel', '2x fluorine'], 0xA7A9A8, METALLIC, []);
 
-    event.create('nickel_fluoride')
-        .dust()
-        .components('1x nickel', '2x fluorine')
-        .color(0xA7A9A8)
-        .iconSet(METALLIC);
+    compDustIcon('caesium_fluoride', ['1x caesium', '1x fluorine'], 0x969D9B, DULL, []);
 
-    event.create('caesium_fluoride')
-        .dust()
-        .components('1x caesium', '1x fluorine')
-        .color(0x969D9B)
-        .iconSet(DULL);
-
-    event.create('bromine_pentafluoride')
-        .fluid()
-        .components('1x bromine', '5x fluorine')
-        .color(0x8E6565);
+    compLiquid('bromine_pentafluoride', ['1x bromine', '5x fluorine'], 0x8E6565, []);
      
-    event.create('hexafluorobromine')
-        .fluid()
-        .components('1x bromine', '6x fluorine')
-        .color(0x000000)
-        .flags(no_decomp);
+    compLiquid('hexafluorobromine', ['1x bromine', '6x fluorine'], 0x000000, [no_decomp]);
 
-    event.create('caesium_hexafluorobromine')
-        .fluid()
-        .components('1x caesium', '1x hexafluorobromine')
-        .color(0x988585)
-        .flags(no_decomp);
+    compLiquid('caesium_hexafluorobromine', ['1x caesium', '1x hexafluorobromine'], 0x988585 ,[no_decomp]);
 
-    event.create('hexafluorobromic_acid')
-        .fluid()
-        .components('1x hydrogen', '1x hexafluorobromine')
-        .color(0xA15E5E)
-        .flags(no_decomp);
+    compLiquid('hexafluorobromic_acid', ['1x hydrogen', '1x hexafluorobromine'], 0xA15E5E, [no_decomp]);
 
-//ANSD Line
-const InitialLoadAnsdFluid = (name,components,color) => {
-    event.create(`${name}`).fluid().color(color).components(components).flags(no_decomp);
-}
-const InitialLoadAnsdFluidDecomps = (name,components,color) => {
-    event.create(`${name}`).fluid().color(color).components(components);
-}
-const InitialLoadAnsdDust = (name,components,color) => {
-    event.create(`${name}`).dust().color(color).components(components).flags(no_decomp);
-}
-const InitialLoadAnsdDustDecomps = (name,components,color) => {
-    event.create(`${name}`).dust().color(color).components(components);
-}
-const AnsdFluid = (name,components,color) => {
-    event.create(`${name}`).fluid().color(color).components(components).flags(no_decomp);
-}
-const AnsdDust = (name,components,color) => {
-    event.create(`${name}`).dust().color(color).components(components).flags(no_decomp);
-}
-const AnsdFluidDecomps = (name,components,color) => {
-    event.create(`${name}`).fluid().color(color).components(components);
-}
-const AnsdDustDecomps = (name,components,color) => {
-    event.create(`${name}`).dust().color(color).components(components);
-}
-const ComplexAnsdFluid = (name,components,color) => {
-    event.create(`${name}`).fluid().color(color).components(components).flags(no_decomp);
-}
-const ComplexAnsdDust = (name,components,color) => {
-    event.create(`${name}`).dust().color(color).components(components).flags(no_decomp);
-}
+    //ANSD Line
+    compDust('sulfate', ['1x sulfur', '4x oxygen'], 0xD5BA23, []);
 
-InitialLoadAnsdDustDecomps('sulfate', ['1x sulfur', '4x oxygen'], 0xD5BA23);  
-InitialLoadAnsdDust('silicate', ['1x silicon', '4x oxygen'], 0xC0BA97);  
-InitialLoadAnsdDust('pyrophosphate', ['2x phosphorus', '7x oxygen'], 0xC08B63);  
-InitialLoadAnsdDust('sulfur_hexafluoride', ['1x sulfur', '6x fluorine'], 0xC0BA63);  
-InitialLoadAnsdDust('plutonium_octofluoride', ['2x plutonium', '8x fluorine'], 0x000000);      
-InitialLoadAnsdFluid('uranium_tetrafluoride', ['1x uranium', '4x fluorine'], 0x6CAB3F);      
-InitialLoadAnsdFluidDecomps('hydroxide',['1x oxygen','1x hydrogen'],0xC0D4DD);
-AnsdFluid('caesium_oganesson_hexanitrate', ['2x caesium', '1x oganesson', '6x nitrate'], 0x769192);      
-AnsdFluid('caesium_oganesson_trioxide', ['2x caesium', '1x oganesson', '3x oxygen'], 0x4E7577);      
-AnsdFluidDecomps('caesium_nitrate', ['1x caesium', '1x nitrogen', '3x oxygen'], 0x7C8A8B);      
-AnsdFluid('oganesson_tetranitrate', ['1x oganesson', '4x nitrate'], 0x948FAD);      
-AnsdDust('magnesium_hydroxide', ['1x magnesium', '2x hydroxide'], 0x766B73);      
-AnsdDust('hafnium_thorium_iron_2_hydroxide_potassium_disilicate', ['1x hafnium', '1x thorium', '1x iron', '2x hydroxide', '4x potassium', '2x silicate'], 0x618782);      
-AnsdDust('iron_2_hydroxide', ['1x iron', '2x hydroxide'], 0x929A98);      
-AnsdDust('hafnium_thorium_octachloride', ['1x hafnium', '1x thorium', '8x chlorine'], 0x637770);      
-AnsdDust('thorium_dioxide', ['1x thorium', '2x oxygen'], 0x384F47);      
-AnsdDust('hafnium_dioxide', ['1x hafnium', '2x oxygen'], 0x88A1A0);      
-AnsdDust('sodium_hafnate', ['2x sodium', '1x hafnium', '3x oxygen'], 0x8894A1);      
-AnsdDust('barium_diastatide', ['1x barium', '2x astatine'], 0x665058);      
-AnsdDust('barium_hydroxide', ['1x barium', '2x hydroxide'], 0xB5AC9B);      
-AnsdDustDecomps('barium_carbonate', ['1x barium', '1x carbon', '3x oxygen'], 0x9B8F77);  
-AnsdDust('sodium_astatide', ['1x sodium', '1x astatine'], 0x5F5076);
-AnsdFluid('hydroastatic_acid', ['1x hydrogen', '1x astatine'], 0xB56C5B);
-AnsdFluid('silicic_acid', ['4x hydrogen', '1x silicate'], 0xB4BBBE);    
-AnsdDust('seaborgium_cerium_tricarbon_octasulfate', ['1x seaborgium', '1x cerium', '3x carbon', '8x sulfate'], 0x75A99E);
-AnsdDust('cerium_4_sulfate', ['1x cerium', '2x sulfate'], 0x828685);
-AnsdDustDecomps('chromium_sulfate', ['2x chromium', '3x sulfate'], 0xEEE9DB);
-AnsdDustDecomps('cerium_dioxide', ['1x cerium', '2x oxygen'], 0xB9CFDB);
-AnsdDust('seaborgium_trisulfate', ['1x seaborgium', '3x sulfate'], 0x8AA89B);
-AnsdDust('seaborgium_trioxide', ['1x seaborgium', '3x oxygen'], 0x4B827B);
-AnsdDust('sodium_seaborgate', ['2x sodium', '1x seaborgium', '4x oxygen'], 0x298B80);
-AnsdDust('seaborgium_dioxide', ['1x seaborgium', '2x oxygen'], 0x12A190);
-AnsdDust('hafnium_hexachloride', ['1x hafnium', '6x chlorine'], 0xA0A8A6);      
-AnsdDust('hafnium_thorium_iron_magnesium_disilicate_monosulfate', ['1x hafnium', '1x thorium', '1x iron', '2x magnesium', '2x silicate', '1x sulfate'], 0x98B4B0);      
-AnsdDust('seaborgium_cerium_tricarbon_tetrakis_orthosilicate', ['1x seaborgium', '1x cerium', '3x carbon', '4x silicate'], 0x268075);      
-AnsdDust('iron_2_barium_diastatide_trisulfate', ['2x iron', '1x barium', '2x astatine', '3x sulfate'], 0x9EB286);      
-AnsdDust('dipolonium_diplatinum_tris_pyrophosphate', ['2x polonium', '2x platinum', '3x pyrophosphate'], 0xA0664D);
-AnsdDust('flerovium_hexadecafluoride_di_sulfur_trioxide', ['1x flerovium', '2x sulfur_trioxide', '16x fluorine'], 0x36413F);
-AnsdDustDecomps('silver_sulfate', ['2x silver', '1x sulfate'], 0xD4CF91);
-AnsdDust('flerovium_hexadecafluoride', ['1x flerovium', '16x fluorine'], 0x5A6759);
-AnsdDust('flerovium_tetrafluoride', ['1x flerovium', '4x fluorine'], 0x254722);
-AnsdDust('polonium_pyrophosphate', ['1x polonium', '1x pyrophosphate'], 0x356231);
-AnsdFluid('pyrophosphoric_acid', ['4x hydrogen', '1x pyrophosphate'], 0xB3A36D);
-AnsdFluid('orthophosphoric_acid', ['3x hydrogen', '1x phosphorus', '4x oxygen'], 0xD5C385);
-AnsdDustDecomps('sodium_phosphate', ['3x sodium', '1x phosphorus', '4x oxygen'], 0x819BC8);
-AnsdDust('polonium_tetrachloride', ['1x polonium', '4x chlorine'], 0x357C44);
-AnsdDust('polonium_hydroxide', ['1x polonium', '4x hydroxide'], 0x0E5A1F);
-AnsdDust('polonium_carbonate', ['1x polonium', '1x carbon', '3x oxygen'], 0x2F5637);
-ComplexAnsdDust('flerovium_hexaoxide_octafluorosulfatoplutonate', ['1x flerovium', '6x oxygen', '2x sulfur_hexafluoride', '2x plutonium_octofluoride'], 0x582914);      
-ComplexAnsdFluid('caesium_oganesson_hexanitrate_tetrafluorouranate', ['2x caesium', '1x oganesson', '6x nitrate', '2x uranium_tetrafluoride'], 0x427A21);      
-ComplexAnsdDust('hafnium_thorium_iron_magnesium_disilicate_monosulfate_bonded_iron_2_barium_diastatide_trisulfate', ['1x hafnium_thorium_iron_magnesium_disilicate_monosulfate', '1x iron_2_barium_diastatide_trisulfate'], 0x6A8B9A);      
-ComplexAnsdDust('seaborgium_cerium_tricarbon_tetrakis_orthosilicate_linked_dipolonium_diplatinum_tris_pyrophosphate', ['1x seaborgium_cerium_tricarbon_tetrakis_orthosilicate', '1x dipolonium_diplatinum_tris_pyrophosphate'], 0x526A48);      
-ComplexAnsdDust('flerovium_hexaoxide_octafluorosulfatoplutonate_enriched_rare_earth', ['1x flerovium_hexaoxide_octafluorosulfatoplutonate', '6x mystery'], 0x6A4852);      
+    compDust('silicate', ['1x silicon', '4x oxygen'], 0xC0BA97, [no_decomp]);
 
-// Large Multis
-const largeMulti = (name,components,color) => {
-    event.create(`${name}`)
-        .ingot()
-        .components(components)
-        .color(color)
-        .flags(plates, frame, rod)
-        .iconSet(DULL)
-        .blastTemp(2200, 'low', VA('mv'), 2000);
-}
+    compDust('pyrophosphate', ['2x phosphorus', '7x oxygen'], 0xC08B63, [no_decomp]);
 
-largeMulti('birmabright', ['7x aluminium', '2x magnesium', '1x manganese'], 0xbfbfbf);  
-largeMulti('duralumin', ['4x aluminium', '3x copper', '1x magnesium', '1x manganese'], 0x66ccff);  
-largeMulti('hydronalium', ['6x aluminium', '3x magnesium', '1x manganese'], 0x660000);  
-largeMulti('beryllium_aluminium_alloy', ['7x beryllium', '1x aluminium'], 0x006699);  
-largeMulti('elgiloy', ['4x cobalt', '2x chromium', '1x nickel', '1x steel', '1x molybdenum', '1x manganese'], 0xff00ff);  
-largeMulti('beryllium_bronze', ['10x copper', '1x beryllium'], 0x003300);  
-largeMulti('silicon_bronze', ['32x copper', '2x silicon', '1x manganese'], 0x1a1a1a);  
-largeMulti('kovar', ['18x iron', '11x nickel', '6x cobalt'], 0x000080);  
-largeMulti('zamak', ['1x zinc', '4x aluminium', '3x copper'], 0x8c8c8c);  
-largeMulti('tumbaga', ['20x copper', '6x gold', '1x silver'], 0xffdb4d);  
+    compDust('sulfur_hexafluoride', ['1x sulfur', '6x fluorine'], 0xC0BA63, [no_decomp]);
+
+    compDust('plutonium_octofluoride', ['2x plutonium', '8x fluorine'], 0x000000, [no_decomp]);
+
+    compLiquid('uranium_tetrafluoride', ['1x uranium', '4x fluorine'], 0x6CAB3F, [no_decomp]);
+
+    compLiquid('hydroxide',['1x oxygen','1x hydrogen'],0xC0D4DD, []);
+
+    compLiquid('caesium_oganesson_hexanitrate', ['2x caesium', '1x oganesson', '6x nitrate'], 0x769192, [no_decomp]);
+
+    compLiquid('caesium_oganesson_trioxide', ['2x caesium', '1x oganesson', '3x oxygen'], 0x4E7577, [no_decomp]);
+
+    compLiquid('caesium_nitrate', ['1x caesium', '1x nitrogen', '3x oxygen'], 0x7C8A8B, []);
+
+    compLiquid('oganesson_tetranitrate', ['1x oganesson', '4x nitrate'], 0x948FAD, [no_decomp]);
+
+    compDust('magnesium_hydroxide', ['1x magnesium', '2x hydroxide'], 0x766B73, [no_decomp]);
+
+    compDust('hafnium_thorium_iron_2_hydroxide_potassium_disilicate', ['1x hafnium', '1x thorium', '1x iron', '2x hydroxide', '4x potassium', '2x silicate'], 0x618782, [no_decomp]);
+
+    compDust('iron_2_hydroxide', ['1x iron', '2x hydroxide'], 0x929A98, [no_decomp]);
+
+    compDust('hafnium_thorium_octachloride', ['1x hafnium', '1x thorium', '8x chlorine'], 0x637770, [no_decomp]);
+
+    compDust('thorium_dioxide', ['1x thorium', '2x oxygen'], 0x384F47, [no_decomp]);
+
+    compDust('hafnium_dioxide', ['1x hafnium', '2x oxygen'], 0x88A1A0, [no_decomp]);
+
+    compDust('sodium_hafnate', ['2x sodium', '1x hafnium', '3x oxygen'], 0x8894A1, [no_decomp]);
+
+    compDust('barium_diastatide', ['1x barium', '2x astatine'], 0x665058, [no_decomp]);
+
+    compDust('barium_hydroxide', ['1x barium', '2x hydroxide'], 0xB5AC9B, [no_decomp]);
+
+    compDust('barium_carbonate', ['1x barium', '1x carbon', '3x oxygen'], 0x9B8F77, []);
+
+    compDust('sodium_astatide', ['1x sodium', '1x astatine'], 0x5F5076, [no_decomp]);
+
+    compLiquid('hydroastatic_acid', ['1x hydrogen', '1x astatine'], 0xB56C5B, [no_decomp]);
+
+    compLiquid('silicic_acid', ['4x hydrogen', '1x silicate'], 0xB4BBBE, [no_decomp]);
+
+    compDust('seaborgium_cerium_tricarbon_octasulfate', ['1x seaborgium', '1x cerium', '3x carbon', '8x sulfate'], 0x75A99E, [no_decomp]);
+
+    compDust('cerium_4_sulfate', ['1x cerium', '2x sulfate'], 0x828685, [no_decomp]);
+
+    compDust('chromium_sulfate', ['2x chromium', '3x sulfate'], 0xEEE9DB, []);
+
+    compDust('cerium_dioxide', ['1x cerium', '2x oxygen'], 0xB9CFDB, []);
+
+    compDust('seaborgium_trisulfate', ['1x seaborgium', '3x sulfate'], 0x8AA89B, [no_decomp]);
+
+    compDust('seaborgium_trioxide', ['1x seaborgium', '3x oxygen'], 0x4B827B, []);
+
+    compDust('sodium_seaborgate', ['2x sodium', '1x seaborgium', '4x oxygen'], 0x298B80, [no_decomp]);
+
+    compDust('seaborgium_dioxide', ['1x seaborgium', '2x oxygen'], 0x12A190, [no_decomp]);
+
+    compDust('hafnium_hexachloride', ['1x hafnium', '6x chlorine'], 0xA0A8A6, [no_decomp]);
+
+    compDust('hafnium_thorium_iron_magnesium_disilicate_monosulfate', ['1x hafnium', '1x thorium', '1x iron', '2x magnesium', '2x silicate', '1x sulfate'], 0x98B4B0, [no_decomp]);
+
+    compDust('seaborgium_cerium_tricarbon_tetrakis_orthosilicate', ['1x seaborgium', '1x cerium', '3x carbon', '4x silicate'], 0x268075, [no_decomp]);
+
+    compDust('iron_2_barium_diastatide_trisulfate', ['2x iron', '1x barium', '2x astatine', '3x sulfate'], 0x9EB286, [no_decomp]);
+
+    compDust('dipolonium_diplatinum_tris_pyrophosphate', ['2x polonium', '2x platinum', '3x pyrophosphate'], 0xA0664D, [no_decomp]);
+
+    compDust('flerovium_hexadecafluoride_di_sulfur_trioxide', ['1x flerovium', '2x sulfur_trioxide', '16x fluorine'], 0x36413F, [no_decomp]);
+
+    compDust('silver_sulfate', ['2x silver', '1x sulfate'], 0xD4CF91, []);
+
+    compDust('flerovium_hexadecafluoride', ['1x flerovium', '16x fluorine'], 0x5A6759, [no_decomp]);
+
+    compDust('flerovium_tetrafluoride', ['1x flerovium', '4x fluorine'], 0x254722, [no_decomp]);
+
+    compDust('polonium_pyrophosphate', ['1x polonium', '1x pyrophosphate'], 0x356231, [no_decomp]);
+
+    compLiquid('pyrophosphoric_acid', ['4x hydrogen', '1x pyrophosphate'], 0xB3A36D, [no_decomp]);
+
+    compLiquid('orthophosphoric_acid', ['3x hydrogen', '1x phosphorus', '4x oxygen'], 0xD5C385, [no_decomp]);
+
+    compDust('sodium_phosphate', ['3x sodium', '1x phosphorus', '4x oxygen'], 0x819BC8, []);
+
+    compDust('polonium_tetrachloride', ['1x polonium', '4x chlorine'], 0x357C44, [no_decomp]);
+
+    compDust('polonium_hydroxide', ['1x polonium', '4x hydroxide'], 0x0E5A1F, [no_decomp]);
+
+    compDust('polonium_carbonate', ['1x polonium', '1x carbon', '3x oxygen'], 0x2F5637, [no_decomp]);
+
+    compDust('flerovium_hexaoxide_octafluorosulfatoplutonate', ['1x flerovium', '6x oxygen', '2x sulfur_hexafluoride', '2x plutonium_octofluoride'], 0x582914, [no_decomp]);
+
+    compLiquid('caesium_oganesson_hexanitrate_tetrafluorouranate', ['2x caesium', '1x oganesson', '6x nitrate', '2x uranium_tetrafluoride'], 0x427A21, [no_decomp]);
+
+    compDust('hafnium_thorium_iron_magnesium_disilicate_monosulfate_bonded_iron_2_barium_diastatide_trisulfate', ['1x hafnium_thorium_iron_magnesium_disilicate_monosulfate', '1x iron_2_barium_diastatide_trisulfate'], 0x6A8B9A, [no_decomp]);
+
+    compDust('seaborgium_cerium_tricarbon_tetrakis_orthosilicate_linked_dipolonium_diplatinum_tris_pyrophosphate', ['1x seaborgium_cerium_tricarbon_tetrakis_orthosilicate', '1x dipolonium_diplatinum_tris_pyrophosphate'], 0x526A48, [no_decomp]);
+
+    compDust('flerovium_hexaoxide_octafluorosulfatoplutonate_enriched_rare_earth', ['1x flerovium_hexaoxide_octafluorosulfatoplutonate', '6x mystery'], 0x6A4852, [no_decomp]);
+
+    // Large Multis
+    const largeMulti = (name,components,color) => {
+        compIngot(name, components, color, DULL, [2200, 'low', VA('mv'), 2000], [plates, frame, rod]);
+    }
+
+    largeMulti('birmabright', ['7x aluminium', '2x magnesium', '1x manganese'], 0xbfbfbf);  
+    largeMulti('duralumin', ['4x aluminium', '3x copper', '1x magnesium', '1x manganese'], 0x66ccff);  
+    largeMulti('hydronalium', ['6x aluminium', '3x magnesium', '1x manganese'], 0x660000);  
+    largeMulti('beryllium_aluminium_alloy', ['7x beryllium', '1x aluminium'], 0x006699);  
+    largeMulti('elgiloy', ['4x cobalt', '2x chromium', '1x nickel', '1x steel', '1x molybdenum', '1x manganese'], 0xff00ff);  
+    largeMulti('beryllium_bronze', ['10x copper', '1x beryllium'], 0x003300);  
+    largeMulti('silicon_bronze', ['32x copper', '2x silicon', '1x manganese'], 0x1a1a1a);  
+    largeMulti('kovar', ['18x iron', '11x nickel', '6x cobalt'], 0x000080);  
+    largeMulti('zamak', ['1x zinc', '4x aluminium', '3x copper'], 0x8c8c8c);  
+    largeMulti('tumbaga', ['20x copper', '6x gold', '1x silver'], 0xffdb4d);  
 
     // Ultimate (Akreyrium-Tier-Start) Multiblocks
-        
-    // Thallium-Tungstate and intermediates
-    event.create('thallium_tungstate')
-        .dust()
-        .iconSet(DULL)
-        .components('2x thallium', '1x tungsten', '4x oxygen')
-        .color(0xE3D18A);
 
-    event.create('tungsten_trioxide')
-        .dust()
-        .iconSet(DULL)
-        .components('1x tungsten', '3x oxygen')
-        .color(0xADB426);
+    // Thallium-Tungstate and intermediates
+    compDustIcon('thallium_tungstate', ['2x thallium', '1x tungsten', '4x oxygen'], 0xe3d18a, DULL, []);
+
+    compDustIcon('tungsten_trioxide', ['1x tungsten', '3x oxygen'], 0xadb426, DULL, []);
 
     // Boron Nitride and intermediates
-    event.create('boron_nitride')
-        .dust()
-        .iconSet(DULL)
-        .components('1x boron', '1x nitrogen')
-        .color(0xD4C4A0);
+    compDustIcon('boron_nitride', ['1x boron', '1x nitrogen'], 0xD4C4A0, DULL, []);
 
-    event.create('boron_trioxide')
-        .dust()
-        .iconSet(DULL)
-        .components('2x boron', '3x oxygen')
-        .color(0xDACABB);
+    compDustIcon('boron_trioxide', ['2x boron', '3x oxygen'], 0xDACABB, DULL, []);
 
     // Hastelloy X Upgrade
-    event.create('astrenalloy_nx')
-        .ingot()
-        .fluid()
-        .components('1x hastelloy_x', '4x enriched_naquadah', '3x zirconium', '6x tantalum_carbide', '4x osmiridium', '3x boron_nitride')
-        .color(0x63478e)
-        .iconSet(SHINY)
-        .blastTemp(10090, 'highest', VA('uv'), 2800)
-        .flags(plates, rod, frame);
+    compIngotLiquid('astrenalloy_nx', ['1x hastelloy_x', '4x enriched_naquadah', '3x zirconium', '6x tantalum_carbide', '4x osmiridium', '3x boron_nitride'], 0x63478e, SHINY, [10090, 'highest', VA('uv'), 2800], [plates, rod, frame]);
     
     // Incoloy MA-956 upgrade
-    event.create('thacoloy_nq_42x')
-        .ingot()
-        .fluid()
-        .components('6x incoloy_ma_956', '4x enriched_naquadah', '2x niobium_titanium', '4x osmiridium', '4x thallium_tungstate')
-        .color(0x467624)
-        .iconSet(SHINY)
-        .blastTemp(10090, 'highest', VA('zpm'), 3400)
-        .flags(plates, rod, frame);
+    compIngotLiquid('thacoloy_nq_42x', ['6x incoloy_ma_956', '4x enriched_naquadah', '2x niobium_titanium', '4x osmiridium', '4x thallium_tungstate'], 0x467624, SHINY, [10090, 'highest', VA('zpm'), 3400], [plates, rod, frame]);
 
 
     // Akreyium Line
-    
-    event.create('utopian_akreyrium')
-        .fluid()
-        .element(GTElements.get('akreyrium'))
-        .color(0xFFFFFF);
+    elemFluid('utopian_akreyrium', 'akreyrium', 0xffffff, []);
 
-    event.create('lepton_coalescing_superalloy')
-        .ingot()
-        .fluid()
-        .dust()
-        .iconSet(DULL)
-        .components('4x thallium_tungstate', '2x nickel', '4x graphene', '3x niobium', '4x bismuth')
-        .flags(foil)
-        .blastTemp(5300, 'high', VA('luv'), 1400)
-        .color(0xe1ccff);
+    compIngotLiquid('lepton_coalescing_superalloy', ['4x thallium_tungstate', '2x nickel', '4x graphene', '3x niobium', '4x bismuth'], 0xe1ccff, DULL ,[5300, 'high', VA('luv'), 1400], [foil]);
 
-    event.create('lepton_sparse_akreyrium')
-        .fluid()
-        .flags(no_decomp)
-        .components('1x utopian_akreyrium', '1x mystery')
-        .color(0x6E6E87);
+    compLiquid('lepton_sparse_akreyrium', ['1x utopian_akreyrium', '1x mystery'], 0x6E6E87, [no_decomp]);
 
-    event.create('lepton_flux_akreyrium')
-        .fluid()
-        .flags(no_decomp)
-        .components('1x utopian_akreyrium', '6x lepton_coalescing_superalloy', '1x mystery')
-        .color(0xaca2ba);
+    compLiquid('lepton_flux_akreyrium', ['1x utopian_akreyrium', '6x lepton_coalescing_superalloy', '1x mystery'], 0xaca2ba, [no_decomp]);
 
-    event.create('gritty_akreyrium')
-        .fluid()
-        .flags(no_decomp)
-        .components('1x utopian_akreyrium', '1x mystery')
-        .color(0x464655);
+    compLiquid('gritty_akreyrium', ['1x utopian_akreyrium', '1x mystery'], 0x464655, [no_decomp]);
 
-    event.create('akreyrium_pcb_graphite_nanoparticle_coolant')
-        .fluid()
-        .components('5x pcb_coolant', '2x utopian_akreyrium', '32x graphite')
-        .color(0x676763);
+    compLiquid('akreyrium_pcb_graphite_nanoparticle_coolant', ['5x pcb_coolant', '2x utopian_akreyrium', '32x graphite'], 0x676763, []);
     
     // Akreyrium Variants
-    event.create('lepton_flavour_foundational_flux')
-        .fluid()
-        .flags(no_decomp)
-        .components('6x lepton_coalescing_superalloy', '1x mystery')
-        .color(0xE5CEE1);
+    compLiquid('lepton_flavour_foundational_flux', ['6x lepton_coalescing_superalloy', '1x mystery'], 0xe5cee1, [no_decomp]);
     
     // Tau
-    event.create('light_tau_infusion_flux')
-        .fluid()
-        .flags(no_decomp)
-        .components('1x mystery')
-        .color(0xE5CEE1);
+    compLiquid('light_tau_infusion_flux', ['1x mystery'], 0xe5cee1, [no_decomp]);
 
-    event.create('heavy_tau_infusion_flux')
-        .fluid()
-        .flags(no_decomp)
-        .components('1x light_tau_infusion_flux')
-        .color(0xDFDAE9);
+    compLiquid('heavy_tau_infusion_flux', ['1x light_tau_infusion_flux'], 0xdfdae9, [no_decomp]);
 
-    event.create('superlight_tau_infusion_flux')
-        .fluid()
-        .flags(no_decomp)
-        .components('1x light_tau_infusion_flux')
-        .color(0xD9E7F0);
+    compLiquid('superlight_tau_infusion_flux', ['1x light_tau_infusion_flux'], 0xd9e7f0, [no_decomp]);
 
-    event.create('superheavy_tau_infusion_flux')
-        .fluid()
-        .flags(no_decomp)
-        .components('1x heavy_tau_infusion_flux')
-        .color(0xCCFFFF);
+    compLiquid('superheavy_tau_infusion_flux', ['1x heavy_tau_infusion_flux'], 0xccffff ,[no_decomp]);
 
-    event.create('ethereal_tau_infusion_flux')
-        .fluid()
-        .flags(no_decomp)
-        .components('2x superheavy_tau_infusion_flux', '2x superlight_tau_infusion_flux')
-        .color(0x99CCFF);
+    compLiquid('ethereal_tau_infusion_flux', ['2x superheavy_tau_infusion_flux', '2x superlight_tau_infusion_flux'], 0x99ccff, [no_decomp]);
 
-    event.create('sparse_tau_akreyrium')
-        .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
-        .flags(no_decomp)
-        .components('1x utopian_akreyrium', '1x mystery')
+    compLiquidStill('sparse_tau_akreyrium', ['1x utopian_akreyrium', '1x mystery'], [no_decomp])
 
-    event.create('dense_tau_akreyrium')
-        .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
-        .flags(no_decomp)
-        .components('1x utopian_akreyrium', '1x mystery', '1x ethereal_tau_infusion_flux')
+    compLiquidStill('dense_tau_akreyrium', ['1x utopian_akreyrium', '1x mystery', '1x ethereal_tau_infusion_flux'], [no_decomp])
 
     // Muon
-    event.create('twinkling_muon_infusion_flux')
-        .fluid()
-        .flags(no_decomp)
-        .components('1x mystery')
-        .color(0xDDD8DC);
+    compLiquid('twinkling_muon_infusion_flux', ['1x mystery'], 0xddd8dc, [no_decomp]);
 
-    event.create('glowing_muon_infusion_flux')
-        .fluid()
-        .flags(no_decomp)
-        .components('1x mystery')
-        .color(0xD5E1D6);
+    compLiquid('glowing_muon_infusion_flux', ['1x mystery'], 0xd5e1d6, [no_decomp]);
 
-    event.create('shining_muon_infusion_flux')
-        .fluid()
-        .flags(no_decomp)
-        .components('1x mystery')
-        .color(0xCDEBD1);
+    compLiquid('shining_muon_infusion_flux', ['1x mystery'], 0xcdebd1, [no_decomp]);
 
-    event.create('radiant_muon_infusion_flux')
-        .fluid()
-        .flags(no_decomp)
-        .components('1x mystery')
-        .color(0xC5F4CB);
+    compLiquid('radiant_muon_infusion_flux', ['1x mystery'], 0xc5f4Cb, [no_decomp]);
 
-    event.create('brilliant_muon_infusion_flux')
-        .fluid()
-        .flags(no_decomp)
-        .components('1x mystery')
-        .color(0xBDFEC6);
+    compLiquid('brilliant_muon_infusion_flux', ['1x mystery'], 0xbdfec6, [no_decomp]);
 
-    event.create('sparse_muon_akreyrium')
-        .flags(no_decomp)
-        .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
-        .components('1x utopian_akreyrium', '1x mystery')
+    compLiquidStill('sparse_muon_akreyrium', ['1x utopian_akreyrium', '1x mystery'], [no_decomp])
 
-    event.create('dense_muon_akreyrium')
-        .flags(no_decomp)
-        .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
-        .components('1x utopian_akreyrium', '1x mystery', 'brilliant_muon_infusion_flux')
-
+    compLiquidStill('dense_muon_akreyrium', ['1x utopian_akreyrium', '1x mystery', 'brilliant_muon_infusion_flux'], [no_decomp])
 
     // Electron
+    compLiquid('mono_phase_electron_infusion_flux', ['1x mystery'], 0xe0c5f6, [no_decomp]);
 
-    event.create('mono_phase_electron_infusion_flux')
-        .fluid()
-        .flags(no_decomp)
-        .components('1x mystery')
-        .color(0xE0C5F6);
+    compDust('di_phase_electron_infusion_agent', ['1x mystery'], 0xe0bded, [no_decomp]);
 
-    event.create('di_phase_electron_infusion_agent')
-        .dust()
-        .flags(no_decomp)
-        .components('1x mystery')
-        .color(0xE0BDED);
+    compDustIcon('tri_phase_electron_infusion_agent', ['1x mystery'], 0xdfb6e4, MAGNETIC, [no_decomp]);
 
-    event.create('tri_phase_electron_infusion_agent')
-        .dust()
-        .flags(no_decomp)
-        .iconSet(MAGNETIC)
-        .components('1x mystery')
-        .color(0xDFB6E4);
+    compDustIcon('weak_gamma_phase_electron_infusion_agent', ['1x mystery'], 0x856783, MAGNETIC, [no_decomp]);
 
-    event.create('weak_gamma_phase_electron_infusion_agent')
-        .dust()
-        .flags(no_decomp)
-        .iconSet(MAGNETIC)
-        .components('1x mystery')
-        .color(0x856783);
+    compDustIcon('weak_beta_phase_electron_infusion_agent', ['1x mystery'], 0x6b4f66, MAGNETIC, [no_decomp]);
 
-    event.create('weak_beta_phase_electron_infusion_agent')
-        .dust()
-        .flags(no_decomp)
-        .iconSet(MAGNETIC)
-        .components('1x mystery')
-        .color(0x6b4f66);
+    compDustIcon('gamma_phase_electron_infusion_agent', ['1x mystery'], 0xdeafdc, MAGNETIC, [no_decomp]);
 
-    event.create('gamma_phase_electron_infusion_agent')
-        .dust()
-        .flags(no_decomp)
-        .iconSet(MAGNETIC)
-        .components('1x mystery')
-        .color(0xDEAFDC);
+    compDustIcon('beta_phase_electron_infusion_agent', ['1x mystery'], 0xdda8d3, MAGNETIC, [no_decomp]);
 
-    event.create('beta_phase_electron_infusion_agent')
-        .dust()
-        .flags(no_decomp)
-        .iconSet(MAGNETIC)
-        .components('1x mystery')
-        .color(0xDDA8D3);
+    compDustIcon('alpha_phase_electron_infusion_agent', ['1x mystery'], 0xdc99c1, MAGNETIC, [no_decomp]);
 
-    event.create('alpha_phase_electron_infusion_agent')
-        .dust()
-        .flags(no_decomp)
-        .iconSet(MAGNETIC)
-        .components('1x mystery')
-        .color(0xDC99C1);
+    compLiquid('alternating_phase_electron_infusion_flux', ['1x mystery'], 0xdeadb3, [no_decomp]);
 
-    event.create('alternating_phase_electron_infusion_flux')
-        .fluid()
-        .flags(no_decomp)
-        .components('1x mystery')
-        .color(0xDEADB3);
+    compLiquidStill('sparse_electron_akreyrium', ['1x utopian_akreyrium', '1x mystery'], [no_decomp]);
 
-    event.create('sparse_electron_akreyrium')
-        .flags(no_decomp)
-        .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
-        .components('1x utopian_akreyrium', '1x mystery');
+    compLiquidStill('dense_electron_akreyrium', ['1x utopian_akreyrium', '1x mystery', 'alternating_phase_electron_infusion_flux'], [no_decomp]);
 
-    event.create('dense_electron_akreyrium')
-        .flags(no_decomp)
-        .liquid(new GTFluidBuilder().state(GTFluidState.LIQUID).customStill())
-        .components('1x utopian_akreyrium', '1x mystery', 'alternating_phase_electron_infusion_flux')
+    // Resource Gen
+    compLiquid('brackish_water', ['1x water', '1x mystery'], 0x459ea4, [no_decomp]);
 
-    //EPSILON Resource Gen stuff
-    function liquid(name, color, composition){
-        event.create(name)
-            .fluid()
-            .components(composition)
-            .color(color)
-            .flags(no_decomp);
-    };
-
-    function dust(name, color, composition){
-        event.create(name)
-            .dust()
-            .color(color)
-            .components(composition) 
-            .flags(no_decomp);
-    };
-
-    liquid('brackish_water', 0x459EA4, ['1x water', '1x mystery'])
-    liquid('iron_mixture', 0xC42626, '1x mystery');
-    liquid('copper_mixture', 0xC86524, '1x mystery');
-    liquid('quartz_mixture', 0xABC5E0, '1x mystery');
+    compLiquid('iron_mixture', ['1x mystery'], 0xc42626, [no_decomp]);
+    
+    compLiquid('copper_mixture', ['1x mystery'], 0xc86524, [no_decomp]);
+    
+    compLiquid('quartz_mixture', ['1x mystery'], 0xabc5e0, [no_decomp]);
 
     /*/reflective metal
     event.create('reflective_metal')
@@ -1392,172 +1049,90 @@ largeMulti('tumbaga', ['20x copper', '6x gold', '1x silver'], 0xffdb4d);
         .iconSet(DULL)
         .blastTemp(2000, 'low', VA('mv'), 600);*/
 
-    liquid('rare_ore_residue', 0x556278, '1x mystery');
+    compLiquid('rare_ore_residue', ['1x mystery'], 0x556278, [no_decomp]);
 
-    dust('chromite_sludge', 0x4C3C4C, ['2x chromite', '1x mystery']);
-    dust('rare_sludge', 0xCCEC94, ['1x mystery']);
-    dust('vanadium_magnetite_sludge', 0x1C1C2C, ['2x vanadium_magnetite', '1x mystery']);
-    dust('cobaltite_sludge', 0x6186BB, ['2x cobaltite', '1x mystery']);
+    compDust('chromite_sludge', ['2x chromite', '1x mystery'], 0x4c3c4c, [no_decomp]);
 
-    dust('rare_metallic_residue', 0x515755, ['1x silver', '2x calcite'])
+    compDust('rare_sludge', ['1x mystery'], 0xceec94, [no_decomp]);
 
-    liquid('raw_ore_slurry', 0x7B8087, '1x mystery');
-    liquid('mixed_mineral_residue', 0x566E6E, '1x mystery');
-    liquid('sulfuric_mineral_mixture', 0xE34f1E, '1x mystery');
-    liquid('oxygenous_mineral_mixture', 0x359696, '1x mystery');
+    compDust('vanadium_magnetite_sludge', ['2x vanadium_magnetite', '1x mystery'], 0x1c1c2c, [no_decomp]);
+
+    compDust('cobaltite_sludge', ['2x cobaltite', '1x mystery'], 0x6186bb, [no_decomp]);
+
+    compDust('rare_metallic_residue', ['1x silver', '2x calcite'], 0x515755, [no_decomp])
+
+    compLiquid('raw_ore_slurry', ['1x mystery'], 0x7b8087, [no_decomp]);
+
+    compLiquid('mixed_mineral_residue', ['1x mystery'], 0x566e6e, [no_decomp]);
+
+    compLiquid('sulfuric_mineral_mixture', ['1x mystery'], 0xe34f1e, [no_decomp]);
+
+    compLiquid('oxygenous_mineral_mixture', ['1x mystery'], 0x359696, [no_decomp]);
     
-
     //molten ores
-    function moltenore(name, color, composition, temp){
-        event.create(`molten_${name}`)
-            .liquid(new GTFluidBuilder().temperature(temp))
-            .components(composition)
-            .color(color)
-            .flags(no_decomp);
-    };
-    moltenore('ore_mixture', 0x575050, '1x mystery', 1273);
-    moltenore('bauxite_ore', 0xB5B69A, '1x bauxite', 1160);
-    moltenore('pitchblende_ore', 0xAFC585, '1x pitchblende', 1160);
-    moltenore('molybdenite_ore', 0xC1D0A4, '1x molybdenite', 1160);
-    moltenore('ilmenite_ore', 0xCBA88F, '1x ilmenite', 1160);
-    moltenore('tungstate_ore', 0x9CACB1, '1x tungstate', 1160);
-    moltenore('bastnasite_ore',0x988E84, '1x bastnasite', 1160);
-    moltenore('cooperite_ore', 0xA4A38B, '1x cooperite', 1160);
+    compLiquidTemp('ore_mixture', 1273, ['1x mystery'], 0x575050, [no_decomp]);
+    
+    compLiquidTemp('bauxite_ore', 1160, ['1x bauxite'], 0xB5B69A, [no_decomp]);
+    
+    compLiquidTemp('pitchblende_ore', 1160, ['1x pitchblende'], 0xAFC585, [no_decomp]);
+    
+    compLiquidTemp('molybdenite_ore', 1160, ['1x molybdenite'], 0xC1D0A4, [no_decomp]);
+    
+    compLiquidTemp('ilmenite_ore', 1160, ['1x ilmenite'], 0xCBA88F, [no_decomp]);
+    
+    compLiquidTemp('tungstate_ore', 1160, ['1x tungstate'], 0x9CACB1, [no_decomp]);
+    
+    compLiquidTemp('bastnasite_ore', 1160, ['1x bastnasite'],0x988E84, [no_decomp]);
+    
+    compLiquidTemp('cooperite_ore', 1160, ['1x cooperite'], 0xA4A38B, [no_decomp]);
 
-    event.create('purified_naquadah')
-        .gem()
-        .color(0x000807)
-        .element(GTElements.get('purified_naquadah')) 
-        .flags(no_decomp);
+    elemGem('purified_naquadah', 0x000807, [], [no_decomp]);
 
-    event.create('indium_oxide')
-        .dust()
-        .color(0xE3D28E)
-        .components('2x indium', '3x oxygen');
+    compDust('indium_oxide', ['2x indium', '3x oxygen'], 0xe3d28e, []);
 
     //nether star line essences
-    liquid('blitz', 0xFDF3C4, '1x mystery');
-    liquid('blizz', 0xB4EFFA, '1x mystery');
-    liquid('basalz', 0x6F190E, '1x mystery');
+    compLiquid('blitz', ['1x mystery'], 0xfdf3c4, [no_decomp]);
+    
+    compLiquid('blizz', ['1x mystery'], 0xb4effa, [no_decomp]);
+    
+    compLiquid('basalz', ['1x mystery'], 0x6f190e, [no_decomp]);
 
     //UEV Materials
-    event.create('nether_star_concentrate')
-        .components('1x mystery')
-        .fluid()
-        .color(0xEEEEEE)
-        .flags(no_decomp);
+    compLiquid('nether_star_concentrate', ['1x mystery'], 0xeeeeee, [no_decomp]);
 
-    event.create('aurourium')
-        .components('1x mystery')
-        .ingot()
-        .fluid()
-        .color(0x5D44DE)
-        .secondaryColor(0xDE44CE)
-        .iconSet(SHINY)
-        .flags(no_decomp, fine_wire, no_smelt);
+    compIngotLiquidSeccolor('aurourium', ['1x mystery'], 0x5d44de, 0xde44ce, SHINY, [], [no_decomp, fine_wire, no_smelt]);
        
-    event.create('cerium_tritelluride')
-        .ingot()
-        .components('1x cerium', '3x tellurium')
-        .color(0x6D8B5D)
-        .iconSet(DULL)
-        .blastTemp(11699, 'highest', VA('uhv'), 1800)
-        .flags(bolt_and_screw,spring,small_spring)
-        .cableProperties(V('uev'), 6, 16, false);
+    conductor('cerium_tritelluride', ['1x cerium', '3x tellurium'], 0x6d8B5d, DULL, [11699, 'highest', VA('uhv'), 1800], [V('uev'), 6, 16, false], [bolt_and_screw,spring,small_spring]);
 
-    event.create('bec_og')
-        .components('1x oganesson')
-        .liquid(new GTFluidBuilder().temperature(0.0001))
-        .color(0xBFACFF)
-        .flags(no_decomp);
+    compLiquidTemp('bec_og', 0.0001, ['1x oganesson'], 0xbfacff, [no_decomp]);
 
-    event.create('superstate_helium_3')
-        .components('1x helium_3')
-        .liquid(new GTFluidBuilder().temperature(2))
-        .color(0xEDFAF5)
-        .flags(no_decomp);
-
-    event.create('magmada_alloy')
-        .components('4x adamantine', '1x neutronium', '3x tungsten')
-        .ingot()
-        .fluid()
-        .plasma()
-        .color(0xDA8607)
-        .blastTemp(15049, 'highest', VA('uev'), 3600)
-        .iconSet(SHINY)
-        .flags(plates, frame, rod, bolt_and_screw, round, long_rod, gear, small_gear, ring, no_decomp, rotor, no_abs_recipe)
-        .cableProperties(V('uhv'), 1, 3, false);
+    compLiquidTemp('superstate_helium_3', 2, ['1x helium_3'], 0xedfaf5, [no_decomp]);
+    
+    conductorPlasma('magmada_alloy', ['4x adamantine', '1x neutronium', '3x tungsten'], 0xda8607, SHINY, [15049, 'highest', VA('uev'), 3600], [V('uhv'), 1, 3, false], [plates, frame, rod, bolt_and_screw, round, long_rod, gear, small_gear, ring, no_decomp, rotor, no_abs_recipe]);
 
     event.create('mythrolic_alloy')
         .components('5x mythril', '2x osmium', '2x tantalum', '1x iridium')
         .ingot()
         .fluid()
         .plasma()
-        .color(0x30956C)
+        .color(0x30956c)
         .blastTemp(14999, 'highest', VA('uev'), 3600)
         .iconSet(SHINY)
         .fluidPipeProperties(120000, 6000, true,true,true,true)
         .flags(plates, frame, rod, bolt_and_screw, round, long_rod, gear, small_gear, rotor, ring, foil, no_decomp, no_abs_recipe);
 
-    event.create('starium_alloy')
-        .components('4x mystery', '2x estalt', '2x pure_netherite')
-        .ingot()
-        .fluid()
-        .plasma()
-        .color(0x2253D2)
-        .blastTemp(15199, 'highest', VA('uev'), 3600)
-        .iconSet(SHINY)
-        .flags(plates, frame, rod, bolt_and_screw, round, long_rod, gear, small_gear, ring, no_decomp, no_abs_recipe);
+    compIngotPlasma('starium_alloy', ['4x mystery', '2x estalt', '2x pure_netherite'], 0x2253d2, SHINY, [15199, 'highest', VA('uev'), 3600], [plates, frame, rod, bolt_and_screw, round, long_rod, gear, small_gear, ring, no_decomp, no_abs_recipe]);
 
-    event.create('seaborgium_palladium_enriched_estalt_flerovium_alloy')
-        .ingot()
-        .fluid()
-        .plasma()
-        .components('4x seaborgium', '8x palladium', '3x enriched_estalt', '2x flerovium')
-        .color(0x73022B)
-        .iconSet(DULL)
-        .flags(no_decomp, no_abs_recipe)
-        .blastTemp(15469, 'highest', VA('uev'), 1800)
-        .cableProperties(V('uev'), 32, 0, true);
+    conductorPlasma('seaborgium_palladium_enriched_estalt_flerovium_alloy', ['4x seaborgium', '8x palladium', '3x enriched_estalt', '2x flerovium'], 0x73022b, DULL, [15469, 'highest', VA('uev'), 1800], [V('uev'), 32, 0, true], [no_decomp, no_abs_recipe]);
 
-    event.create('iron_titanium_oxide')
-        .dust()
-        .components('3x iron', '2x titanium', '7x oxygen')
-        .flags(no_decomp)
-        .color(0x82229B);
+    compDust('iron_titanium_oxide', ['3x iron', '2x titanium', '7x oxygen'], 0x82229b, [no_decomp]);
 
-    event.create('astatine_bis_tritelluride_cobo_selenium')
-        .dust()
-        .components('1x astatine', '1x bismuth_tritelluride', '4x cobalt', '2x selenium')
-        .flags(no_decomp)
-        .color(0x123718);
+    compDust('astatine_bis_tritelluride_cobo_selenium', ['1x astatine', '1x bismuth_tritelluride', '4x cobalt', '2x selenium'], 0x123718, [no_decomp]);
 
-    event.create('astatium_bioselex_carbonite')
-        .ingot()
-        .fluid()
-        .components('1x astatine', '2x bismuth', '3x selenium', '2x thallium', '4x sulfur', '1x carbon')
-        .color(0x305F84)
-        .iconSet(DULL)
-        .flags(spring, no_decomp)
-        .blastTemp(14900, 'highest', VA('uv'), 4000)
-        .cableProperties(V('uev'), 3, 16, false);
+    conductor('astatium_bioselex_carbonite', ['1x astatine', '2x bismuth', '3x selenium', '2x thallium', '4x sulfur', '1x carbon'], 0x305f84, DULL, [14900, 'highest', VA('uv'), 4000], [V('uev'), 3, 16, false] ,[spring, no_decomp]);
 
-    event.create('astatine_bis_tritelluride_cobo_selenium_over_iron_titanium_oxide')
-        .ingot()
-        .components('1x astatine_bis_tritelluride_cobo_selenium', 'iron_titanium_oxide')
-        .color(0xE61485)
-        .iconSet(DULL)
-        .flags(fine_wire, bolt_and_screw)
-        .blastTemp(14799, 'highest', VA('uhv'), 2500)
-        .cableProperties(V('uev'), 2, 12, false);
+    conductor('astatine_bis_tritelluride_cobo_selenium_over_iron_titanium_oxide', ['1x astatine_bis_tritelluride_cobo_selenium', 'iron_titanium_oxide'], 0xe61485, DULL, [14799, 'highest', VA('uhv'), 2500], [V('uev'), 2, 12, false], [fine_wire, bolt_and_screw]);
 
     //UIV Materials
-    event.create('polonium_bismide')
-        .ingot()
-        .components('1x polonium', '1x bismuth')
-        .color(0x016038)
-        .iconSet(DULL)
-        .blastTemp(14400, 'highest', VA('uev'), 1800)
-        .flags(bolt_and_screw,spring,small_spring)
-        .cableProperties(V('uiv'), 5, 24, false);
+    conductor('polonium_bismide', ['1x polonium', '1x bismuth'], 0x016038, DULL, [14400, 'highest', VA('uev'), 1800], [V('uiv'), 5, 24, false], [bolt_and_screw,spring,small_spring]);
 });

--- a/kubejs/startup_scripts/materials/materials.js
+++ b/kubejs/startup_scripts/materials/materials.js
@@ -214,21 +214,28 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
 
     // Plasmas
 
+    // This material is meant to place a ? symbol in a material's chemical formula
+    event.create('mystery')
+        .element(GTElements.get('mystery'));
+
     // Material modification
-    GTMaterials.Lead.addFlags(gear);
-    GTMaterials.Silver.addFlags(gear);
-    GTMaterials.Naquadah.addFlags(dense_plate);
-    GTMaterials.NaquadahEnriched.addFlags(dense_plate, rotor, gear, frame, long_rod);
-    GTMaterials.Naquadria.addFlags(dense_plate);
-    GTMaterials.Neutronium.addFlags(foil, small_gear,rotor);
-    GTMaterials.Europium.addFlags(small_spring);
-    GTMaterials.Zirconium.addFlags(fine_wire);
-    GTMaterials.Hafnium.addFlags(fine_wire); 
-    GTMaterials.RedSteel.addFlags(rod, frame);
-    GTMaterials.SterlingSilver.addFlags(rod, frame);
-    GTMaterials.NetherStar.addFlags(foil);
-    GTMaterials.Netherite.addFlags(no_decomp);
-    GTMaterials.EchoShard.addFlags(lens);
+    const matmod = (mat, flag) => {
+        GTMaterials.get(mat).addFlags(flag);
+    }
+    matmod('lead', gear);
+    matmod('silver', gear);
+    matmod('naquadah', dense_plate);
+    matmod('enriched_naquadah', [dense_plate, rotor, gear, frame, long_rod]);
+    matmod('naquadria', dense_plate);
+    matmod('neutronium', [foil, small_gear,rotor]);
+    matmod('europium', small_spring);
+    matmod('zirconium', fine_wire);
+    matmod('hafnium', fine_wire);
+    matmod('red_steel', [rod, frame]);
+    matmod('sterling_silver', [rod, frame]);
+    matmod('nether_star', foil);
+    matmod('netherite', no_decomp);
+    matmod('echo_shard', lens);
 
     // Blast Properties of periodic table metals
     const blast = global.blastProperty;
@@ -245,12 +252,150 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
     GTMaterials.NaquadahEnriched.setProperty(PropertyKey.FLUID_PIPE, new FluidPipeProperties(8000, 500, true, true, true, false));
 
     // Materials from elements
-    event.create('magnetic_zapolgium')
-        .ingot()
-        .element(GTElements.get('zapolgium'))
-        .color(0xcc00cc)
-        .iconSet(MAGNETIC)
-        .flags(rod, long_rod, magnetic);
+    const compIngot = (name, elements, color, icon, blasting, flags) => {
+        if (blasting.includes(blasting[0])){
+            event.create(name).ingot()
+                .composition(elements)
+                .color(color)
+                .iconSet(icon)
+                .flags(flags)
+                .blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]);
+        } else {
+            event.create(name).ingot().fluid()
+                .composition(elements)
+                .color(color)
+                .iconSet(icon)
+                .flags(flags);
+        }
+    }
+
+    const elemIngot = (name, element, color, icon, blasting, flags) => {
+        if (blasting.includes(blasting[0])){
+            event.create(name).ingot()
+                .element(GTElements.get(element))
+                .color(color)
+                .iconSet(icon)
+                .flags(flags)
+                .blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]);
+        } else {
+            event.create(name).ingot().fluid()
+                .element(GTElements.get(element))
+                .color(color)
+                .iconSet(icon)
+                .flags(flags);
+        }
+    }
+
+    const compIngotFluid = (name, elements, color, icon, blasting, flags) => {
+        if (blasting.includes(blasting[0])){
+            event.create(name).ingot().fluid()
+                .components(elements).color(color)
+                .iconSet(icon)
+                .flags(flags)
+                .blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]);
+        } else {
+            event.create(name).ingot().fluid()
+                .components(elements)
+                .color(color)
+                .iconSet(icon)
+                .flags(flags);
+        }
+    }
+
+    const elemIngotFluid = (name, color, icon, blasting, flags) => {
+        if (blasting.includes(blasting[0])){
+            event.create(name).ingot().fluid()
+                .element(GTElements.get(name))
+                .color(color).iconSet(icon)
+                .flags(flags)
+                .blastTemp(blasting[0], blasting[1], blasting[2], blasting[3]);
+        } else {
+            event.create(name).ingot().fluid()
+                .element(GTElements.get(name))
+                .color(color)
+                .iconSet(icon)
+                .flags(flags);
+        }
+    }
+    
+    const compFluid = (name, elements, color, flags) => {
+        event.create(name).fluid()
+            .composition(elements)
+            .color(color)
+            .flags(flags);
+    }
+
+    const elemFluid = (name, color, flags) => {
+        event.create(name).fluid()
+            .element(GTElements.get(name))
+            .color(color)
+            .flags(flags);
+    }
+    
+    const compDustFluid = (name, elements, color, flags) => {
+        event.create(name).dust().fluid()
+            .composition(elements)
+            .color(color)
+            .flags(flags);
+    }
+
+    const elemDustFluid = (name, color, flags) => {
+        event.create(name).dust().fluid()
+            .element(GTElements.get(name))
+            .color(color)
+            .flags(flags);
+    }
+    
+    const compDust = (name, elements, color, flags) => {
+        event.create(name).dust()
+            .composition(elements)
+            .color(color)
+            .flags(flags);
+    }
+
+    const elemDust = (name, color, flags) => {
+        event.create(name).dust()
+            .element(GTElements.get(name))
+            .color(color)
+            .flags(flags);
+    }
+    
+    const compGem = (name, elements, color, icon, flags) => {
+        event.create(name).gem()
+            .composition(elements)
+            .color(color)
+            .iconSet(icon)
+            .flags(flags);
+    }
+
+    const elemGem = (name, color, icon, flags) => {
+        event.create(name).gem()
+            .element(GTElements.get(name))
+            .iconSet(icon)
+            .color(color)
+            .flags(flags);
+    }
+
+
+    elemIngot('magnetic_zapolgium', GTElements.get('zapolgium'), 0xcc00cc, MAGNETIC, [], [rod, long_rod, magnetic]);
+
+    elemIngotFluid('xeproda', 0x1a0d00, DULL, [15499, 'highest', VA('uev'), 3750], []);
+
+    elemIngotFluid('rhexis', 0x330000, DULL, [15499, 'highest', VA('uiv'), 4750], []);
+
+    elemIngotFluid('chalyblux', 0xffcccc, DULL, [15499, 'highest', VA('uev'), 5750], []);
+
+    elemIngotFluid('mythril', 0x006666, METALLIC, [11299, 'highest', VA('uhv'), 2400], [foil, gear, long_rod, plates, rod, rotor, small_gear, ring, frame]);
+
+    elemIngotFluid('adamantine', 0xe99700, METALLIC, [13299, 'highest', VA('uev'), 3000], [foil, gear, long_rod, plates, rod, rotor, small_gear, ring, frame]);
+
+    elemIngotFluid('estalt', 0xff5050, DULL, [12299, 'highest', VA('uhv'), 2600], [foil, gear, long_rod, plates, rod, rotor, small_gear, ring, frame]);
+
+    elemIngotFluid('enriched_estalt', 0xe76c6c, RADIOACTIVE, [12899, 'highest', VA('uhv'), 2800], [foil, gear, long_rod, plates, rod, rotor, small_gear, ring, frame]);
+
+    elemIngotFluid('calamatium', 0x660000, DULL, [13199, 'highest', VA('uhv'), 2750], [foil, gear, long_rod, plates, rod, rotor, small_gear, ring, frame]);
+
+    elemIngotFluid('isovol', 0x290066, DULL, [12999, 'highest', VA('uhv'), 2750], [foil, gear, long_rod, plates, rod, rotor, small_gear, ring, frame]);
 
     event.create('zapolgium')
         .ingot()
@@ -261,378 +406,97 @@ GTCEuStartupEvents.registry('gtceu:material', event => {
         .flags(plates, rod, frame)
         .fluidPipeProperties(18000, 7200, true,true,true,true);
 
-    event.create('xeproda')
-        .ingot()
-        .fluid()
-        .element(GTElements.get('xeproda'))
-        .color(0x1a0d00)
-        .iconSet(DULL)
-        .blastTemp(15499, 'highest', VA('uev'), 3750);
+    // Thermal Superconductors (twinite and higher rotor values by @richie3366)
+    const conductor = (name, elements, color, blasting, cable, rotor, flags) => {
+        if (blasting.includes(blasting[0])){
+            event.create(name).ingot().fluid()
+                .components(elements)
+                .color(color)
+                .iconSet(SHINY)
+                .flags(flags)
+                .blastTemp(blasting[0], blasting[1], blasting[2], blasting[3])
+                .cableProperties(cable[0], cable[1], cable[2], cable[3])
+                .rotorStats(rotor[0], rotor[1], rotor[2], rotor[3]);
+        } else {
+            event.create(name).ingot().fluid()
+                .components(elements)
+                .color(color)
+                .iconSet(SHINY)
+                .flags(foil, gear, long_rod, plates, rod, rotor, small_gear, ring, frame)
+                .cableProperties(cable[0], cable[1], cable[2], cable[3])
+                .rotorStats(rotor[0], rotor[1], rotor[2], rotor[3]);
+        }
+    }
 
-    event.create('rhexis')
-        .ingot()
-        .fluid()
-        .element(GTElements.get('rhexis'))
-        .color(0x330000)
-        .iconSet(DULL)
-        .blastTemp(15499, 'highest', VA('uiv'), 4750);
+    conductor('soul_infused', ['1x invar', '2x mystery'], 0xcc9966, [], [V('lv'), 4, 0, true], [150, 130, 3, 37600]);
 
-    event.create('chalyblux')
-        .ingot()
-        .fluid()
-        .element(GTElements.get('chalyblux'))
-        .color(0xffcccc)
-        .iconSet(DULL)
-        .blastTemp(15499, 'highest', VA('uev'), 5750);
+    conductor('signalum', ['1x silver', '3x copper', '4x redstone'], 0xff3300, [1700, 'low', VA('mv'), 1200], [V('mv'), 16, 0, true], [190, 150, 3, 24000]);
 
-    event.create('mythril')
-        .ingot()
-        .fluid()
-        .element(GTElements.get('mythril'))
-        .color(0x006666)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring, frame)
-        .blastTemp(11299, 'highest', VA('uhv'), 2400)
-        .iconSet(METALLIC);
+    conductor('lumium', ['1x silver', '3x tin', '2x glowstone'], 0xffffb3, [1700, 'low', VA('hv'), 1500], [V('hv'), 16, 0, true], [220, 170, 3, 24000]);
 
-    event.create('adamantine')
-        .ingot()
-        .fluid()
-        .element(GTElements.get('adamantine'))
-        .color(0xe99700)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring, frame)
-        .blastTemp(13299, 'highest', VA('uev'), 3000)
-        .iconSet(METALLIC);
+    conductor('enderium', ['3x lead', '1x diamond', '2x ender_pearl'], 0x006666, [3500, 'low', VA('ev'), 1500], [V('ev'), 32, 0, true], [300, 190, 3, 45600]);
 
-    event.create('estalt')
-        .ingot()
-        .fluid()
-        .element(GTElements.get('estalt'))
-        .color(0xff5050)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring, frame)
-        .blastTemp(12299, 'highest', VA('uhv'), 2600)
-        .iconSet(DULL);
+    conductor('shellite', ['1x black_bronze', '3x signalum'], 0x9933ff, [4400, 'mid', VA('iv'), 1800], [V('iv'), 64, 0, true], [450, 220, 3, 37600]);
 
-    event.create('enriched_estalt')
-        .ingot()
-        .fluid()
-        .element(GTElements.get('enriched_estalt'))
-        .color(0xE76C6C)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring, frame)
-        .blastTemp(12899, 'highest', VA('uhv'), 2800)
-        .iconSet(RADIOACTIVE);
+    conductor('twinite', ['3x manganese_phosphide', '2x amethyst', '1x lumium'], 0xf66999, [5300, 'mid', VA('luv'), 2100], [V('luv'), 64, 0, true], [700, 260, 3, 24000]);
 
-    event.create('calamatium')
-        .ingot()
-        .fluid()
-        .element(GTElements.get('calamatium'))
-        .color(0x660000)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring, frame)
-        .iconSet(DULL)
-        .blastTemp(13199, 'highest', VA('uhv'), 2750);
+    conductor('dragonsteel', ['4x tungsten', '8x magnesium_diboride', '2x cadmium'], 0x3333cc, [7100, 'high', VA('zpm'), 2400], [V('zpm'), 96, 0, true], [1100, 380, 3, 32000]);
 
-    event.create('isovol')
-        .ingot()
-        .fluid()
-        .element(GTElements.get('isovol'))
-        .color(0x290066)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring, frame)
-        .iconSet(DULL)
-        .blastTemp(12999, 'highest', VA('uhv'), 2750);
+    conductor('prismalium', ['8x naquadah', '4x mercury_barium_calcium_cuprate', '7x tungsten_carbide'], 0x66ffff, [9000, 'high', VA('zpm'), 2700], [V('uv'), 48, 0, true], [1600, 470, 3, 48000]);
 
-    // This material is meant to place a ? symbol in a material's chemical formula
-    event.create('mystery')
-        .element(GTElements.get('mystery'));
+    conductor('melodium', ['2x uranium_triplatinum', '14x electrum', '3x amethyst', '4x darmstadtium', '7x europium'], 0xd9b3ff, [10000, 'higher', VA('uv'), 3000], [V('uv'), 128, 0, true], [2000, 550, 3, 64000]);
 
-    // Thermal Superconductors (twinite and higher rotor values by @richie3366
-    event.create('soul_infused')
-        .ingot(1)
-        .fluid()
-        .components('1x invar', '2x mystery') // invar and soul sand
-        .color(0xcc9966)
-        .iconSet(SHINY)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring, frame)
-        .cableProperties(V('lv'), 4, 0, true)
-        .rotorStats(150, 130, 3, 37600);
+    conductor('stellarium', ['12x neutronium', '4x melodium', '1x samarium_iron_arsenic_oxide'], 0xccffff, [10799, 'highest', VA('uhv'), 4000], [V('uhv'), 192, 0, true], [3200, 660, 3, 96000]);
 
-    event.create('signalum')
-        .ingot(1)
-        .fluid()
-        .components('1x silver', '3x copper', '4x redstone')
-        .color(0xff3300)
-        .iconSet(SHINY)
-        .blastTemp(1700, 'low', VA('mv'), 1200)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring, frame)
-        .cableProperties(V('mv'), 16, 0, true)
-        .rotorStats(190, 150, 3, 24000);
-
-    event.create('lumium')
-        .ingot(1)
-        .fluid()
-        .components('1x silver', '3x tin', '2x glowstone')
-        .color(0xffffb3)
-        .iconSet(SHINY)
-        .blastTemp(1700, 'low', VA('hv'), 1500)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring, frame)
-        .cableProperties(V('hv'), 16, 0, true)
-        .rotorStats(220, 170, 3, 24000);
-
-    event.create('enderium')
-        .ingot(1)
-        .fluid()
-        .components('3x lead', '1x diamond', '2x ender_pearl')
-        .color(0x006666)
-        .iconSet(SHINY)
-        .blastTemp(3500, 'low', VA('ev'), 1500)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring, frame)
-        .cableProperties(V('ev'), 32, 0, true)
-        .rotorStats(300, 190, 3, 45600);
-
-    event.create('shellite')
-        .ingot(1)
-        .fluid()
-        .components('1x black_bronze', '3x signalum')
-        .color(0x9933ff)
-        .iconSet(SHINY)
-        .blastTemp(4400, 'mid', VA('iv'), 1800)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring, frame)
-        .cableProperties(V('iv'), 64, 0, true)
-        .rotorStats(450, 220, 3, 37600);
-
-    event.create('twinite')
-        .ingot(1)
-        .fluid()
-        .components('3x manganese_phosphide', '2x amethyst', '1x lumium')
-        .color(0xf66999)
-        .iconSet(SHINY)
-        .blastTemp(5300, 'mid', VA('luv'), 2100)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring, frame)
-        .cableProperties(V('luv'), 64, 0, true)
-        .rotorStats(700, 260, 3, 24000);
-
-    event.create('dragonsteel')
-        .ingot(1)
-        .fluid()
-        .components('4x tungsten', '8x magnesium_diboride', '2x cadmium')
-        .color(0x3333cc)
-        .iconSet(SHINY)
-        .blastTemp(7100, 'high', VA('zpm'), 2400)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring, frame)
-        .cableProperties(V('zpm'), 96, 0, true)
-        .rotorStats(1100, 380, 3, 32000);
-
-    event.create('prismalium')
-        .ingot(1)
-        .fluid()
-        .components('8x naquadah', '4x mercury_barium_calcium_cuprate', '7x tungsten_carbide')
-        .color(0x66ffff)
-        .iconSet(SHINY)
-        .blastTemp(9000, 'high', VA('zpm'), 2700)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring, frame)
-        .cableProperties(V('uv'), 48, 0, true)
-        .rotorStats(1600, 470, 3, 48000);
-
-    event.create('melodium')
-        .ingot(1)
-        .fluid()
-        .components('2x uranium_triplatinum', '14x electrum', '3x amethyst', '4x darmstadtium', '7x europium')
-        .color(0xd9b3ff)
-        .iconSet(SHINY)
-        .blastTemp(10000, 'higher', VA('uv'), 3000)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring, frame)
-        .cableProperties(V('uv'), 128, 0, true)
-        .rotorStats(2000, 550, 3, 64000);
-
-    event.create('stellarium')
-        .ingot(1)
-        .fluid()
-        .components('12x neutronium', '4x melodium', '1x samarium_iron_arsenic_oxide')
-        .color(0xccffff)
-        .iconSet(SHINY)
-        .blastTemp(10799, 'highest', VA('uhv'), 4000)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring, frame, fine_wire)
-        .cableProperties(V('uhv'), 192, 0, true)
-        .rotorStats(3200, 660, 3, 96000);
-
-    event.create('ancient_runicalium')
-        .ingot(2)
-        .fluid()
-        .components('5x zapolgium', '18x stellarium', '8x zirconium')
-        .color(0xFAB922)
-        .iconSet(SHINY)
-        .blastTemp(11749, 'highest', VA('uev'), 5000)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring, frame, fine_wire)
-        .cableProperties(V('uev'), 256, 0, true)
-        .rotorStats(6400, 720, 3, 128000);
+    conductor('ancient_runicalium', ['5x zapolgium', '18x stellarium', '8x zirconium'], 0xFAB922, [11749, 'highest', VA('uev'), 5000], [V('uev'), 256, 0, true], [6400, 720, 3, 128000]);
 
     // Nuclear Reactor Materials
-    event.create('austenitic_stainless_steel_304')
-        .ingot(1)
-        .fluid()
-        .components('35x steel', '10x chromium', '4x nickel', '1x manganese', '1x silicon')
-        .color(0x800040)
-        .blastTemp(3500, 'low', VA('ev'), 1500)
-        .iconSet(METALLIC)
-        .flags(plates, rod, frame);
+    compIngot('austenitic_stainless_steel_304', ['35x steel', '10x chromium', '4x nickel', '1x manganese', '1x silicon'], 0x800040, METALLIC, [3500, 'low', VA('ev'), 1500], [plates, rod, frame]);
 
-    event.create('inconel_625')
-        .ingot()
-        .fluid()
-        .components('7x nickel', '2x chromium', '1x steel')
-        .color(0xa3a375)
-        .blastTemp(3500, 'low', VA('ev'), 1500)
-        .iconSet(SHINY)
-        .flags(plates, rod, frame);
+    compIngot('inconel_625', ['7x nickel', '2x chromium', '1x steel'], 0xa3a375, SHINY, [3500, 'low', VA('ev'), 1500], [plates, rod, frame]);
 
-    event.create('nuclear_steam')
-        .fluid()
-        .components('1x steam', '1x mystery')
-        .color(0xcccccc)
-        .flags(no_decomp);
+    compFluid('nuclear_steam', ['1x steam', '1x mystery'], 0xcccccc, [no_decomp]);
 
-    event.create('hot_sodium_potassium')
-        .fluid()
-        .components('1x sodium_potassium', '1x mystery')
-        .color(0x82fcc3)
-        .flags(no_decomp);
+    compFluid('hot_sodium_potassium', ['1x sodium_potassium', '1x mystery'], 0x82fcc3, [no_decomp]);
 
-    event.create('hot_pcb_coolant')
-        .fluid()
-        .components('1x pcb_coolant', '1x mystery')
-        .color(0xc9ca81)
-        .flags(no_decomp);
+    compFluid('hot_pcb_coolant', ['1x pcb_coolant', '1x mystery'], 0xc9ca81, [no_decomp]);
 
     // Netherite Line
-    event.create('debris')
-        .dust()
-        .liquid()
-        .element(GTElements.get('debris'))
-        .color(0x804000)
-        .flags(no_decomp);
+    elemDustFluid('debris', 0x804000, [no_decomp]);
 
-    event.create('purified_debris')
-        .dust()
-        .components('debris')
-        .color(0xcc0000);
+    compDust('purified_debris', ['debris'], 0xcc0000, []);
 
-    // event.create('netherite')
-    //     .dust()
-    //     .components('4x debris', '4x gold')
-    //     .color(0x1a0d00)
-    //     .iconSet(DULL)
-    //     .flags(no_decomp);
+    compFluid('chlorine_trifluoride', ['1x chlorine', '3x fluorine'], 0xb3ff99, []);
+
+    compFluid('tetrachloroethylene', ['2x carbon', '4x chlorine'], 0xd966ff, []);
     
-    event.create('chlorine_trifluoride')
-        .fluid()
-        .components('1x chlorine', '3x fluorine')
-        .color(0xb3ff99);
-
-    event.create('tetrachloroethylene')
-        .fluid()
-        .components('2x carbon', '4x chlorine')
-        .color(0xd966ff);
-
     // Netherite Derivatives/Alloys
-    event.create('pure_netherite')
-        .ingot()
-        .fluid()
-        .element(GTElements.get('pure_netherite'))
-        .color(0x1a0d00)
-        .iconSet(DULL)
-        .blastTemp(5000, 'low', VA('iv'), 1200)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring);
+    elemIngotFluid('pure_netherite', 0x1a0d00, DULL, [5000, 'low', VA('iv'), 1200], [foil, gear, long_rod, plates, rod, rotor, small_gear, ring]);
 
-    event.create('magnetic_pure_netherite')
-        .ingot()
-        .element(GTElements.get('pure_netherite'))
-        .color(0x1a0d00)
-        .iconSet(MAGNETIC)
-        .flags(rod, long_rod, magnetic);
+    elemIngot('magnetic_pure_netherite', 'pure_netherite', 0x1a0d00, MAGNETIC, [], [rod, long_rod, magnetic]);
 
-    event.create('naquadic_netherite')
-        .gem(0)
-        .components('3x naquadah', '5x pure_netherite', '2x caesium', '5x cerium', '12x fluorine', '32x oxygen')
-        .color(0xffd966)
-        .iconSet(DIAMOND);
+    compGem('naquadic_netherite', ['3x naquadah', '5x pure_netherite', '2x caesium', '5x cerium', '12x fluorine', '32x oxygen'], 0xffd966, DIAMOND, []);
 
-    event.create('weapon_grade_naquadah')
-        .ingot()
-        .fluid()
-        .components('7x naquadria', '2x pure_netherite', '5x neutronium', '16x fluorine')
-        .color(0xccff33)
-        .iconSet(DULL)
-        .blastTemp(10500, 'highest', VHA('uv'), 2700)
-        .flags(foil, gear, long_rod, plates,
-            rod, rotor, small_gear, ring, frame);
+    compIngotFluid('weapon_grade_naquadah', ['7x naquadria', '2x pure_netherite', '5x neutronium', '16x fluorine'], 0xccff33, DULL, [10500, 'highest', VHA('uv'), 2700], [foil, gear, long_rod, plates, rod, rotor, small_gear, ring, frame]);
 
-    event.create('runic_laser_source_base')
-        .gem(0)
-        .components('2x naquadic_netherite', '10x tritanium', '2x trinium')
-        .color(0x00ff00)
-        .iconSet(OPAL);
+    compGem('runic_laser_source_base', ['2x naquadic_netherite', '10x tritanium', '2x trinium'], 0x00ff00, OPAL, []);
 
     // Crown Ethers
-    event.create('sulfur_dichloride')
-        .fluid()
-        .components('1x sulfur', '2x chlorine')
-        .color(0xcc0000);
+    compFluid('sulfur_dichloride', ['1x sulfur', '2x chlorine'], 0xcc0000, []);
 
-    event.create('thionyl_chloride')
-        .fluid()
-        .components('1x sulfur', '1x oxygen', '2x chlorine')
-        .color(0xffffcc);
+    compDust('thionyl_chloride', ['1x sulfur', '1x oxygen', '2x chlorine'], 0xffffcc, []);
 
-    event.create('sulfuryl_chloride')
-        .fluid()
-        .components('1x sulfur', '2x oxygen', '2x chlorine')
-        .color(0xffffcc);
+    compDust('sulfuryl_chloride', ['1x sulfur', '2x oxygen', '2x chlorine'], 0xffffcc, []);
 
-    event.create('triglycol_dichloride')
-        .fluid()
-        .components('6x carbon', '12x hydrogen', '2x oxygen', '2x chlorine')
-        .color(0xffffcc);
+    compDust('triglycol_dichloride', ['6x carbon', '12x hydrogen', '2x oxygen', '2x chlorine'], 0xffffcc, []);
 
-    event.create('ethylene_glycol')
-        .fluid()
-        .components('2x carbon', '6x hydrogen', '2x oxygen')
-        .color(0xf2f2f2);
+    compDust('ethylene_glycol', ['2x carbon', '6x hydrogen', '2x oxygen'], 0xf2f2f2, []);
 
-    event.create('diethylene_glycol')
-        .fluid()
-        .components('4x carbon', '10x hydrogen', '3x oxygen')
-        .color(0xf2f2f2);
+    compDust('diethylene_glycol', ['4x carbon', '10x hydrogen', '3x oxygen'], 0xf2f2f2, []);
 
-    event.create('triethylene_glycol')
-        .fluid()
-        .components('6x carbon', '14x hydrogen', '4x oxygen')
-        .color(0xf2f2f2);
+    compDust('triethylene_glycol', ['6x carbon', '14x hydrogen', '4x oxygen'], 0xf2f2f2, []);
 
-    event.create('ethylene_oxide')
-        .fluid()
-        .components('2x carbon', '4x hydrogen', '1x oxygen')
-        .color(0xd9d9d9);
-
-    // event.create('potassium_hydroxide')
-    //     .dust()
-    //     .components('1x potassium', '1x oxygen', '1x hydrogen')
-    //     .color(0xffcc99);
+    compDust('ethylene_oxide', ['2x carbon', '4x hydrogen', '1x oxygen'], 0xd9d9d9, []);
 
     event.create('lithium_perchlorate')
         .dust()


### PR DESCRIPTION
- reformat materials.js
- add recipe id's to non gt-based recipes and make all recipes use the 'start:' prefix