### PR TITLE
fix: typo in quest book lore

### DIFF
--- a/config/ftbquests/quests/chapters/welcome.snbt
+++ b/config/ftbquests/quests/chapters/welcome.snbt
@@ -24,7 +24,7 @@
 		}
 		{
 			description: [
-				"     Red screens flash and alarms are going off. Everyone in the room is evacuating. The experiment is a failure. There is little time before this this building will explode. But you notice something... the gate ... is opening! You stare in awe and think: \"Yes! My theories were right and I figured out what was the problem!\". You don't notice the others calling out to you to run. But it was too late. A failure is still a failure and the gate engulfs everything in the room."
+				"     Red screens flash and alarms are going off. Everyone in the room is evacuating. The experiment is a failure. There is little time before this building will explode. But you notice something... the gate ... is opening! You stare in awe and think: \"Yes! My theories were right and I figured out what was the problem!\". You don't notice the others calling out to you to run. But it was too late. A failure is still a failure and the gate engulfs everything in the room."
 				"    You wake up stranded on a floating island in an alternate dimension. The only things you have is a tree and some dirt around it. But you are not discouraged. As the world's greatest scientist you can use these materials to develop technology at faster rate than anyone. You can try once again interdimensional travel. For that you will have to make from almost nothing everything, to develop up to draconic and even star technology. You &oWILL&r succed. You &oWILL&r return home."
 				"     &lWelcome to Star Technology.&r"
 			]


### PR DESCRIPTION
Just removing a doubled `this` in the lore section of the quest book.